### PR TITLE
fix(xcross): support Flutter workspace package configs

### DIFF
--- a/packages/xcross/lib/src/dap/xcross_dap.dart
+++ b/packages/xcross/lib/src/dap/xcross_dap.dart
@@ -9,6 +9,7 @@ import 'package:path/path.dart' as p;
 import 'package:pure/pure.dart';
 import 'package:vm_service/vm_service.dart' as vm;
 import 'package:xcross/src/constants.dart';
+import 'package:xcross/src/package_config_resolver.dart';
 
 /// Spawns `xcross flutter run` and drives it: keypresses on its stdin for
 /// hot reload/restart/quit, plus a Dart VM Service connection (via
@@ -125,9 +126,8 @@ final class XcrossDap
   }
 
   Future<void> _prepareUriMappings(String cwd) async {
-    _packageUris ??= await PackageUris.load(
-      p.join(cwd, '.dart_tool', 'package_config.json'),
-    );
+    final packageConfig = await PackageConfigResolver.require(cwd);
+    _packageUris ??= await PackageUris.load(packageConfig);
     orgDartlangSdkMappings.clear();
   }
 

--- a/packages/xcross/lib/src/flutter/build/flutter_debug_bundler.dart
+++ b/packages/xcross/lib/src/flutter/build/flutter_debug_bundler.dart
@@ -13,6 +13,7 @@ import 'package:xcross/src/flutter/build/ios_engine_cache.dart';
 import 'package:xcross/src/flutter/constants.dart';
 import 'package:xcross/src/flutter/errors.dart';
 import 'package:xcross/src/flutter/models/pubspec_info.dart';
+import 'package:xcross/src/package_config_resolver.dart';
 
 /// Assembles `App.framework` (debug/JIT mode) for a Flutter iOS app without
 /// invoking `xcrun` or `flutter_tools.snapshot assemble`.
@@ -105,17 +106,7 @@ final class FlutterDebugBundler {
     _validateKernelDependencies(compiler, engineCache);
 
     final outputDill = await _prepareKernelScratch();
-    final packageConfig = p.join(
-      projectRoot,
-      '.dart_tool',
-      'package_config.json',
-    );
-    if (!File(packageConfig).existsSync()) {
-      throw FlutterBuildError(
-        'FlutterDebugBundler: package_config.json missing at $packageConfig; '
-        'run `dart pub get` first.',
-      );
-    }
+    final packageConfig = await PackageConfigResolver.require(projectRoot);
 
     final args = _frontendServerArgs(
       compiler: compiler,

--- a/packages/xcross/lib/src/flutter/build/flutter_packer.dart
+++ b/packages/xcross/lib/src/flutter/build/flutter_packer.dart
@@ -15,6 +15,7 @@ import 'package:xcross/src/flutter/constants.dart';
 import 'package:xcross/src/flutter/errors.dart';
 import 'package:xcross/src/flutter/models/flutter/flutter_build_options.dart';
 import 'package:xcross/src/flutter/models/pubspec_info.dart';
+import 'package:xcross/src/package_config_resolver.dart';
 
 /// Builds a Flutter iOS `.app` bundle using Dart and xcross's cross-platform
 /// toolchain. Does NOT call `xcrun`.
@@ -98,11 +99,6 @@ final class FlutterPacker {
   /// Run `flutter pub get`. Tolerates failures when `package_config.json`
   /// already exists (container builds with ephemeral pub caches).
   Future<void> _runFlutterPubGet(String flutterRoot) {
-    final packageConfig = p.join(
-      projectRoot,
-      '.dart_tool',
-      'package_config.json',
-    );
     return Log.logStep('Resolving dependencies', () async {
       try {
         await ProcessRunner.runChecked(
@@ -122,7 +118,8 @@ final class FlutterPacker {
           label: 'flutter',
         );
       } on FlutterBuildError {
-        final packageConfigExists = File(packageConfig).existsSync();
+        final packageConfig = await PackageConfigResolver.find(projectRoot);
+        final packageConfigExists = packageConfig != null;
         if (packageConfigExists) {
           Log.logWarn(
             'Ignoring flutter pub get error because '

--- a/packages/xcross/lib/src/flutter/build/hot_reload_setup.dart
+++ b/packages/xcross/lib/src/flutter/build/hot_reload_setup.dart
@@ -5,6 +5,7 @@ import 'package:path/path.dart' as p;
 import 'package:xcross/src/flutter/build/flutter_packer.dart';
 import 'package:xcross/src/flutter/build/ios_engine_cache.dart';
 import 'package:xcross/src/flutter/models/hot_reload_config.dart';
+import 'package:xcross/src/package_config_resolver.dart';
 
 /// Groups hot-reload configuration setup.
 abstract final class HotReloadSetup {
@@ -34,11 +35,7 @@ abstract final class HotReloadSetup {
     }
 
     final sdkRoot = engineCache.patchedSdkRoot;
-    final packageConfig = p.join(
-      projectRoot,
-      '.dart_tool',
-      'package_config.json',
-    );
+    final packageConfig = await PackageConfigResolver.require(projectRoot);
     final entrypoint = p.isAbsolute(target)
         ? target
         : p.join(projectRoot, target);

--- a/packages/xcross/lib/src/package_config_resolver.dart
+++ b/packages/xcross/lib/src/package_config_resolver.dart
@@ -1,0 +1,27 @@
+import 'dart:io';
+
+import 'package:package_config/package_config.dart';
+import 'package:xcross/src/flutter/errors.dart';
+
+/// Discovers the Dart package configuration used by a Flutter project.
+abstract final class PackageConfigResolver {
+  /// Finds the nearest package configuration at [projectRoot] or an ancestor.
+  static Future<String?> find(String projectRoot) async {
+    final result = await findPackageConfigAndFile(
+      Directory(projectRoot),
+      // ignore: avoid_redundant_argument_values
+      minVersion: 2, // Explicitly exclude legacy `.packages` resolution.
+    );
+    return result?.file.path;
+  }
+
+  /// Finds the package configuration or reports how to create it.
+  static Future<String> require(String projectRoot) async {
+    final packageConfig = await find(projectRoot);
+    if (packageConfig != null) return packageConfig;
+    throw FlutterBuildError(
+      'package_config.json not found from $projectRoot; '
+      'run `flutter pub get` or `dart pub get` first.',
+    );
+  }
+}

--- a/packages/xcross/pubspec.yaml
+++ b/packages/xcross/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   completion: ^1.0.2
   cli_util: ^0.5.2
   meta: ^1.19.0
+  package_config: ^3.0.0
   path: ^1.9.1
   standard_message_codec: ^0.0.1+5
   yaml: ^3.1.3

--- a/packages/xcross/test/package_config_resolver_test.dart
+++ b/packages/xcross/test/package_config_resolver_test.dart
@@ -1,0 +1,97 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:xcross/src/flutter/errors.dart';
+import 'package:xcross/src/package_config_resolver.dart';
+
+void _writePackageConfig(String directory) {
+  final file = File(
+    p.join(directory, '.dart_tool', 'package_config.json'),
+  );
+  file.parent.createSync(recursive: true);
+  file.writeAsStringSync(
+    jsonEncode(<String, Object>{
+      'configVersion': 2,
+      'packages': <Object>[],
+    }),
+  );
+}
+
+void main() {
+  group('PackageConfigResolver', () {
+    late Directory temp;
+
+    setUp(() {
+      temp = Directory.systemTemp.createTempSync(
+        'package_config_resolver_test-',
+      );
+    });
+
+    tearDown(() {
+      temp.deleteSync(recursive: true);
+    });
+
+    test('finds a standalone project package config', () async {
+      _writePackageConfig(temp.path);
+
+      final result = await PackageConfigResolver.find(temp.path);
+
+      expect(
+        result,
+        p.join(temp.path, '.dart_tool', 'package_config.json'),
+      );
+    });
+
+    test('finds a workspace package config in an ancestor', () async {
+      final app = Directory(p.join(temp.path, 'apps', 'example'))
+        ..createSync(recursive: true);
+      _writePackageConfig(temp.path);
+
+      final result = await PackageConfigResolver.find(app.path);
+
+      expect(
+        result,
+        p.join(temp.path, '.dart_tool', 'package_config.json'),
+      );
+    });
+
+    test('prefers a local package config over an ancestor', () async {
+      final app = Directory(p.join(temp.path, 'apps', 'example'))
+        ..createSync(recursive: true);
+      _writePackageConfig(temp.path);
+      _writePackageConfig(app.path);
+
+      final result = await PackageConfigResolver.find(app.path);
+
+      expect(
+        result,
+        p.join(app.path, '.dart_tool', 'package_config.json'),
+      );
+    });
+
+    test('find returns null when no package config exists', () async {
+      expect(await PackageConfigResolver.find(temp.path), isNull);
+    });
+
+    test('require reports the directory and recovery command', () async {
+      await expectLater(
+        PackageConfigResolver.require(temp.path),
+        throwsA(
+          isA<FlutterBuildError>()
+              .having(
+                (error) => error.message,
+                'message',
+                contains(temp.path),
+              )
+              .having(
+                (error) => error.message,
+                'message',
+                contains('pub get'),
+              ),
+        ),
+      );
+    });
+  });
+}

--- a/packages/xcross/test/package_config_resolver_test.dart
+++ b/packages/xcross/test/package_config_resolver_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:isolate';
 
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
@@ -7,16 +8,19 @@ import 'package:xcross/src/flutter/errors.dart';
 import 'package:xcross/src/package_config_resolver.dart';
 
 void _writePackageConfig(String directory) {
-  final file = File(
-    p.join(directory, '.dart_tool', 'package_config.json'),
-  );
+  final file = File(p.join(directory, '.dart_tool', 'package_config.json'));
   file.parent.createSync(recursive: true);
   file.writeAsStringSync(
-    jsonEncode(<String, Object>{
-      'configVersion': 2,
-      'packages': <Object>[],
-    }),
+    jsonEncode(<String, Object>{'configVersion': 2, 'packages': <Object>[]}),
   );
+}
+
+String _readXcrossSource(String relativePath) {
+  final library = File.fromUri(
+    Isolate.resolvePackageUriSync(Uri.parse('package:xcross/xcross.dart'))!,
+  );
+  final packageRoot = library.parent.parent.path;
+  return File(p.join(packageRoot, relativePath)).readAsStringSync();
 }
 
 void main() {
@@ -38,10 +42,7 @@ void main() {
 
       final result = await PackageConfigResolver.find(temp.path);
 
-      expect(
-        result,
-        p.join(temp.path, '.dart_tool', 'package_config.json'),
-      );
+      expect(result, p.join(temp.path, '.dart_tool', 'package_config.json'));
     });
 
     test('finds a workspace package config in an ancestor', () async {
@@ -51,10 +52,7 @@ void main() {
 
       final result = await PackageConfigResolver.find(app.path);
 
-      expect(
-        result,
-        p.join(temp.path, '.dart_tool', 'package_config.json'),
-      );
+      expect(result, p.join(temp.path, '.dart_tool', 'package_config.json'));
     });
 
     test('prefers a local package config over an ancestor', () async {
@@ -65,10 +63,7 @@ void main() {
 
       final result = await PackageConfigResolver.find(app.path);
 
-      expect(
-        result,
-        p.join(app.path, '.dart_tool', 'package_config.json'),
-      );
+      expect(result, p.join(app.path, '.dart_tool', 'package_config.json'));
     });
 
     test('find returns null when no package config exists', () async {
@@ -80,18 +75,28 @@ void main() {
         PackageConfigResolver.require(temp.path),
         throwsA(
           isA<FlutterBuildError>()
-              .having(
-                (error) => error.message,
-                'message',
-                contains(temp.path),
-              )
-              .having(
-                (error) => error.message,
-                'message',
-                contains('pub get'),
-              ),
+              .having((error) => error.message, 'message', contains(temp.path))
+              .having((error) => error.message, 'message', contains('pub get')),
         ),
       );
     });
+  });
+
+  test('all package config consumers use the shared resolver', () {
+    final bundler = _readXcrossSource(
+      'lib/src/flutter/build/flutter_debug_bundler.dart',
+    );
+    final packer = _readXcrossSource(
+      'lib/src/flutter/build/flutter_packer.dart',
+    );
+    final hotReload = _readXcrossSource(
+      'lib/src/flutter/build/hot_reload_setup.dart',
+    );
+    final dap = _readXcrossSource('lib/src/dap/xcross_dap.dart');
+
+    expect(bundler, contains('PackageConfigResolver.require(projectRoot)'));
+    expect(packer, contains('PackageConfigResolver.find(projectRoot)'));
+    expect(hotReload, contains('PackageConfigResolver.require(projectRoot)'));
+    expect(dap, contains('PackageConfigResolver.require(cwd)'));
   });
 }


### PR DESCRIPTION
## Summary
- add canonical recursive `package_config.json` discovery for standalone projects and workspace members
- use the resolved config in Flutter dependency fallback, debug kernel compilation, hot reload, and DAP URI mappings
- add regression coverage for local precedence, ancestor workspace configs, missing configs, and consumer wiring

## Validation
- `dart analyze` in `packages/xcross`: no issues
- `dart test` in `packages/xcross`: 227 tests passed
- real Dart workspace fixture: config created at workspace root and absent from the member directory
- final whole-branch review: no Critical or Important findings