### PR TITLE
fix(flutter): expose Flutter headers to ObjC plugins

### DIFF
--- a/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
@@ -123,9 +123,9 @@ abstract final class GeneratedPluginsPackage {
     // (verified against a real published plugin: its manifest lists zero
     // dependencies, yet its Swift source does `import Flutter`). A plain
     // `swift build` has no such implicit project-wide behaviour, so we
-    // reproduce it ourselves with a build-wide `-Xswiftc -F` flag, applied
-    // uniformly to every target's compile step regardless of what that
-    // target's own manifest declares.
+    // reproduce it ourselves with build-wide framework search flags. Swift
+    // targets need `-Xswiftc -F`; C and Objective-C targets need the matching
+    // `-Xcc -F` pair so imports such as `<Flutter/Flutter.h>` resolve too.
     final flutterFrameworkSlice = p.join(flutterXcframework, 'ios-arm64');
     final linker = await DarwinSdk.resolveLd64Lld(sdk);
     final toolsetPath = await writeToolset(
@@ -188,6 +188,10 @@ abstract final class GeneratedPluginsPackage {
     '-Xswiftc',
     '-F',
     '-Xswiftc',
+    flutterFrameworkSlice,
+    '-Xcc',
+    '-F',
+    '-Xcc',
     flutterFrameworkSlice,
     '-Xswiftc',
     '-Xfrontend',

--- a/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
+++ b/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
@@ -454,6 +454,15 @@ let package = Package(
           'Flutter.xcframework/ios-arm64',
         ]),
       );
+      expect(
+        arguments,
+        containsAllInOrder([
+          '-Xcc',
+          '-F',
+          '-Xcc',
+          'Flutter.xcframework/ios-arm64',
+        ]),
+      );
       expect(arguments, contains('-disable-availability-checking'));
       expect(arguments, isNot(contains('-install_name')));
     });


### PR DESCRIPTION
## Summary

- pass the Flutter framework search path to every C and Objective-C compiler invocation in the generated SwiftPM build
- preserve the existing Swift compiler framework search path
- add regression coverage for the exact `-Xcc -F <Flutter framework slice>` argument sequence

## Problem

Objective-C Flutter plugins built through SwiftPM can fail with:

```text
fatal error: 'Flutter/Flutter.h' file not found
```

For example, `wakelock_plus` is an Objective-C SwiftPM target with no declared Flutter package dependency and imports `<Flutter/Flutter.h>`. xcross already supplied the Flutter framework directory through `-Xswiftc -F`, which only reaches Swift compiler invocations. Objective-C targets compile through Clang and therefore never received that search path.

## Fix

Add the equivalent build-wide C-family compiler passthrough flags:

```text
-Xcc -F -Xcc <Flutter.xcframework/ios-arm64>
```

SwiftPM documents `-Xcc` as passing an argument to every C compiler invocation, covering C, C++, and Objective-C plugin targets on both Linux and Windows cross builds.

## Verification

- regression assertion failed before the implementation because no `-Xcc` argument existed
- focused regression test passed after the change
- complete `ios_plugin_package_test.dart`: 15 tests passed
- `cd packages/xcross && dart analyze`: no issues found
- `cd packages/xcross && dart test`: 227 tests passed
- changed files formatted with 0 changes
- `git diff --check`: passed
- independent code review: approved with no findings
