### PR TITLE
fix(flutter): pin iOS SDK for SwiftPM plugins

### DIFF
--- a/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
@@ -207,6 +207,16 @@ abstract final class GeneratedPluginsPackage {
     '-Xfrontend',
     '-Xswiftc',
     '-disable-availability-checking',
+    // Swift uses clang as its link driver. Pin that driver too, otherwise a
+    // macOS host reselects MacOSX.sdk while linking iOS plugin products.
+    '-Xswiftc',
+    '-Xclang-linker',
+    '-Xswiftc',
+    '-isysroot',
+    '-Xswiftc',
+    '-Xclang-linker',
+    '-Xswiftc',
+    iosSdk,
     // The link runs through the toolchain's own clang, which resolves
     // `-use-ld=lld` to the `ld64.lld` sitting next to itself — swiftly's, the
     // one that refuses iOS (see [resolveLd64Lld]). `--ld-path` overrides that

--- a/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
@@ -144,6 +144,7 @@ abstract final class GeneratedPluginsPackage {
         pluginsDir: pluginsDir,
         scratchPath: scratchPath,
         swiftSdksPath: p.dirname(sdk.swiftSdkPath),
+        iosSdk: sdk.iPhoneOSSdk(),
         flutterFrameworkSlice: flutterFrameworkSlice,
         toolsetPath: toolsetPath,
         // Windows gets the same override from the toolset's `linker`.
@@ -161,6 +162,7 @@ abstract final class GeneratedPluginsPackage {
     required String pluginsDir,
     required String scratchPath,
     required String swiftSdksPath,
+    required String iosSdk,
     required String flutterFrameworkSlice,
     String? toolsetPath,
     String? linkerPath,
@@ -185,6 +187,18 @@ abstract final class GeneratedPluginsPackage {
     if (toolsetPath != null) ...['--toolset', toolsetPath],
     '--scratch-path',
     scratchPath,
+    // On macOS, SwiftPM's host toolchain can override the Swift SDK bundle's
+    // sdkRootPath with the host MacOSX SDK. Pin the installed iPhoneOS SDK for
+    // Swift imports and every C/Objective-C target so UIKit and Foundation are
+    // resolved from the target platform on every host.
+    '-Xswiftc',
+    '-sdk',
+    '-Xswiftc',
+    iosSdk,
+    '-Xcc',
+    '-isysroot',
+    '-Xcc',
+    iosSdk,
     '-Xswiftc',
     '-F',
     '-Xswiftc',

--- a/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
+++ b/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
@@ -458,6 +458,19 @@ let package = Package(
         arguments,
         containsAllInOrder([
           '-Xswiftc',
+          '-Xclang-linker',
+          '-Xswiftc',
+          '-isysroot',
+          '-Xswiftc',
+          '-Xclang-linker',
+          '-Xswiftc',
+          'iPhoneOS.sdk',
+        ]),
+      );
+      expect(
+        arguments,
+        containsAllInOrder([
+          '-Xswiftc',
           '-F',
           '-Xswiftc',
           'Flutter.xcframework/ios-arm64',

--- a/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
+++ b/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
@@ -409,6 +409,7 @@ let package = Package(
         pluginsDir: 'plugins',
         scratchPath: 'scratch',
         swiftSdksPath: 'xcross-swift-sdks',
+        iosSdk: 'iPhoneOS.sdk',
         flutterFrameworkSlice: 'Flutter.xcframework/ios-arm64',
         toolsetPath: 'toolset.json',
         linkerPath: '/usr/bin/ld64.lld',
@@ -444,6 +445,14 @@ let package = Package(
           '--scratch-path',
           'scratch',
         ]),
+      );
+      expect(
+        arguments,
+        containsAllInOrder(['-Xswiftc', '-sdk', '-Xswiftc', 'iPhoneOS.sdk']),
+      );
+      expect(
+        arguments,
+        containsAllInOrder(['-Xcc', '-isysroot', '-Xcc', 'iPhoneOS.sdk']),
       );
       expect(
         arguments,


### PR DESCRIPTION
## Summary

- pass the installed iPhoneOS SDK explicitly to Swift compilation and Clang/Objective-C compilation during SwiftPM plugin builds
- forward the same SDK through the Swift clang-linker driver so link steps do not fall back to the host macOS SDK
- add regression coverage for all three argument sequences

## Root cause

The Swift SDK bundle selects the iOS target, but SwiftPM subprocesses can still inherit the host Command Line Tools macOS sysroot. Objective-C plugins then fail to find `UIKit/UIKit.h`, Swift Foundation overlays can lose `URL`/`Data`, and link invocations warn that they are using a MacOSX sysroot while targeting iPhone.

## Validation

- `dart format --output=none --set-exit-if-changed ...` passed
- `dart analyze` passed with no issues
- focused iOS plugin package tests passed, 15/15
- full `packages/xcross` test suite passed
- `git diff --check origin/main...HEAD` passed
- the supplied real-project command now reports zero `UIKit/UIKit.h` failures, zero MacOSX sysroot warnings, zero missing `URL`/`Data` errors, and zero FlutterFramework identity conflicts

The real project now reaches a separate `flutter_soloud` linker incompatibility: `unknown argument: '-Wl,-undefined,dynamic_lookup'`. That plugin-specific issue is intentionally outside this PR.
