### PR TITLE
feat(cli): replace verbose output with a spinner and progress-bar TUI

### DIFF
--- a/lib/src/build/flutter_debug_bundler.dart
+++ b/lib/src/build/flutter_debug_bundler.dart
@@ -63,13 +63,15 @@ class FlutterDebugBundler {
   /// Build `App.framework` inside [outputDir]. Returns the framework path.
   Future<String> build() async {
     final engineCache = IosEngineCache(flutterRoot: flutterRoot);
-    logStatus('[xcross] ensuring Flutter iOS debug artifacts...');
-    await engineCache.ensureArtifactsAvailable();
+    await logStep(
+      'Fetching Flutter engine artifacts',
+      engineCache.ensureArtifactsAvailable,
+    );
 
-    logStatus('[xcross] resolving iOS debug toolchain...');
+    logTrace('resolving iOS debug toolchain');
     final toolchain = await _resolveToolchain();
 
-    logStatus('[xcross] preparing App.framework output...');
+    logTrace('preparing App.framework output');
     await Directory(outputDir).create(recursive: true);
 
     final appFramework = p.join(outputDir, 'App.framework');
@@ -81,14 +83,15 @@ class FlutterDebugBundler {
 
     final appDill = await _runKernelSnapshot(engineCache);
 
-    logStatus('[xcross] bundling Flutter debug assets...');
-    await _copyDataAssets(assetsDir, engineCache, appDill);
-    await _copyMaterialFonts(assetsDir);
-    _writeManifests(assetsDir);
+    await logStep('Bundling assets', () async {
+      await _copyDataAssets(assetsDir, engineCache, appDill);
+      await _copyMaterialFonts(assetsDir);
+      _writeManifests(assetsDir);
+    });
 
     await _buildAppStub(appFramework, toolchain);
 
-    logStatus('[xcross] writing App.framework Info.plist...');
+    logTrace('writing App.framework Info.plist');
     _writeAppFrameworkInfoPlist(appFramework);
 
     return appFramework;
@@ -152,13 +155,17 @@ class FlutterDebugBundler {
       resolvedEntrypoint,
     ];
 
-    logStatus('[frontend_server] kernel snapshot (debug/JIT)...');
-    await ProcessRunner.runChecked(
-      runtime,
-      args,
-      workingDirectory: projectRoot,
-      inheritStdio: true,
-      label: 'frontend_server',
+    await logStep(
+      'Compiling Dart kernel',
+      () => ProcessRunner.runChecked(
+        runtime,
+        args,
+        workingDirectory: projectRoot,
+        // Inheriting fd1 while a spinner animates shreds the line; capture
+        // instead (the stderr is folded into the thrown error either way).
+        inheritStdio: isVerbose,
+        label: 'frontend_server',
+      ),
     );
 
     if (!File(outputDill).existsSync()) {
@@ -260,38 +267,38 @@ class FlutterDebugBundler {
     );
   }
 
-  Future<void> _buildAppStub(String appFramework, _Toolchain toolchain) async {
-    logStatus('[clang] building App stub dylib...');
+  Future<void> _buildAppStub(String appFramework, _Toolchain toolchain) =>
+      logStep('Building App.framework', () async {
+        final tmp =
+            await Directory.systemTemp.createTemp('xtool-flutter-stub-');
+        final stubSource = p.join(tmp.path, 'debug_app.c');
+        // Exact stub content emitted by flutter_tools.
+        await File(stubSource).writeAsString('static const int Moo = 88;\n');
 
-    final tmp = await Directory.systemTemp.createTemp('xtool-flutter-stub-');
-    final stubSource = p.join(tmp.path, 'debug_app.c');
-    // Exact stub content emitted by flutter_tools.
-    await File(stubSource).writeAsString('static const int Moo = 88;\n');
+        await Directory(appFramework).create(recursive: true);
+        final outputBinary = p.join(appFramework, 'App');
 
-    await Directory(appFramework).create(recursive: true);
-    final outputBinary = p.join(appFramework, 'App');
+        // Flags mirror flutter_tools `_createStubAppFramework`.
+        final args = _appStubClangArgs(
+          toolchain: toolchain,
+          stubSource: stubSource,
+          outputBinary: outputBinary,
+        );
 
-    // Flags mirror flutter_tools `_createStubAppFramework`.
-    final args = _appStubClangArgs(
-      toolchain: toolchain,
-      stubSource: stubSource,
-      outputBinary: outputBinary,
-    );
+        await ProcessRunner.runChecked(
+          toolchain.clang,
+          args,
+          inheritStdio: isVerbose,
+          label: 'clang',
+        );
 
-    await ProcessRunner.runChecked(
-      toolchain.clang,
-      args,
-      inheritStdio: true,
-      label: 'clang',
-    );
+        if (!File(outputBinary).existsSync()) {
+          throw XcrossError(
+              'FlutterDebugBundler: clang did not produce $outputBinary');
+        }
 
-    if (!File(outputBinary).existsSync()) {
-      throw XcrossError(
-          'FlutterDebugBundler: clang did not produce $outputBinary');
-    }
-
-    await tmp.delete(recursive: true);
-  }
+        await tmp.delete(recursive: true);
+      });
 
   /// Build the clang argument list for the App stub dylib.
   static List<String> _appStubClangArgs({

--- a/lib/src/build/flutter_packer.dart
+++ b/lib/src/build/flutter_packer.dart
@@ -42,16 +42,16 @@ class FlutterPacker {
   /// Returns path to `<projectRoot>/build/xtool-ios/<appName>.app`.
   Future<String> pack() async {
     final flutterRoot = await resolveFlutterRoot(projectRoot: projectRoot);
-    logStatus('[xcross] Flutter SDK: $flutterRoot');
+    logTrace('Flutter SDK: $flutterRoot');
 
     if (options.pub) {
       await _runFlutterPubGet(flutterRoot);
     } else {
-      logStatus('[xcross] skipping flutter pub get (--no-pub).');
+      logTrace('skipping flutter pub get (--no-pub)');
     }
 
     if (options.flavor != null) {
-      logStatus('[xcross] building flavor "${options.flavor}"...');
+      logTrace('building flavor "${options.flavor}"');
     }
 
     final appFramework = await _buildAppFramework(flutterRoot);
@@ -85,26 +85,29 @@ class FlutterPacker {
 
   /// Run `flutter pub get`. Tolerates failures when `package_config.json`
   /// already exists (container builds with ephemeral pub caches).
-  Future<void> _runFlutterPubGet(String flutterRoot) async {
+  Future<void> _runFlutterPubGet(String flutterRoot) {
     final packageConfig =
         p.join(projectRoot, '.dart_tool', 'package_config.json');
-    logStatus('[flutter] pub get...');
-    try {
-      await ProcessRunner.runChecked(
-        p.join(flutterRoot, 'bin', 'flutter'),
-        ['pub', 'get'],
-        workingDirectory: projectRoot,
-        inheritStdio: true,
-        label: 'flutter',
-      );
-    } on XcrossError {
-      if (File(packageConfig).existsSync()) {
-        logWarn(
-            'Ignoring flutter pub get error because package_config.json exists.');
-        return;
+    return logStep('Resolving dependencies', () async {
+      try {
+        await ProcessRunner.runChecked(
+          p.join(flutterRoot, 'bin', 'flutter'),
+          ['pub', 'get'],
+          workingDirectory: projectRoot,
+          // `pub get` is non-interactive; inheriting fd1 would shred the
+          // spinner, so only inherit when verbose (no spinner then).
+          inheritStdio: isVerbose,
+          label: 'flutter',
+        );
+      } on XcrossError {
+        if (File(packageConfig).existsSync()) {
+          logWarn('Ignoring flutter pub get error because '
+              'package_config.json exists.');
+          return;
+        }
+        rethrow;
       }
-      rethrow;
-    }
+    });
   }
 
   /// Build `App.framework` via [FlutterDebugBundler].

--- a/lib/src/build/ios_engine_cache.dart
+++ b/lib/src/build/ios_engine_cache.dart
@@ -26,7 +26,8 @@ class IosEngineCache {
   String get flutterXcframework => p.join(_engineDir, 'Flutter.xcframework');
 
   /// `vm_isolate_snapshot.bin` from the host engine cache.
-  String get vmSnapshotData => p.join(_hostEngineDir, 'vm_isolate_snapshot.bin');
+  String get vmSnapshotData =>
+      p.join(_hostEngineDir, 'vm_isolate_snapshot.bin');
 
   /// `isolate_snapshot.bin` from the host engine cache.
   String get isolateSnapshotData =>
@@ -105,23 +106,26 @@ class IosEngineCache {
     final hash = await _engineHash();
     final url =
         '$flutterArtifactBaseUrl/$hash/$_hostEngineCacheDir/artifacts.zip';
-    logStatus('[curl] downloading Flutter host engine artifacts from $url');
-    await _fetchAndExtract(url, _hostEngineDir, 'host-artifacts-');
+    logTrace('downloading Flutter host engine artifacts from $url');
+    await _fetchAndExtract(url, _hostEngineDir, 'host-artifacts-',
+        label: 'Flutter host engine');
   }
 
   Future<void> _downloadIosArtifacts() async {
     final hash = await _engineHash();
     final url = '$flutterArtifactBaseUrl/$hash/ios/artifacts.zip';
-    logStatus('[curl] downloading Flutter iOS engine artifacts from $url');
-    await _fetchAndExtract(url, _engineDir, 'ios-artifacts-');
+    logTrace('downloading Flutter iOS engine artifacts from $url');
+    await _fetchAndExtract(url, _engineDir, 'ios-artifacts-',
+        label: 'Flutter iOS engine');
   }
 
   Future<void> _downloadPatchedSdk() async {
     final hash = await _engineHash();
     final leaf = p.basename(patchedSdkRoot);
     final url = '$flutterArtifactBaseUrl/$hash/$leaf.zip';
-    logStatus('[curl] downloading Flutter patched SDK from $url');
-    await _fetchAndExtract(url, p.dirname(patchedSdkRoot), 'patched-sdk-');
+    logTrace('downloading Flutter patched SDK from $url');
+    await _fetchAndExtract(url, p.dirname(patchedSdkRoot), 'patched-sdk-',
+        label: 'Flutter patched SDK');
   }
 
   /// Download [url] into a temp directory, extract into [destDir], then
@@ -133,13 +137,18 @@ class IosEngineCache {
   static Future<void> _fetchAndExtract(
     String url,
     String destDir,
-    String tmpPrefix,
-  ) async {
+    String tmpPrefix, {
+    required String label,
+  }) async {
     await Directory(destDir).create(recursive: true);
     final tmp = await Directory.systemTemp.createTemp(tmpPrefix);
     final zipPath = p.join(tmp.path, 'artifacts.zip');
-    await downloadToFile(url, File(zipPath), maxAttempts: 5);
-    await extractFileToDisk(zipPath, destDir);
+    await downloadToFile(url, File(zipPath), maxAttempts: 5, label: label);
+    // Unzipping hundreds of MB is slow enough to look like a hang on its own.
+    await logStep(
+      'Extracting $label',
+      () => extractFileToDisk(zipPath, destDir),
+    );
     await tmp.delete(recursive: true);
   }
 

--- a/lib/src/build/runner_shim.dart
+++ b/lib/src/build/runner_shim.dart
@@ -25,57 +25,55 @@ class RunnerShim {
     required DarwinSdk sdk,
     required String flutterXcframework,
     required String outputDir,
-  }) async {
-    logStatus(
-        '[xcross] compiling Runner via clang/ld64.lld Objective-C shim...');
+  }) =>
+      logStep('Compiling Runner', () async {
+        final clang = await locateTool('clang');
+        final iosSdk = _resolveIPhoneOsSDK(sdk);
+        final flutterSlice = _flutterDeviceSlice(flutterXcframework);
+        final subframeworks =
+            p.join(iosSdk, 'System', 'Library', 'SubFrameworks');
 
-    final clang = await locateTool('clang');
-    final iosSdk = _resolveIPhoneOsSDK(sdk);
-    final flutterSlice = _flutterDeviceSlice(flutterXcframework);
-    final subframeworks = p.join(iosSdk, 'System', 'Library', 'SubFrameworks');
+        await Directory(outputDir).create(recursive: true);
+        final sourcePath = p.join(outputDir, 'Runner.m');
+        final objectPath = p.join(outputDir, 'Runner.o');
+        final outputPath = p.join(outputDir, 'Runner');
 
-    await Directory(outputDir).create(recursive: true);
-    final sourcePath = p.join(outputDir, 'Runner.m');
-    final objectPath = p.join(outputDir, 'Runner.o');
-    final outputPath = p.join(outputDir, 'Runner');
+        await File(sourcePath).writeAsString(_runnerObjcSource);
 
-    await File(sourcePath).writeAsString(_runnerObjcSource);
+        await _compileObject(
+          clang: clang,
+          sourcePath: sourcePath,
+          objectPath: objectPath,
+          iosSdk: iosSdk,
+          subframeworks: subframeworks,
+          flutterSlice: flutterSlice,
+        );
 
-    await _compileObject(
-      clang: clang,
-      sourcePath: sourcePath,
-      objectPath: objectPath,
-      iosSdk: iosSdk,
-      subframeworks: subframeworks,
-      flutterSlice: flutterSlice,
-    );
+        // _sdkVersion() returns null whenever the un-versioned iPhoneOS.sdk
+        // symlink is used (the standard install), so this fallback is what
+        // reaches ld64.lld's -platform_version and lands in LC_BUILD_VERSION.
+        final sdkVersion = _sdkVersion(iosSdk) ?? '26.5';
+        await _linkBinary(
+          ld64lld: sdk.ld64lld,
+          objectPath: objectPath,
+          outputPath: outputPath,
+          iosSdk: iosSdk,
+          flutterSlice: flutterSlice,
+          subframeworks: subframeworks,
+          sdkVersion: sdkVersion,
+        );
 
-    // _sdkVersion() returns null whenever the un-versioned iPhoneOS.sdk
-    // symlink is used (the standard install), so this fallback is what
-    // reaches ld64.lld's -platform_version and lands in LC_BUILD_VERSION.
-    final sdkVersion = _sdkVersion(iosSdk) ?? '26.5';
-    await _linkBinary(
-      ld64lld: sdk.ld64lld,
-      objectPath: objectPath,
-      outputPath: outputPath,
-      iosSdk: iosSdk,
-      flutterSlice: flutterSlice,
-      subframeworks: subframeworks,
-      sdkVersion: sdkVersion,
-    );
+        if (!File(outputPath).existsSync()) {
+          throw XcrossError('RunnerShim: clang/ld64.lld did not produce '
+              'Runner at $outputPath');
+        }
 
-    if (!File(outputPath).existsSync()) {
-      throw XcrossError(
-          'RunnerShim: clang/ld64.lld did not produce Runner at $outputPath');
-    }
+        makeExecutable(outputPath);
+        final size = await File(outputPath).length();
+        logTrace('Runner binary produced: $outputPath (${size ~/ 1024} KB)');
 
-    makeExecutable(outputPath);
-    final size = await File(outputPath).length();
-    logStatus(
-        '[xcross] Runner binary produced: $outputPath (${size ~/ 1024} KB)');
-
-    return outputPath;
-  }
+        return outputPath;
+      });
 
   /// Compile [sourcePath] to [objectPath] via clang.
   static Future<void> _compileObject({
@@ -86,7 +84,7 @@ class RunnerShim {
     required String subframeworks,
     required String flutterSlice,
   }) async {
-    logStatus('[clang] compile Runner.m → Runner.o');
+    logTrace('[clang] compile Runner.m → Runner.o');
     await ProcessRunner.runChecked(
       clang,
       [
@@ -107,7 +105,7 @@ class RunnerShim {
         '-o',
         objectPath,
       ],
-      inheritStdio: true,
+      inheritStdio: isVerbose,
       label: 'clang',
     );
   }
@@ -122,7 +120,7 @@ class RunnerShim {
     required String subframeworks,
     required String sdkVersion,
   }) async {
-    logStatus('[ld64.lld] link Runner.o → Runner');
+    logTrace('[ld64.lld] link Runner.o → Runner');
     await ProcessRunner.runChecked(
       ld64lld,
       [
@@ -154,7 +152,7 @@ class RunnerShim {
         '-rpath',
         '@executable_path/Frameworks',
       ],
-      inheritStdio: true,
+      inheritStdio: isVerbose,
       label: 'ld64.lld',
     );
   }

--- a/lib/src/cli/flutter/flutter_build_args.dart
+++ b/lib/src/cli/flutter/flutter_build_args.dart
@@ -85,7 +85,7 @@ class FlutterBuildCommand extends Command<void> {
       // install time. Fail before building rather than after.
       throw UsageException(
         'xcross cannot sign a .app: the original xtool has no standalone sign '
-        'command.',
+            'command.',
         'Use `xcross flutter run` or `xtool install <app>` to sign + install.',
       );
     }
@@ -102,8 +102,7 @@ class FlutterBuildCommand extends Command<void> {
 
     final result = await flutterPack(options: options);
 
-    final finalPath =
-        _ipa ? await packageIpa(result.appPath) : result.appPath;
-    logStatus('Wrote to $finalPath');
+    final finalPath = _ipa ? await packageIpa(result.appPath) : result.appPath;
+    logDone('Wrote $finalPath');
   }
 }

--- a/lib/src/cli/flutter/flutter_run_args.dart
+++ b/lib/src/cli/flutter/flutter_run_args.dart
@@ -117,8 +117,8 @@ class FlutterRunCommand extends Command<void> {
   DeviceSearchMode get _searchMode {
     if (argResults!.flag('usb')) return DeviceSearchMode.usb;
     if (argResults!.flag('wifi')) return DeviceSearchMode.wifi;
-    final connection =
-        DeviceConnection.values.byName(argResults!.option('device-connection')!);
+    final connection = DeviceConnection.values
+        .byName(argResults!.option('device-connection')!);
     return switch (connection) {
       DeviceConnection.attached => DeviceSearchMode.usb,
       DeviceConnection.wireless => DeviceSearchMode.wifi,
@@ -149,8 +149,7 @@ class FlutterRunCommand extends Command<void> {
     final xtool = XtoolCli();
     final device =
         await xtool.resolveDevice(selector: _deviceSelector, mode: _searchMode);
-    logStatus(
-        '[xtool] installing to device: ${device.name} (udid: ${device.udid})');
+    logInfo('Device', '${device.name} ${ansi.subtle(device.udid)}');
 
     // iOS 17+ removed the classic lockdown debugserver: launch (and process
     // control) go through the CoreDevice/RSD tunnel. Determine this up front so
@@ -165,6 +164,7 @@ class FlutterRunCommand extends Command<void> {
           udid: device.udid, bundleId: pack.bundleId);
     }
 
+    // Renders its own spinner + grey log tail (see [XtoolCli.install]).
     await xtool.install(pack.appPath, udid: device.udid, mode: _searchMode);
 
     await _launch(
@@ -190,7 +190,7 @@ class FlutterRunCommand extends Command<void> {
     const keepAttached = true;
 
     if (!useCoreDevice) {
-      logStatus('[xtool] launching ${pack.bundleId} (debug/JIT)...');
+      logInfo('App', '${pack.bundleId} ${ansi.subtle('debug/JIT')}');
       await DebugLauncher.launch(
         udid: device.udid,
         bundleId: pack.bundleId,
@@ -208,10 +208,10 @@ class FlutterRunCommand extends Command<void> {
       verbose: _verbose,
     );
 
-    final hint = hotReload != null
-        ? " (debug/JIT — hot reload enabled; press 'r' to reload)"
-        : ' (debug/JIT — staying attached via CoreDevice)';
-    logStatus('[xcross] launching ${pack.bundleId}$hint...');
+    final mode = hotReload != null
+        ? 'debug/JIT, hot reload'
+        : 'debug/JIT, attached via CoreDevice';
+    logInfo('App', '${pack.bundleId} ${ansi.subtle(mode)}');
 
     await CoreDeviceLauncher.launch(
       udid: device.udid,

--- a/lib/src/cli/ide/vscode_command.dart
+++ b/lib/src/cli/ide/vscode_command.dart
@@ -33,26 +33,28 @@ class VscodeCommand extends Command<void> {
       // escaped too — jsonEncode does not.
       _shim.replaceAll('<XCROSS>', jsonEncode(exe).replaceAll(r'$', r'\$')),
     );
-    logStatus('wrote ${p.relative(shim.path)}');
+    logDone('Wrote ${p.relative(shim.path)}');
 
     // launch.json / settings.json are JSONC in the wild; a comment-preserving
     // merge is 200 lines of nothing, so print the snippet instead.
     await _writeIfAbsent(p.join(dir.path, 'launch.json'), _launchJson);
     await _writeIfAbsent(p.join(dir.path, 'settings.json'), _settingsJson);
 
-    logStatus('done — open the project in VS Code and press F5 '
-        "(then 'Hot Reload' / 'Restart' in the debug toolbar).");
+    logInfo(
+        'Next',
+        ansi.subtle('open the project in VS Code and press F5, '
+            "then 'Hot Reload' / 'Restart' in the debug toolbar"));
   }
 
   static Future<void> _writeIfAbsent(String path, String content) async {
     final file = File(path);
     if (file.existsSync()) {
-      logStatus('${p.relative(path)} already exists — merge this in yourself:\n'
+      logWarn('${p.relative(path)} already exists — merge this in yourself:\n'
           '$content');
       return;
     }
     await file.writeAsString(content);
-    logStatus('wrote ${p.relative(path)}');
+    logDone('Wrote ${p.relative(path)}');
   }
 }
 

--- a/lib/src/cli/runner.dart
+++ b/lib/src/cli/runner.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:completion/completion.dart';
 import 'package:xcross/src/cli/completion_command.dart';
@@ -8,9 +9,29 @@ import 'package:xcross/src/cli/ide/dap_command.dart';
 import 'package:xcross/src/cli/ide/vscode_command.dart';
 import 'package:xcross/src/cli/prepare_command.dart';
 import 'package:xcross/src/util/errors.dart';
+import 'package:xcross/src/util/logging.dart';
+
+/// Adds a global `-v` so every command can surface its trace output, not just
+/// `flutter run` (which keeps its own `-v` for `xcross flutter run -v`).
+class _XcrossRunner extends CommandRunner<void> {
+  _XcrossRunner(super.executableName, super.description) {
+    argParser.addFlag(
+      'verbose',
+      abbr: 'v',
+      help: 'Verbose output (show every command and tool line).',
+      negatable: false,
+    );
+  }
+
+  @override
+  Future<void> runCommand(ArgResults topLevelResults) {
+    if (topLevelResults.flag('verbose')) setVerbose();
+    return super.runCommand(topLevelResults);
+  }
+}
 
 CommandRunner<void> buildRunner() {
-  return CommandRunner<void>(
+  return _XcrossRunner(
     'xcross',
     'Build, run, and hot-reload Flutter iOS apps from Linux without Xcode.',
   )

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -17,9 +17,11 @@ abstract final class DeviceConstants {
   /// Name of the DevFS filesystem registered with the Dart VM.
   static const String devFsName = 'xtool';
 
-  /// Marker line printed when the on-device VM Service is live; the DAP
-  /// watches for it to emit `flutter.appStarted`.
-  static const String vmServiceMarker = '[xcross] vm-service ';
+  /// Marker printed when the on-device VM Service is live; the DAP scans child
+  /// stdout for it (by substring, so a line glyph may precede it) to emit
+  /// `flutter.appStarted`. Keep the colon — it is what stops a stray mention of
+  /// "vm-service" in the app's own output from being parsed as the URI line.
+  static const String vmServiceMarker = 'vm-service: ';
 
   /// Keycode for 'q' — quits the running session.
   static const int keyQ = 0x71;

--- a/lib/src/device/core_device_launcher.dart
+++ b/lib/src/device/core_device_launcher.dart
@@ -41,7 +41,7 @@ abstract final class CoreDeviceLauncher {
     }
 
     final tunnel = await TunnelDiscovery.discoverTunnel(udid: udid);
-    logStatus('[xtool] connecting to RSD at ${tunnel.address}:${tunnel.port}');
+    logTrace('connecting to RSD at ${tunnel.address}:${tunnel.port}');
 
     final resolvedBundleId = await _resolveBundleId(bundleId);
     final debugproxyPort = await _resolveDebugproxyPort(tunnel);
@@ -63,7 +63,7 @@ abstract final class CoreDeviceLauncher {
       await gdb.start();
       await gdb.attach(pid);
       await gdb.resume();
-      logStatus('[xtool] debugger attached; app running');
+      logDone('Debugger attached');
     } catch (e) {
       tunnelDaemon.stop();
       throw XcrossError('Debugger attach failed: $e');
@@ -115,7 +115,7 @@ abstract final class CoreDeviceLauncher {
         deviceHost: tunnelAddress,
         devicePort: DeviceConstants.vmServicePort,
       );
-      logStatus('${DeviceConstants.vmServiceMarker}'
+      logInfo(DeviceConstants.vmServiceMarker,
           'ws://127.0.0.1:${forwarder.localPort}/ws');
       return forwarder;
     } on Object catch (e) {
@@ -149,8 +149,7 @@ abstract final class CoreDeviceLauncher {
         bundleId: resolved,
       );
       if (pid == null) return;
-      logStatus(
-          '[xtool] app already running (pid $pid); terminating before install…');
+      logTrace('app already running (pid $pid); terminating before install…');
       await Pymd.killPid(
           rsdHost: tunnel.address, rsdPort: tunnel.port, pid: pid);
     } on Object catch (e) {
@@ -168,7 +167,7 @@ abstract final class CoreDeviceLauncher {
       resolved = bundleId;
     }
     if (resolved != bundleId) {
-      logStatus('[xtool] resolved installed bundle id: $bundleId -> $resolved');
+      logTrace('resolved installed bundle id: $bundleId -> $resolved');
     }
     return resolved;
   }
@@ -233,7 +232,7 @@ abstract final class CoreDeviceLauncher {
     } catch (e) {
       throw XcrossError('Launch failed: $e');
     }
-    logStatus('[xtool] launched suspended pid=$pid');
+    logTrace('launched suspended pid=$pid');
     return pid;
   }
 
@@ -244,7 +243,7 @@ abstract final class CoreDeviceLauncher {
     required String tunnelAddress,
   }) async {
     if (hotReload == null) {
-      logStatus('[xtool] streaming app output (press Ctrl-C to stop)');
+      logInfo('Streaming app output ${ansi.subtle('— Ctrl-C to stop')}');
       return null;
     }
     try {
@@ -253,8 +252,8 @@ abstract final class CoreDeviceLauncher {
         tunnelAddress: tunnelAddress,
         vmServicePort: DeviceConstants.vmServicePort,
       );
-      logStatus(
-          "[xtool] hot reload ready ✓  (press 'r' to reload, 'R' to restart)");
+      logInfo('Hot reload ready '
+          '${ansi.subtle('— r reload  ·  R restart  ·  q quit')}');
       return controller;
     } catch (e) {
       logWarn('hot reload unavailable: $e');

--- a/lib/src/device/device_prepare.dart
+++ b/lib/src/device/device_prepare.dart
@@ -44,55 +44,56 @@ abstract final class DevicePrepare {
     await TunnelDaemon().ensureRunning();
     await _ensureLockdownTunnel();
 
-    logStatus(
-      '[xcross] prepare done — DDI mounted, tunneld up, lockdown tunnel '
-      'running.\n'
-      '    You can now: xcross flutter run -u <UDID>',
-    );
+    logDone('Device ready '
+        '${ansi.subtle('— DDI mounted, tunneld and lockdown tunnel up')}');
+    logInfo('Next', ansi.subtle('xcross flutter run -u <UDID>'));
   }
 
   /// `sudo pymobiledevice3 mounter auto-mount` (one-shot).
   static Future<void> _autoMount() async {
     final argv = await _elevatedPymdArgs(['mounter', 'auto-mount']);
-    logStatus(
-      '[pymobiledevice3] mounting Developer Disk Image:\n'
-      '    ${argv.join(' ')}',
-    );
-    final proc = await Process.start(
-      argv.first,
-      argv.sublist(1),
-      environment: Pymd.usbmuxEnvironment(),
-      mode: ProcessStartMode.inheritStdio,
-    );
-    final code = await proc.exitCode;
-    if (code != 0) {
-      throw XcrossError(
-        'mounter auto-mount failed (exit $code).\n'
-        'Retry manually:\n'
-        '    sudo pymobiledevice3 mounter auto-mount',
+    logTrace('[pymobiledevice3] mounting DDI: ${argv.join(' ')}');
+    // Captured (not inheritStdio): a child writing to fd1 would shred the
+    // spinner. Runs under `sudo -n`, so there is no prompt to hide.
+    await logStep('Mounting Developer Disk Image', () async {
+      final result = await ProcessRunner.run(
+        argv.first,
+        argv.sublist(1),
+        environment: Pymd.usbmuxEnvironment(),
       );
-    }
-    logStatus('[pymobiledevice3] Developer Disk Image mounted ✓');
+      logTrace(result.stdout.trim());
+      if (result.exitCode != 0) {
+        throw XcrossError(
+          'mounter auto-mount failed (exit ${result.exitCode}).\n'
+          '${result.stderr.trim()}\n'
+          'Retry manually:\n'
+          '    sudo pymobiledevice3 mounter auto-mount',
+        );
+      }
+    });
   }
 
   /// Start `lockdown start-tunnel` in the background if one is not already
   /// producing an RSD tunnel. Leaves the process running after prepare exits.
   static Future<void> _ensureLockdownTunnel() async {
     if (await _lockdownTunnelLooksAlive()) {
-      logStatus('[pymobiledevice3] lockdown start-tunnel already running');
+      logTrace('lockdown start-tunnel already running');
       return;
     }
+    await logStep('Starting lockdown RSD tunnel', _startLockdownTunnel);
+  }
 
+  /// Spawn `lockdown start-tunnel` and wait for it to report an RSD tunnel.
+  static Future<void> _startLockdownTunnel() async {
     final argv = await _elevatedPymdArgs(['lockdown', 'start-tunnel']);
     final tmpDir = Platform.environment['TMPDIR'] ?? '/tmp';
     final logPath = '$tmpDir/xcross-start-tunnel.log';
     final logFile = File(logPath);
     if (!logFile.existsSync()) logFile.createSync(recursive: true);
 
-    logStatus(
+    logTrace(
       '[pymobiledevice3] starting lockdown RSD tunnel'
-      ' (background; log: $logPath):\n'
-      '    ${argv.join(' ')}',
+      ' (background; log: $logPath): ${argv.join(' ')}',
     );
 
     late Process proc;
@@ -118,7 +119,7 @@ abstract final class DevicePrepare {
     void onLine(String line) {
       final trimmed = line.trimRight();
       if (trimmed.isEmpty) return;
-      logStatus(trimmed);
+      logTrace(trimmed);
       if (!ready.isCompleted && _tunnelReadyPattern.hasMatch(trimmed)) {
         ready.complete();
       }
@@ -165,7 +166,7 @@ abstract final class DevicePrepare {
       rethrow;
     }
 
-    logStatus(
+    logTrace(
       '[pymobiledevice3] lockdown RSD tunnel is up '
       '(pid ${proc.pid}; leave it running)',
     );

--- a/lib/src/device/frontend_server_client.dart
+++ b/lib/src/device/frontend_server_client.dart
@@ -63,7 +63,7 @@ class FrontendServerClient {
     await Directory(File(config.outputDill).parent.path)
         .create(recursive: true);
 
-    logStatus('[frontend_server] running: ${config.dart} ${args.join(' ')}');
+    logTrace('[frontend_server] running: ${config.dart} ${args.join(' ')}');
     final proc = await Process.start(config.dart, args);
 
     _process = proc;

--- a/lib/src/device/hot_reload_controller.dart
+++ b/lib/src/device/hot_reload_controller.dart
@@ -115,7 +115,7 @@ class HotReloadController {
     try {
       return await body();
     } finally {
-      logStatus('[timing] $label ${sw.elapsedMilliseconds}ms');
+      logTrace('[timing] $label ${sw.elapsedMilliseconds}ms');
     }
   }
 
@@ -128,7 +128,8 @@ class HotReloadController {
   Future<bool> reload() async {
     final changed = _sources.changedFileUris();
     if (changed.isEmpty) {
-      logStatus('[xtool] no source changes');
+      // The step's own `✓ Reloaded 0.0s` already tells the story.
+      logTrace('no source changes');
       return true;
     }
 
@@ -269,9 +270,7 @@ class HotReloadController {
     final targetUri = '$baseUri$fileName';
     final raw = await File(dillPath).readAsBytes();
     final gz = GZipCodec().encode(raw);
-    if (config.verbose) {
-      logStatus('[timing] devfs-bytes raw=${raw.length} gz=${gz.length}');
-    }
+    logTrace('[timing] devfs-bytes raw=${raw.length} gz=${gz.length}');
     final targetUriB64 = base64.encode(utf8.encode(targetUri));
 
     final client = HttpClient()

--- a/lib/src/device/pymd.dart
+++ b/lib/src/device/pymd.dart
@@ -67,16 +67,17 @@ abstract final class Pymd {
   static Future<bool> ensureInstalled() async {
     if (await _isInstalled()) return true;
 
-    logStatus('[pymobiledevice3] not found — installing (one-time)…');
+    final step = beginStep('Installing pymobiledevice3 (one-time)');
 
     final py = await which('python3') ?? await which('python');
     if (py == null) {
+      step.fail();
       logError('no python3 found. Install Python 3 first.');
       return false;
     }
 
     for (final attempt in await _buildInstallAttempts(py)) {
-      logStatus('[python] running: ${attempt.join(' ')}');
+      logTrace('[python] running: ${attempt.join(' ')}');
       final result = await Process.run(
         attempt[0],
         attempt.sublist(1),
@@ -86,12 +87,13 @@ abstract final class Pymd {
       if (result.exitCode == 0) {
         _cached = null;
         if (await _isInstalled()) {
-          logStatus('[pymobiledevice3] installed ✓');
+          step.done();
           return true;
         }
       }
     }
 
+    step.fail();
     logError(
       'failed to install pymobiledevice3. Install it manually:\n'
       '    sudo pip3 install --break-system-packages pymobiledevice3',
@@ -259,8 +261,9 @@ abstract final class Pymd {
     final inv = await resolve();
     final executable = inv.executable;
     final arguments = inv.args(args);
-    logStatus(
-      '[pymobiledevice3] running: ${ProcessRunner.commandLine(executable, arguments)}',
+    logTrace(
+      '[pymobiledevice3] running: '
+      '${ProcessRunner.commandLine(executable, arguments)}',
     );
     final result = await ProcessRunner.run(
       executable,

--- a/lib/src/device/session_console.dart
+++ b/lib/src/device/session_console.dart
@@ -5,6 +5,7 @@ import 'package:xcross/src/constants.dart';
 import 'package:xcross/src/device/gdb_remote_client.dart';
 import 'package:xcross/src/device/hot_reload_controller.dart';
 import 'package:xcross/src/util/logging.dart';
+import 'package:xcross/src/util/process.dart';
 
 /// Interactive terminal session for an attached app: streams the app's stdout,
 /// dispatches `r`/`R`/`q` keypresses to hot reload, and stops on SIGINT or when
@@ -48,15 +49,34 @@ class SessionConsole {
     }
   }
 
+  /// App output that arrived while a reload spinner was on screen. Writing it
+  /// straight to fd1 would shred the spinner block, so it waits its turn.
+  final List<List<int>> _heldOutput = [];
+
+  void _writeAppOutput(List<int> bytes) {
+    if (_busy) {
+      _heldOutput.add(bytes);
+      return;
+    }
+    stdout.add(bytes);
+  }
+
+  void _flushAppOutput() {
+    for (final bytes in _heldOutput) {
+      stdout.add(bytes);
+    }
+    _heldOutput.clear();
+  }
+
   /// Forward `O` (stdout) packets and stop on exit/termination.
   Future<void> _drainGdbReplies() async {
     await for (final reply in gdb.replies) {
       if (_stopped) break;
       switch (reply.type) {
         case GdbReply.stdout:
-          stdout.add(reply.stdoutBytes);
+          _writeAppOutput(reply.stdoutBytes);
         case GdbReply.exited || GdbReply.terminated:
-          logStatus('[xtool] app exited (${reply.payload})');
+          logInfo('App exited ${ansi.subtle('(${reply.payload})')}');
           _stopped = true;
           return;
         case GdbReply.stopped || GdbReply.other:
@@ -88,7 +108,10 @@ class SessionConsole {
     // _stopped must flip BEFORE _finish(): run()'s `while (!_stopped)` loop
     // would otherwise spin forever when our stdin pipe closes, orphaning
     // frontend_server and the RSD tunnel.
-    final sub = stdin.listen(
+    // sharedStdin, not stdin: `xtool install` reads stdin too, and cancelling
+    // a raw stdin subscription leaves this listen dead on arrival — onDone
+    // fires at once and the session quits the moment the app launches.
+    final sub = sharedStdin.listen(
       _handleKeyByte,
       onDone: () {
         _stopped = true;
@@ -160,10 +183,12 @@ class SessionConsole {
         _busy = true;
         await _handleHotReload();
         _busy = false;
+        _flushAppOutput();
       } else if (ch == DeviceConstants.keyBigR) {
         _busy = true;
         await _handleHotRestart();
         _busy = false;
+        _flushAppOutput();
       }
     }
   }
@@ -171,26 +196,30 @@ class SessionConsole {
   Future<void> _handleHotReload() async {
     final controller = hotReload;
     if (controller == null) return;
-    logStatus('[xtool] hot reload…');
+    final step = beginStep('Hot reload');
     try {
       final ok = await controller.reload();
-      logStatus(ok
-          ? '[xtool] reloaded ✓'
-          : "[xtool] reload rejected (try 'R' to restart)");
+      if (ok) {
+        step.done('Reloaded');
+      } else {
+        step.fail("Reload rejected (try 'R' to restart)");
+      }
     } catch (e) {
-      logError('reload failed: $e');
+      step.fail('Hot reload failed');
+      logError('$e');
     }
   }
 
   Future<void> _handleHotRestart() async {
     final controller = hotReload;
     if (controller == null) return;
-    logStatus('[xtool] hot restart…');
+    final step = beginStep('Hot restart');
     try {
       await controller.restart();
-      logStatus('[xtool] restarted ✓');
+      step.done('Restarted');
     } catch (e) {
-      logError('restart failed: $e');
+      step.fail('Hot restart failed');
+      logError('$e');
     }
   }
 }

--- a/lib/src/device/tunnel_daemon.dart
+++ b/lib/src/device/tunnel_daemon.dart
@@ -24,7 +24,7 @@ class TunnelDaemon {
   /// Ensure a tunneld REST API is reachable; start one if needed.
   Future<void> ensureRunning() async {
     if (await isReachable()) {
-      logStatus('[xtool] RSD tunnel daemon already running (reusing it)');
+      logTrace('RSD tunnel daemon already running (reusing it)');
       return;
     }
 
@@ -57,12 +57,18 @@ class TunnelDaemon {
       'tunneld',
     ];
 
-    logStatus(
+    logTrace(
       '[pymobiledevice3] starting RSD tunnel daemon'
-      '${sudo != null ? ' (needs root)' : ''}:\n'
-      '    ${argv.join(' ')}',
+      '${sudo != null ? ' (needs root)' : ''}: ${argv.join(' ')}',
     );
 
+    // The sudo prompt above must never be hidden behind the spinner, so the
+    // step only covers the spawn + readiness poll.
+    await logStep('Starting RSD tunnel daemon', () => _startDaemon(argv));
+  }
+
+  /// Spawn tunneld with [argv] and poll until its REST API answers.
+  Future<void> _startDaemon(List<String> argv) async {
     final tmpDir = Platform.environment['TMPDIR'] ?? '/tmp';
     final logPath = '$tmpDir/xtool-tunneld.log';
     final logFile = File(logPath);
@@ -101,10 +107,7 @@ class TunnelDaemon {
       interval: const Duration(seconds: 1),
       attempt: () async => await isReachable() ? true : null,
     );
-    if (up ?? false) {
-      logStatus('[pymobiledevice3] RSD tunnel daemon is up');
-      return;
-    }
+    if (up ?? false) return;
     throw XcrossError(
       'tunneld did not come up. Try starting it manually in another terminal:\n'
       '    sudo pymobiledevice3 remote tunneld\n'
@@ -120,7 +123,7 @@ class TunnelDaemon {
     _ownsDaemon = false;
     if (proc == null) return;
 
-    logStatus('[xtool] stopping RSD tunnel daemon…');
+    logTrace('stopping RSD tunnel daemon…');
 
     // The daemon runs under sudo (root); escalate via sudo kill.
     Sudo.resolve().then((sudo) {

--- a/lib/src/device/tunnel_discovery.dart
+++ b/lib/src/device/tunnel_discovery.dart
@@ -26,6 +26,7 @@ abstract final class TunnelDiscovery {
     var requestedStart = false;
     var loggedWaiting = false;
 
+    final step = beginStep('Waiting for RSD tunnel');
     final found = await pollUntil<Tunnel>(
       timeout: timeout,
       interval: pollInterval,
@@ -38,7 +39,7 @@ abstract final class TunnelDiscovery {
         // tunneld is up but has no tunnels yet — ask it to create one.
         if (udid != null && !requestedStart) {
           requestedStart = true;
-          logStatus(
+          logTrace(
             '[pymobiledevice3] no RSD tunnel yet — requesting '
             '/start-tunnel for $udid…',
           );
@@ -46,7 +47,7 @@ abstract final class TunnelDiscovery {
         }
         if (!loggedWaiting) {
           loggedWaiting = true;
-          logStatus(
+          logTrace(
             '[pymobiledevice3] waiting for RSD tunnel'
             '${udid != null ? ' ($udid)' : ''}…',
           );
@@ -54,7 +55,11 @@ abstract final class TunnelDiscovery {
         return null;
       },
     );
-    if (found != null) return found;
+    if (found != null) {
+      step.done();
+      return found;
+    }
+    step.fail();
 
     if (lastUnreachable) {
       throw XcrossError(
@@ -161,7 +166,7 @@ abstract final class TunnelDiscovery {
       _ => null,
     };
     if (addr == null || port == null) return null;
-    logStatus('[xtool] found RSD tunnel: $addr:$port');
+    logTrace('found RSD tunnel: $addr:$port');
     return Tunnel(address: addr, port: port);
   }
 }

--- a/lib/src/util/download.dart
+++ b/lib/src/util/download.dart
@@ -109,7 +109,10 @@ String _labelFromUrl(String url) {
 class _DownloadProgress {
   _DownloadProgress(this.label, this.total)
       : _stopwatch = Stopwatch()..start(),
-        _isTty = stdout.hasTerminal;
+        _isTty = stdout.hasTerminal {
+    // We draw with raw `\r`; a live spinner on the same line would fight us.
+    stopStep();
+  }
 
   final String label;
   final int total;
@@ -134,10 +137,9 @@ class _DownloadProgress {
       final percent = (_received * 100 ~/ total).clamp(0, 100);
       if (percent >= _lastLoggedPercent + 10) {
         _lastLoggedPercent = percent - (percent % 10);
-        logStatus(
-          '  $label: $percent% (${_fmtBytes(_received)}'
-          ' / ${_fmtBytes(total)})',
-        );
+        logStatus('${Glyph.download} $label '
+            '${ansi.subtle('$percent%  ${_fmtBytes(_received)}'
+                ' / ${_fmtBytes(total)}')}');
       }
     }
   }
@@ -146,25 +148,28 @@ class _DownloadProgress {
     if (_done) return;
     _done = true;
     _stopwatch.stop();
-    if (_isTty) {
-      _render(_stopwatch.elapsedMilliseconds);
-      stdout.writeln();
-    } else {
-      logStatus('  $label: done (${_fmtBytes(_received)})');
-    }
+    if (_isTty) stdout.write('\r${' '.padRight(96)}\r');
+    logDone(label, _fmtBytes(_received));
   }
+
+  static const _barWidth = 24;
 
   void _render(int elapsedMs) {
     final rate = elapsedMs > 0 ? _received * 1000 / elapsedMs : 0.0;
-    final buf = StringBuffer('  $label: ${_fmtBytes(_received)}');
+    final buf = StringBuffer('${Glyph.download} ${label.padRight(24)}');
     if (total > 0) {
-      final percent =
-          (_received * 100 / total).clamp(0, 100).toStringAsFixed(1);
-      buf.write(' / ${_fmtBytes(total)} ($percent%)');
+      final fraction = (_received / total).clamp(0.0, 1.0);
+      final filled = (fraction * _barWidth).round();
+      buf.write('${ansi.cyan}${'━' * filled}${ansi.none}');
+      buf.write(ansi.subtle('━' * (_barWidth - filled)));
+      buf.write(' ${(fraction * 100).round()}%'.padLeft(5));
+      buf.write(ansi.subtle('  ${_fmtBytes(_received)} / ${_fmtBytes(total)}'));
+    } else {
+      buf.write(_fmtBytes(_received));
     }
-    buf.write(' @ ${_fmtBytes(rate.round())}/s');
+    buf.write(ansi.subtle('  ${_fmtBytes(rate.round())}/s'));
     // `\r` + right-pad so leftover chars from a longer prior line are erased.
-    stdout.write('\r${buf.toString().padRight(78)}');
+    stdout.write('\r${buf.toString().padRight(96)}');
   }
 
   static String _fmtBytes(int n) {

--- a/lib/src/util/logging.dart
+++ b/lib/src/util/logging.dart
@@ -1,21 +1,266 @@
+import 'dart:async';
+import 'dart:io';
+
 import 'package:cli_util/cli_logging.dart';
 
 Logger _logger = Logger.standard();
 
-/// Switch global logger to verbose mode (shows trace output).
-void setVerbose() => _logger = Logger.verbose();
+/// Whether `--verbose` was passed. Trace output is only rendered when true.
+bool get isVerbose => _logger.isVerbose;
 
-/// A status/progress line.
-void logStatus(String message) => _logger.stdout(message);
-
-/// A `warning: ...` line on stderr.
-void logWarn(String message) {
-  final ansi = _logger.ansi;
-  _logger.stderr('${ansi.yellow}warning:${ansi.none} $message');
+/// Switch global logger to verbose mode (shows trace output, no spinners).
+void setVerbose() {
+  _stopStep();
+  _logger = Logger.verbose();
 }
 
-/// An `error: ...` line on stderr.
+/// ANSI helpers (colors are stripped automatically on a non-TTY).
+Ansi get ansi => _logger.ansi;
+
+bool get _fancy => _logger.ansi.useAnsi && !_logger.isVerbose;
+
+/// Every line xcross prints starts with one of these markers, so output reads
+/// as one list instead of a mix of bare text and decorated lines.
+abstract final class Glyph {
+  /// A fact, or a phase that has just started.
+  static String get info => '${ansi.cyan}›${ansi.none}';
+
+  /// A phase that finished.
+  static String get ok => '${ansi.green}✓${ansi.none}';
+
+  /// A phase that failed.
+  static String get bad => '${ansi.red}✗${ansi.none}';
+
+  /// Something worth knowing, but not fatal.
+  static String get warn => '${ansi.yellow}!${ansi.none}';
+
+  /// A transfer in flight.
+  static String get download => '${ansi.cyan}↓${ansi.none}';
+}
+
+/// Column the dim right-hand detail (elapsed time, size) is padded out to.
+const _detailColumn = 38;
+
+/// `message` padded so [detail] lines up with every other line's detail.
+String _withDetail(String message, String detail) {
+  final pad = message.length < _detailColumn
+      ? ' ' * (_detailColumn - message.length)
+      : ' ';
+  return '$message$pad${ansi.subtle(detail)}';
+}
+
+/// A user-facing fact: `› Device   iPhone 15 Pro`. Interrupts any spinner.
+///
+/// With a [value], [message] becomes a padded label so consecutive facts line
+/// up in a column.
+void logInfo(String message, [String? value]) => logStatus(
+      '${Glyph.info} '
+      '${value == null ? message : '${message.padRight(13)}$value'}',
+    );
+
+/// A one-off completed action that had no [Step]: `✓ Flutter iOS engine 279 MB`.
+void logDone(String message, [String? detail]) => logStatus(
+      '${Glyph.ok} ${detail == null ? message : _withDetail(message, detail)}',
+    );
+
+/// Print [message] verbatim (already carries its own marker). Interrupts any
+/// running spinner so the two never fight over the same line.
+void logStatus(String message) {
+  _stopStep();
+  _logger.stdout(message);
+}
+
+/// A detail line — only shown with `--verbose`. Use this for command lines,
+/// timings, and per-tool chatter that would otherwise flood the console.
+void logTrace(String message) => _logger.trace(message);
+
+/// A warning on stderr.
+void logWarn(String message) {
+  _stopStep();
+  _logger.stderr('${Glyph.warn} $message');
+}
+
+/// An error on stderr.
 void logError(String message) {
-  final ansi = _logger.ansi;
-  _logger.stderr('${ansi.red}error:${ansi.none} $message');
+  _stopStep();
+  _logger.stderr('${Glyph.bad} $message');
+}
+
+// ---------------------------------------------------------------------------
+// Steps: one spinner line per phase, replaced in place by a ✓/✗ on completion.
+// ---------------------------------------------------------------------------
+
+/// Run [body] under a spinner labelled [label]; prints `✓ label 1.2s` when it
+/// returns, `✗ label` when it throws.
+Future<T> logStep<T>(String label, Future<T> Function() body) async {
+  final step = beginStep(label);
+  try {
+    final result = await body();
+    step.done();
+    return result;
+  } on Object {
+    step.fail();
+    rethrow;
+  }
+}
+
+/// Start a spinner for work that cannot be wrapped in a closure. The caller
+/// must call [Step.done] or [Step.fail].
+Step beginStep(String label) {
+  _stopStep();
+  return _active = Step._(label);
+}
+
+/// Erase any running spinner — for code that writes to stdout directly
+/// (e.g. the download progress bar).
+void stopStep() => _stopStep();
+
+Step? _active;
+
+void _stopStep() {
+  final step = _active;
+  _active = null;
+  step?._erase();
+}
+
+/// A single in-progress phase.
+class Step {
+  Step._(this.label) : _watch = Stopwatch()..start() {
+    if (_fancy) {
+      _timer = Timer.periodic(const Duration(milliseconds: 80), (_) => _draw());
+      _draw();
+    } else {
+      // No spinner to watch (piped output, a debug console, `--verbose`), so
+      // announce the phase up front — otherwise long steps look like a hang.
+      _logger.stdout('${Glyph.info} $label…');
+    }
+  }
+
+  static const _frames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+  /// How many trailing output lines stay visible under the spinner.
+  static const _tailLines = 3;
+
+  final String label;
+  final Stopwatch _watch;
+  Timer? _timer;
+  int _tick = 0;
+  bool _closed = false;
+
+  /// Completed tail lines (most recent last), plus the partial line still
+  /// being written — kept separate so a prompt without a trailing newline is
+  /// still shown.
+  final List<String> _tail = [];
+  String _partial = '';
+
+  /// Lines occupied by the last render, so the next one knows how far up to go.
+  int _drawn = 0;
+
+  /// Feed subprocess output into the collapsing grey tail under the spinner.
+  /// Accepts arbitrary chunks — partial lines are fine. Off a fancy TTY the
+  /// lines go to trace instead (visible only with `--verbose`).
+  void log(String chunk) {
+    if (_closed || chunk.isEmpty) return;
+    _partial += chunk.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+    final parts = _partial.split('\n');
+    _partial = parts.removeLast();
+    for (final line in parts) {
+      if (_fancy) {
+        _tail.add(line);
+        if (_tail.length > _tailLines) _tail.removeAt(0);
+      } else {
+        logTrace(line);
+      }
+    }
+    if (_fancy) _draw();
+  }
+
+  /// Replace the spinner with a success line, discarding the tail.
+  void done([String? message]) =>
+      _close(Glyph.ok, message ?? label, timed: true);
+
+  /// Replace the spinner with a failure line, discarding the tail.
+  void fail([String? message]) => _close(Glyph.bad, message ?? label);
+
+  /// Repaint the spinner and its tail as one block, in place.
+  void _draw() {
+    // A `logStatus` mid-step erases the block and kills the timer; a later log
+    // line should bring the spinner back rather than leave it frozen.
+    _timer ??= Timer.periodic(const Duration(milliseconds: 80), (_) => _draw());
+    final frame = _frames[_tick++ % _frames.length];
+    final block = renderBlock(
+      head: '${ansi.cyan}$frame${ansi.none} $label',
+      tail: [for (final line in _visibleTail()) ansi.subtle(_fit(line))],
+      previousRows: _drawn,
+    );
+    _drawn = 1 + _visibleTail().length;
+    stdout.write(block);
+  }
+
+  /// The escape sequence that repaints a [head] line plus indented [tail] lines
+  /// over the [previousRows] rows drawn last time.
+  ///
+  /// The cursor starts and ends on the row just below the block, so the next
+  /// call moves up exactly [previousRows]. Pure so it can be unit-tested
+  /// without a terminal.
+  static String renderBlock({
+    required String head,
+    required List<String> tail,
+    required int previousRows,
+  }) {
+    final buf = StringBuffer();
+    // Back to the top of the block we drew last time.
+    if (previousRows > 0) buf.write('\x1B[${previousRows}A');
+    buf.write('\r$head\x1B[K\n');
+    for (final line in tail) {
+      buf.write('\r    $line\x1B[K\n');
+    }
+    // The block only ever grows, so nothing stale can be left below it.
+    return buf.toString();
+  }
+
+  List<String> _visibleTail() {
+    final partial = _partial.trimRight();
+    if (partial.isEmpty) return _tail;
+    final lines = [..._tail, partial];
+    return lines.length > _tailLines
+        ? lines.sublist(lines.length - _tailLines)
+        : lines;
+  }
+
+  /// Truncate to the terminal width: a wrapped line would break the cursor-up
+  /// arithmetic and leave garbage on screen.
+  static String _fit(String line) {
+    final max = (stdout.hasTerminal ? stdout.terminalColumns : 80) - 6;
+    if (max < 8 || line.length <= max) return line;
+    return '${line.substring(0, max - 1)}…';
+  }
+
+  /// Stop animating and blank the whole block. Idempotent; does NOT close the
+  /// step, so a later [done]/[fail] still reports on a fresh line.
+  void _erase() {
+    if (_timer == null) return;
+    _timer!.cancel();
+    _timer = null;
+    if (!_fancy) return;
+    // Up to the top of the block, then clear everything below the cursor.
+    stdout.write(_drawn > 0 ? '\r\x1B[${_drawn}A\x1B[J' : '\r\x1B[K');
+    _drawn = 0;
+  }
+
+  void _close(String mark, String message, {bool timed = false}) {
+    if (_closed) return;
+    _closed = true;
+    if (_active == this) _active = null;
+    _erase();
+    _logger.stdout('$mark '
+        '${timed ? _withDetail(message, _fmtElapsed(_watch.elapsed)) : message}');
+  }
+
+  static String _fmtElapsed(Duration d) {
+    if (d.inMinutes >= 1) {
+      return '${d.inMinutes}m${(d.inSeconds % 60).toString().padLeft(2, '0')}s';
+    }
+    return '${(d.inMilliseconds / 1000).toStringAsFixed(1)}s';
+  }
 }

--- a/lib/src/util/process.dart
+++ b/lib/src/util/process.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -5,6 +6,26 @@ import 'package:path/path.dart' as p;
 import 'package:posix/posix.dart' as posix;
 import 'package:xcross/src/util/errors.dart';
 import 'package:xcross/src/util/logging.dart';
+
+/// Every stdin reader in the process must go through this one broadcast.
+///
+/// Cancelling a subscription to [stdin] closes the underlying fd for good: a
+/// later `stdin.listen` then fires `onDone` immediately instead of delivering
+/// keys, which silently killed the hot-reload keypress loop after an install.
+/// `onCancel`/`onListen` pause and resume the source instead of tearing it
+/// down, so bytes typed between readers stay queued in the tty.
+Stream<List<int>> get sharedStdin => _sharedStdin ??= pausingBroadcast(stdin);
+Stream<List<int>>? _sharedStdin;
+
+/// A broadcast view of [source] that pauses — never cancels — the source
+/// subscription when its last listener goes away, so a later listener still
+/// gets events. Split out from [sharedStdin] so it is testable without a tty.
+Stream<T> pausingBroadcast<T>(Stream<T> source) => source.asBroadcastStream(
+      onListen: (sub) {
+        if (sub.isPaused) sub.resume();
+      },
+      onCancel: (sub) => sub.pause(),
+    );
 
 /// Captured result of a finished subprocess.
 class CapturedProcess {
@@ -42,10 +63,11 @@ abstract final class ProcessRunner {
 
   /// Run [executable], throwing [XcrossError] on a non-zero exit code.
   ///
-  /// When [inheritStdio] is true the child shares this process's stdio via
-  /// [ProcessStartMode.inheritStdio] (needed for interactive prompts like
-  /// `xtool install` certificate revocation). Otherwise output is captured
-  /// and the stderr is included in the thrown error.
+  /// When [tail] is given, output is streamed into that step's collapsing grey
+  /// log and this process's stdin is forwarded to the child, so prompts still
+  /// work. Otherwise, when [inheritStdio] is true the child shares this
+  /// process's stdio via [ProcessStartMode.inheritStdio]. In the default case
+  /// output is captured and the stderr is included in the thrown error.
   static Future<void> runChecked(
     String executable,
     List<String> arguments, {
@@ -53,9 +75,20 @@ abstract final class ProcessRunner {
     Map<String, String>? environment,
     bool inheritStdio = false,
     String? label,
+    Step? tail,
   }) async {
     final prefix = label ?? _labelForExecutable(executable);
-    logStatus('[$prefix] running: ${commandLine(executable, arguments)}');
+    logTrace('[$prefix] running: ${commandLine(executable, arguments)}');
+
+    if (tail != null) {
+      return _runWithTail(
+        executable,
+        arguments,
+        workingDirectory: workingDirectory,
+        environment: environment,
+        tail: tail,
+      );
+    }
 
     if (inheritStdio) {
       // Must use inheritStdio (not piped stdout/stderr): xtool writes
@@ -88,6 +121,77 @@ abstract final class ProcessRunner {
         'command failed (${result.exitCode}): '
         '${commandLine(executable, arguments)}\n${result.stderr}',
       );
+    }
+  }
+
+  /// Stream a child's merged output into [tail] while forwarding our stdin to
+  /// it. The stdin forwarding is what makes this safe for `xtool install`:
+  /// piping alone previously hid its "certificates must be revoked" prompt AND
+  /// left the child's stdin disconnected, so the install hung forever.
+  static Future<void> _runWithTail(
+    String executable,
+    List<String> arguments, {
+    required Step tail,
+    String? workingDirectory,
+    Map<String, String>? environment,
+  }) async {
+    final process = await Process.start(
+      executable,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+    );
+
+    // Keep the full text for the error message; the step only shows the last
+    // few lines. utf8.decoder as a stream transformer is chunk-boundary safe.
+    final captured = StringBuffer();
+    void sink(String chunk) {
+      captured.write(chunk);
+      tail.log(chunk);
+    }
+
+    final drained = Future.wait([
+      process.stdout.transform(utf8.decoder).forEach(sink),
+      process.stderr.transform(utf8.decoder).forEach(sink),
+    ]);
+
+    // A byte forwarded just as the child exits fails on the closed pipe, and
+    // an IOSink reports that on `done` — unhandled, it takes down the process.
+    unawaited(process.stdin.done.catchError((Object _) {}));
+
+    StreamSubscription<List<int>>? input;
+    try {
+      input = sharedStdin.listen(
+        (bytes) {
+          try {
+            process.stdin.add(bytes);
+          } on Object catch (_) {
+            // Child already gone; nothing left to feed.
+          }
+        },
+        onError: (Object _) {},
+      );
+    } on Object catch (e) {
+      // Unavailable stdin is not fatal: the child simply gets no input,
+      // exactly as before this streaming path existed.
+      logTrace('stdin not forwarded to $executable: $e');
+    }
+
+    try {
+      final code = await process.exitCode;
+      // Stop forwarding the moment the child is gone, before its pipe errors.
+      await input?.cancel();
+      input = null;
+      await drained;
+      if (code != 0) {
+        throw XcrossError(
+          'command failed ($code): ${commandLine(executable, arguments)}\n'
+          '$captured',
+        );
+      }
+    } finally {
+      await input?.cancel();
+      unawaited(process.stdin.close().catchError((Object _) {}));
     }
   }
 
@@ -146,10 +250,9 @@ void makeExecutable(String path) {
 String bracketHost(String addr) => addr.contains(':') ? '[$addr]' : addr;
 
 /// Strip IPv6 brackets so [Socket.connect] receives a raw host string.
-String unbracketHost(String host) =>
-    host.startsWith('[') && host.endsWith(']')
-        ? host.substring(1, host.length - 1)
-        : host;
+String unbracketHost(String host) => host.startsWith('[') && host.endsWith(']')
+    ? host.substring(1, host.length - 1)
+    : host;
 
 /// Retry [attempt] every [interval] until it yields a non-null value or
 /// [timeout] elapses. Exceptions from [attempt] are swallowed and retried.

--- a/lib/src/util/sudo.dart
+++ b/lib/src/util/sudo.dart
@@ -17,10 +17,8 @@ abstract final class Sudo {
     final sudo = await resolve();
     if (sudo == null) return;
 
-    logStatus(
-      '[sudo] confirming access '
-      '(you may be asked for your password once)…',
-    );
+    logInfo('Confirming sudo access '
+        '${ansi.subtle('— you may be asked for your password once')}');
     final proc = await Process.start(
       sudo,
       const ['-v'],

--- a/lib/src/xtool/xtool_cli.dart
+++ b/lib/src/xtool/xtool_cli.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:xcross/src/models/device/device.dart';
 import 'package:xcross/src/util/errors.dart';
+import 'package:xcross/src/util/logging.dart';
 import 'package:xcross/src/util/process.dart';
 
 /// Which devices `xtool` should search for.
@@ -157,8 +158,9 @@ class XtoolCli {
   /// `xtool install <path> [--udid <udid>] [--usb|--wifi]`.
   ///
   /// Signs (using saved `xtool auth` credentials) and installs a `.app` or
-  /// `.ipa`. Inherits stdio so progress and interactive prompts (e.g.
-  /// certificate revocation confirmation) work.
+  /// `.ipa`. Runs under a spinner whose grey tail shows xtool's own progress;
+  /// stdin is forwarded so interactive prompts (e.g. certificate revocation)
+  /// still work.
   Future<void> install(
     String appOrIpaPath, {
     String? udid,
@@ -168,12 +170,20 @@ class XtoolCli {
     if (udid != null) args.addAll(['--udid', udid]);
     final flag = mode.flag;
     if (flag != null) args.add(flag);
-    await ProcessRunner.runChecked(
-      executable,
-      args,
-      inheritStdio: true,
-      label: 'xtool',
-    );
+
+    final step = beginStep('Signing and installing');
+    try {
+      await ProcessRunner.runChecked(
+        executable,
+        args,
+        label: 'xtool',
+        tail: step,
+      );
+      step.done();
+    } on Object {
+      step.fail();
+      rethrow;
+    }
   }
 
   /// `xtool launch <bundleID> [args...] [--udid <udid>]`.

--- a/test/util/logging_test.dart
+++ b/test/util/logging_test.dart
@@ -1,0 +1,95 @@
+import 'dart:async';
+
+import 'package:test/test.dart';
+// ignore: implementation_imports
+import 'package:xcross/src/util/logging.dart';
+
+/// Collect everything the logger prints to stdout. Under `dart test` there is
+/// no TTY, so spinners are disabled and every line arrives via `print`.
+List<String> capture(void Function() body) {
+  final lines = <String>[];
+  runZoned(
+    body,
+    zoneSpecification: ZoneSpecification(
+      print: (_, __, ___, line) => lines.add(line),
+    ),
+  );
+  return lines;
+}
+
+void main() {
+  // Without a spinner to watch (piped output, a VS Code debug console,
+  // --verbose) a long step must still announce itself, or it looks like a hang.
+  test('a step announces its start, then reports once', () {
+    final lines = capture(() {
+      final step = beginStep('Building');
+      step.done();
+      step.done(); // double-close must not double-report
+    });
+    expect(lines, hasLength(2));
+    expect(lines.first, startsWith('› Building…'));
+    expect(lines.last, startsWith('✓ Building'));
+  });
+
+  test('failure reports ✗', () {
+    final lines = capture(() => beginStep('Building').fail());
+    expect(lines.last, startsWith('✗ Building'));
+  });
+
+  test('an interrupting status line does not swallow the ✓', () {
+    final lines = capture(() {
+      final step = beginStep('Building');
+      logInfo('vm-service:', 'ws://127.0.0.1:1234/ws');
+      step.done();
+    });
+    expect(lines, hasLength(3));
+    expect(lines[1], contains('vm-service: '));
+    expect(lines.last, startsWith('✓ Building'));
+  });
+
+  test('logStep rethrows and marks the step failed', () async {
+    final lines = <String>[];
+    await runZoned(
+      () async {
+        await expectLater(
+          logStep<void>('Compiling', () async => throw StateError('boom')),
+          throwsStateError,
+        );
+      },
+      zoneSpecification: ZoneSpecification(
+        print: (_, __, ___, line) => lines.add(line),
+      ),
+    );
+    expect(lines.last, startsWith('✗ Compiling'));
+  });
+
+  test('trace output is suppressed until --verbose', () {
+    expect(capture(() => logTrace('clang -c foo.m')), isEmpty);
+  });
+
+  group('renderBlock', () {
+    // The cursor ends one row below the block, so the next repaint must move
+    // up by exactly the row count of the previous one. Getting this wrong
+    // smears the spinner down the screen.
+    test('first paint does not move the cursor up', () {
+      final out = Step.renderBlock(head: 'x', tail: [], previousRows: 0);
+      expect(out, isNot(matches(RegExp(r'\x1B\[\d+A'))));
+      expect('\n'.allMatches(out), hasLength(1));
+    });
+
+    test('repaint rewinds by the previous row count', () {
+      final first =
+          Step.renderBlock(head: 'x', tail: ['a', 'b'], previousRows: 0);
+      expect('\n'.allMatches(first), hasLength(3));
+      final second =
+          Step.renderBlock(head: 'x', tail: ['a', 'b'], previousRows: 3);
+      expect(second, startsWith('\x1B[3A'));
+      expect('\n'.allMatches(second), hasLength(3));
+    });
+
+    test('every row clears its own leftovers', () {
+      final out = Step.renderBlock(head: 'x', tail: ['a'], previousRows: 2);
+      expect('\x1B[K'.allMatches(out), hasLength(2));
+    });
+  });
+}

--- a/test/util/shared_stdin_test.dart
+++ b/test/util/shared_stdin_test.dart
@@ -1,0 +1,46 @@
+import 'dart:async';
+
+import 'package:test/test.dart';
+import 'package:xcross/src/util/process.dart';
+
+void main() {
+  // Regression: `xtool install` forwards stdin to the child, then cancels.
+  // With a plain `stdin.listen`, that cancel closes the fd for good and
+  // SessionConsole's later listen fires onDone at once — the session quit the
+  // instant the app launched and r/R did nothing.
+  test('a second listener still receives events after the first cancels',
+      () async {
+    final source = StreamController<int>();
+    final shared = pausingBroadcast(source.stream);
+
+    final first = shared.listen((_) {});
+    await first.cancel();
+
+    var done = false;
+    final seen = <int>[];
+    shared.listen(seen.add, onDone: () => done = true);
+
+    source.add(1);
+    source.add(2);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(seen, [1, 2]);
+    expect(done, isFalse, reason: 'source must not have been torn down');
+    await source.close();
+  });
+
+  test('events sent between listeners are not lost', () async {
+    final source = StreamController<int>();
+    final shared = pausingBroadcast(source.stream);
+
+    await shared.listen((_) {}).cancel();
+    source.add(7); // nobody listening — must queue, not vanish
+
+    final seen = <int>[];
+    shared.listen(seen.add);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(seen, [7]);
+    await source.close();
+  });
+}

--- a/tool/tui_demo.dart
+++ b/tool/tui_demo.dart
@@ -1,0 +1,76 @@
+// Visual smoke test for the console UI. Run in a real terminal to see the
+// spinner + progress bar; pipe it to see the ANSI-less rendering.
+import 'dart:async';
+import 'dart:io';
+
+import 'package:xcross/src/constants.dart';
+import 'package:xcross/src/util/download.dart';
+import 'package:xcross/src/util/logging.dart';
+
+Future<void> main() async {
+  logInfo('Device', 'iPhone Mind ${ansi.subtle('00008030-000664292232802E')}');
+
+  await logStep('Resolving dependencies', _work(600));
+
+  // A download inside a step: the bar takes over the line, the step still ✓s.
+  final fetch = beginStep('Fetching Flutter engine artifacts');
+  await _fakeDownload('Flutter iOS engine', 279 * 1024 * 1024);
+  fetch.done();
+
+  await logStep('Compiling Dart kernel', _work(900));
+  await logStep('Building App.framework', _work(400));
+
+  // A step with a collapsing grey log tail, like `xtool install`.
+  final install = beginStep('Signing and installing');
+  for (final line in const [
+    'Fetching signing certificate',
+    'Registering app id com.test.abra',
+    'Provisioning profile: iOS Team Provisioning',
+    'Signing Frameworks/Flutter.framework',
+    'Signing Frameworks/App.framework',
+    'Uploading to device (12.4 MB)',
+  ]) {
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+    install.log('$line\n');
+  }
+  install.done();
+
+  await logStep('Waiting for RSD tunnel', _work(500));
+  await logStep('Debugger attached', _work(200));
+  logInfo('App', 'com.test.abra ${ansi.subtle('debug/JIT, hot reload')}');
+  logInfo(DeviceConstants.vmServiceMarker, 'ws://127.0.0.1:46269/ws');
+  logInfo('Hot reload ready '
+      '${ansi.subtle('— r reload  ·  R restart  ·  q quit')}');
+
+  await logStep('Hot reload', _work(4400)).then((_) {});
+  logWarn('expression evaluation unavailable: no isolate');
+  try {
+    await logStep('Hot restart', () async => throw StateError('vm rejected'));
+  } catch (_) {}
+}
+
+Future<void> Function() _work(int ms) =>
+    () => Future<void>.delayed(Duration(milliseconds: ms));
+
+/// Exercise the real download path against a local server, so the progress bar
+/// shown here is exactly the one users see.
+Future<void> _fakeDownload(String label, int total) async {
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+  const chunks = 25;
+  final chunk = List<int>.filled(total ~/ chunks, 0);
+  unawaited(server.first.then((req) async {
+    req.response.contentLength = chunk.length * chunks;
+    for (var i = 0; i < chunks; i++) {
+      req.response.add(chunk);
+      await req.response.flush();
+      await Future<void>.delayed(const Duration(milliseconds: 70));
+    }
+    await req.response.close();
+  }));
+
+  final dest = File('${Directory.systemTemp.path}/xcross-tui-demo.bin');
+  await downloadToFile('http://127.0.0.1:${server.port}/artifacts.zip', dest,
+      label: label);
+  await server.close(force: true);
+  await dest.delete();
+}


### PR DESCRIPTION
A plain `xcross flutter run` printed every subprocess command line and ~60 status lines, so the interesting parts scrolled away. Output is now one line per phase; the detail moved behind `--verbose`.

- Add steps to `logging.dart`: an animated spinner per phase that collapses to `✓ label 1.2s` (or `✗ label`), plus `logTrace` for the detail. Built on the cli_logging dependency already in the tree.
- Give steps an optional grey 3-line tail of live subprocess output (`ProcessRunner.runChecked(tail:)`), used by `xtool install` and erased when the step completes. Cursor-block rendering is a pure function so it is unit-tested without a terminal.
- Show a real progress bar for engine-artifact downloads, labelled per artifact set, and put the unzip behind its own step.
- Announce `› label…` up front whenever there is no spinner to watch (piped output, a VS Code debug console, `--verbose`), so long phases cannot look like a hang.
- Give every line one glyph — `›` info, `✓` done, `✗` failed, `!` warn, `↓` download — and drop the `[xcross]`/`[xtool]` prefixes.
- Move `--verbose` onto the runner so `prepare` and `build` can reach their trace output too, not just `flutter run`.

`vmServiceMarker` becomes `vm-service: `; the DAP matches it by substring, so the line glyph in front makes no difference.