### PR TITLE
fix(flutter): canonicalize FlutterFramework package identity

### DIFF
--- a/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
@@ -355,8 +355,18 @@ abstract final class GeneratedPluginsPackage {
     required String flutterXcframework,
     bool? copyFlutterXcframework,
   }) async {
-    final frameworkDir = p.join(outputDir, _flutterFrameworkPackageName);
+    final packagesDir = p.join(outputDir, 'Packages');
+    final frameworkDir = p.join(packagesDir, _flutterFrameworkPackageName);
     final pluginsDir = p.join(outputDir, 'Plugins');
+
+    await Directory(packagesDir).create(recursive: true);
+
+    final pluginPackageDirs = <String, String>{};
+    for (final plugin in plugins) {
+      final packageAlias = p.join(packagesDir, plugin.name);
+      await _createDirectoryAlias(packageAlias, plugin.swiftPackageDir);
+      pluginPackageDirs[plugin.name] = packageAlias;
+    }
 
     await _writeFlutterFrameworkPackage(
       frameworkDir: frameworkDir,
@@ -367,6 +377,7 @@ abstract final class GeneratedPluginsPackage {
       pluginsDir: pluginsDir,
       frameworkDir: frameworkDir,
       plugins: plugins,
+      pluginPackageDirs: pluginPackageDirs,
     );
   }
 
@@ -397,13 +408,18 @@ abstract final class GeneratedPluginsPackage {
     required String pluginsDir,
     required String frameworkDir,
     required List<IosPlugin> plugins,
+    required Map<String, String> pluginPackageDirs,
   }) async {
     final sourcesDir = p.join(pluginsDir, 'Sources', _pluginsProductName);
     await Directory(sourcesDir).create(recursive: true);
 
-    await File(
-      p.join(pluginsDir, 'Package.swift'),
-    ).writeAsString(pluginsManifest(plugins, frameworkDir));
+    await File(p.join(pluginsDir, 'Package.swift')).writeAsString(
+      pluginsManifest(
+        plugins,
+        frameworkDir,
+        pluginPackageDirs: pluginPackageDirs,
+      ),
+    );
 
     await File(
       p.join(sourcesDir, 'GeneratedPluginRegistrant.swift'),
@@ -433,16 +449,22 @@ let package = Package(
   /// into one dynamic library product depending on [frameworkDir]'s
   /// `FlutterFramework` package plus every entry in [plugins].
   @visibleForTesting
-  static String pluginsManifest(List<IosPlugin> plugins, String frameworkDir) {
+  static String pluginsManifest(
+    List<IosPlugin> plugins,
+    String frameworkDir, {
+    Map<String, String>? pluginPackageDirs,
+  }) {
     final dependencies = StringBuffer()
       ..writeln(
         '        .package(name: "$_flutterFrameworkPackageName", '
         'path: "${_swiftPath(frameworkDir)}"),',
       );
     for (final plugin in plugins) {
+      final packageDir =
+          pluginPackageDirs?[plugin.name] ?? plugin.swiftPackageDir;
       dependencies.writeln(
         '        .package(name: "${plugin.name}", '
-        'path: "${_swiftPath(plugin.swiftPackageDir)}"),',
+        'path: "${_swiftPath(packageDir)}"),',
       );
     }
 
@@ -527,6 +549,32 @@ $registrations}
     } else if (type == FileSystemEntityType.file) {
       await File(path).delete();
     }
+  }
+
+  /// Makes the staged Swift package appear directly beside FlutterFramework,
+  /// so every plugin's conventional `../FlutterFramework` dependency resolves
+  /// to the same package path. Directory junctions avoid Windows symlink
+  /// privilege requirements.
+  static Future<void> _createDirectoryAlias(String alias, String target) async {
+    await _deleteEntity(alias);
+    if (Platform.isWindows) {
+      final result = await Process.run('cmd.exe', [
+        '/c',
+        'mklink',
+        '/J',
+        p.windows.normalize(alias),
+        p.windows.normalize(p.absolute(target)),
+      ]);
+      if (result.exitCode != 0) {
+        throw FileSystemException(
+          'Could not create plugin package junction: ${result.stderr}',
+          alias,
+        );
+      }
+      return;
+    }
+
+    await Link(alias).create(p.relative(target, from: p.dirname(alias)));
   }
 
   static Future<void> _copyDirectory(String source, String destination) async {

--- a/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
+++ b/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
@@ -9,6 +9,8 @@ import 'package:xcross/src/flutter/build/ios_plugins.dart';
 import 'package:xcross/src/flutter/constants.dart';
 import 'package:xcross/src/flutter/errors.dart';
 
+String swiftPath(String path) => p.absolute(path).replaceAll(r'\', '/');
+
 void main() {
   late Directory tmp;
 
@@ -21,12 +23,16 @@ void main() {
   /// Creates a fake plugin pub package with an `ios/<name>/Package.swift` and
   /// a `pubspec.yaml` whose `pluginClass` is [pluginClass] (or omitted when
   /// null).
-  IosPlugin makePlugin(String name, {String? pluginClass}) {
+  IosPlugin makePlugin(
+    String name, {
+    String? pluginClass,
+    String packageManifest = '',
+  }) {
     final packageRoot = p.join(tmp.path, name);
     Directory(p.join(packageRoot, 'ios', name)).createSync(recursive: true);
     File(
       p.join(packageRoot, 'ios', name, 'Package.swift'),
-    ).writeAsStringSync('');
+    ).writeAsStringSync(packageManifest);
 
     final pluginSection = pluginClass == null
         ? ''
@@ -166,7 +172,65 @@ let package = Package(
 
   group('writeGeneratedPackages', () {
     test(
-      'writes FlutterFramework/Plugins packages and the xcframework symlink',
+      'stages plugin packages beside one FlutterFramework package',
+      () async {
+        const pluginManifest = '''
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "plugin_a",
+    dependencies: [
+        .package(name: "FlutterFramework", path: "../FlutterFramework")
+    ],
+    targets: [
+        .target(
+            name: "plugin_a",
+            dependencies: [
+                .product(name: "FlutterFramework", package: "FlutterFramework")
+            ]
+        )
+    ]
+)
+''';
+        final pluginA = makePlugin('plugin_a', packageManifest: pluginManifest);
+        final flutterXcframework = p.join(tmp.path, 'Flutter.xcframework');
+        Directory(flutterXcframework).createSync(recursive: true);
+        final outputDir = p.join(tmp.path, 'out');
+
+        await GeneratedPluginsPackage.writeGeneratedPackages(
+          outputDir: outputDir,
+          plugins: [pluginA],
+          flutterXcframework: flutterXcframework,
+          copyFlutterXcframework: true,
+        );
+
+        final packagesDir = p.join(outputDir, 'Packages');
+        final stagedPluginDir = p.join(packagesDir, 'plugin_a');
+        final stagedFrameworkDir = p.join(packagesDir, 'FlutterFramework');
+        expect(
+          File(p.join(stagedPluginDir, 'Package.swift')).readAsStringSync(),
+          pluginManifest,
+        );
+        expect(
+          p.normalize(p.join(stagedPluginDir, '..', 'FlutterFramework')),
+          p.normalize(stagedFrameworkDir),
+        );
+
+        final aggregateManifest = File(
+          p.join(outputDir, 'Plugins', 'Package.swift'),
+        ).readAsStringSync();
+        expect(aggregateManifest, contains(swiftPath(stagedPluginDir)));
+        expect(aggregateManifest, contains(swiftPath(stagedFrameworkDir)));
+        expect(
+          aggregateManifest,
+          isNot(contains(swiftPath(pluginA.swiftPackageDir))),
+        );
+      },
+    );
+
+    test(
+      'writes shared packages and the Flutter xcframework symlink',
       () async {
         final pluginA = makePlugin('plugin_a', pluginClass: 'PluginA');
         final flutterXcframework = p.join(tmp.path, 'Flutter.xcframework');
@@ -174,6 +238,7 @@ let package = Package(
         final outputDir = p.join(tmp.path, 'out');
         final frameworkPath = p.join(
           outputDir,
+          'Packages',
           'FlutterFramework',
           'Flutter.xcframework',
         );
@@ -195,7 +260,7 @@ let package = Package(
         }
 
         final frameworkManifest = File(
-          p.join(outputDir, 'FlutterFramework', 'Package.swift'),
+          p.join(outputDir, 'Packages', 'FlutterFramework', 'Package.swift'),
         );
         expect(frameworkManifest.existsSync(), isTrue);
         expect(
@@ -246,6 +311,7 @@ let package = Package(
       final outputDir = p.join(tmp.path, 'out');
       final copiedFramework = p.join(
         outputDir,
+        'Packages',
         'FlutterFramework',
         'Flutter.xcframework',
       );
@@ -268,7 +334,7 @@ let package = Package(
       );
       expect(
         File(
-          p.join(outputDir, 'FlutterFramework', 'Package.swift'),
+          p.join(outputDir, 'Packages', 'FlutterFramework', 'Package.swift'),
         ).readAsStringSync(),
         GeneratedPluginsPackage.flutterFrameworkManifest(),
       );


### PR DESCRIPTION
## Summary

- stage every iOS plugin Swift package through a shared generated `Packages` directory
- place the canonical `FlutterFramework` wrapper in that same directory so plugin-local `../FlutterFramework` dependencies resolve to one path
- use directory junctions on Windows to avoid symlink privilege requirements

## Root cause

The generated aggregate package depended directly on each plugin's original Swift package path while also depending on xcross's generated `FlutterFramework` package. Plugins that declare `.package(name: "FlutterFramework", path: "../FlutterFramework")` therefore introduced additional paths with the same SwiftPM package identity. SwiftPM warns today and plans to make this an error.

## Validation

- `dart analyze`
- `dart test packages/xcross`
- `dart test test/flutter/build/ios_plugin_package_test.dart`
- `dart format --output=none --set-exit-if-changed packages/xcross/lib/src/flutter/build/ios_plugin_package.dart packages/xcross/test/flutter/build/ios_plugin_package_test.dart`
- `git diff --check`
  The generated aggregate manifest routed all 13 plugin packages through `build/xcross-flutter-plugins/Packages`, and the build emitted 0 `Conflicting identity for flutterframework` warnings. It then advanced to native compilation and stopped on a separate Darwin SDK/sysroot issue where `UIKit/UIKit.h` was unavailable.
