### PR TITLE
fix(xcross): App Groups support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,16 +25,22 @@
   App Groups are reached over the pre-JSON `QH65B2` protocol Xcode itself
   uses, because they have no modern API at all: Apple's App Store Connect
   OpenAPI specification declares 966 paths and none mentions App Groups.
-- **App Groups require an Apple ID session.** An App Store Connect API key
-  cannot provision them, and xcross now says so in one clear sentence instead
-  of failing obscurely. Verified against a live key: `/v1/appGroups` 404s, the
-  `APP_GROUPS` capability can be enabled but not pointed at a group
-  (`settings[].key` accepts only `ICLOUD_VERSION`,
-  `DATA_PROTECTION_PERMISSION_LEVEL`, `APPLE_ID_AUTH_APP_CONSENT`), the
-  resulting profile grants an empty `application-groups` array, and signing a
-  real group against it is refused by iOS with `0xe8008015`.
-  developerservices2 does expose App Groups but rejects API keys under every
-  JWT audience tried. Everything else about an API key build is unaffected.
+- Take the App Group from the **issued provisioning profile** rather than
+  assuming the request succeeded. Only the profile decides what iOS accepts,
+  so this both avoids promising a container that does not exist and picks up a
+  group attached by any other means. Signing with an ungranted group is what
+  makes iOS refuse an install with `0xe8008015`.
+- **App Groups with an App Store Connect API key.** Apple exposes no App
+  Groups API to keys, so xcross cannot create the group, but it can now use
+  one you attached yourself: add the group to your App IDs in Xcode or at
+  developer.apple.com and pass `XCROSS_APP_GROUP=group.your.id`, which skips
+  the per-account rewrite. Verified against a live key that no route exists to
+  create one: `/v1/appGroups` 404s, the `APP_GROUPS` capability enables but
+  cannot name a group (`settings[].key` accepts only `ICLOUD_VERSION`,
+  `DATA_PROTECTION_PERMISSION_LEVEL`, `APPLE_ID_AUTH_APP_CONSENT`, on POST and
+  PATCH alike), a `group.` identifier registers as an App ID but cannot be
+  linked, and the developerservices2/portal hosts that do expose App Groups
+  reject API keys under every audience tried.
 - Warnings that describe an account-wide condition are printed once per run
   rather than once per App ID (an app with two extensions provisions three).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,14 +22,21 @@
   developer.apple.com. Without the shared container a share extension can
   hand nothing back to the app, which is the whole point of
   `receive_sharing_intent`. (#23)
-- This works with **both** credential types. App Groups have no modern API at
-  all (Apple's App Store Connect OpenAPI spec declares 966 paths and none
-  mentions them; `CapabilitySetting.key` has no `APP_GROUP_IDENTIFIERS`), so
-  xcross reaches them over the pre-JSON `QH65B2` protocol Xcode itself uses.
-  That protocol authenticates with an Apple ID session *or* an ordinary
-  `Authorization: Bearer` App Store Connect API key JWT, and returns the same
-  resource ids the JSON:API does. An API key carries no team id, so xcross
-  reads one from a bundle id's `seedId` and caches it.
+  App Groups are reached over the pre-JSON `QH65B2` protocol Xcode itself
+  uses, because they have no modern API at all: Apple's App Store Connect
+  OpenAPI specification declares 966 paths and none mentions App Groups.
+- **App Groups require an Apple ID session.** An App Store Connect API key
+  cannot provision them, and xcross now says so in one clear sentence instead
+  of failing obscurely. Verified against a live key: `/v1/appGroups` 404s, the
+  `APP_GROUPS` capability can be enabled but not pointed at a group
+  (`settings[].key` accepts only `ICLOUD_VERSION`,
+  `DATA_PROTECTION_PERMISSION_LEVEL`, `APPLE_ID_AUTH_APP_CONSENT`), the
+  resulting profile grants an empty `application-groups` array, and signing a
+  real group against it is refused by iOS with `0xe8008015`.
+  developerservices2 does expose App Groups but rejects API keys under every
+  JWT audience tried. Everything else about an API key build is unaffected.
+- Warnings that describe an account-wide condition are printed once per run
+  rather than once per App ID (an app with two extensions provisions three).
 
 ## 1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,17 @@
   account (`group.XCR-<TEAM>.…`) because App Group ids are globally unique,
   and enable the App Groups capability on every App ID automatically, so the
   app and its extensions share a container with no manual step on
-  developer.apple.com. App Groups are reached over the pre-JSON `QH65B2`
-  protocol Xcode itself uses: the JSON:API surface refuses capability changes
-  with `403 The API key in use does not allow this request`, and App Store
-  Connect exposes no App Groups resource at all. Without the shared container
-  a share extension can hand nothing back to the app, which is the whole
-  point of `receive_sharing_intent`. (#23)
+  developer.apple.com. Without the shared container a share extension can
+  hand nothing back to the app, which is the whole point of
+  `receive_sharing_intent`. (#23)
+- This works with **both** credential types. App Groups have no modern API at
+  all (Apple's App Store Connect OpenAPI spec declares 966 paths and none
+  mentions them; `CapabilitySetting.key` has no `APP_GROUP_IDENTIFIERS`), so
+  xcross reaches them over the pre-JSON `QH65B2` protocol Xcode itself uses.
+  That protocol authenticates with an Apple ID session *or* an ordinary
+  `Authorization: Bearer` App Store Connect API key JWT, and returns the same
+  resource ids the JSON:API does. An API key carries no team id, so xcross
+  reads one from a bundle id's `seedId` and caches it.
 
 ## 1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,15 @@
   their version string. Embedded extensions inherit the app's versions, which
   iOS requires them to match.
 - Register App Groups declared by an app or its extensions, qualified per
-  account (`group.XCR-<TEAM>.…`) because App Group ids are globally unique.
-  Enabling the capability on the App IDs is still a manual step on
-  developer.apple.com; xcross reuses an existing group, so the next run picks
-  it up.
+  account (`group.XCR-<TEAM>.…`) because App Group ids are globally unique,
+  and enable the App Groups capability on every App ID automatically, so the
+  app and its extensions share a container with no manual step on
+  developer.apple.com. App Groups are reached over the pre-JSON `QH65B2`
+  protocol Xcode itself uses: the JSON:API surface refuses capability changes
+  with `403 The API key in use does not allow this request`, and App Store
+  Connect exposes no App Groups resource at all. Without the shared container
+  a share extension can hand nothing back to the app, which is the whole
+  point of `receive_sharing_intent`. (#23)
 
 ## 1.1.1
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,20 @@ Use `xcross update --to <tag>` to pin a specific release, and `--force` to reins
 
 xcross talks to Apple's Developer Services directly. Two options:
 
+|  | Apple ID | App Store Connect API key |
+| --- | --- | --- |
+| Apple account needed | free account works | paid Developer Program |
+| Interactive login | password + 2FA once | none, good for CI |
+| Protocol | the one Xcode speaks, undocumented | official and documented |
+| Build, sign, install, run | yes | yes |
+| **App Groups** (share extensions) | **created and attached automatically** | cannot be created; use one you attached yourself, see [app extensions](docs/app-extensions.md#app-store-connect-api-keys) |
+
+The App Groups row is the only functional difference, and it is Apple's doing
+rather than xcross's: the public App Store Connect API has no App Groups
+resource at all, while the older protocol Xcode itself uses does. It only
+matters if your app ships a share or action extension that hands data back to
+the app.
+
 ### Apple ID (free account works)
 
 ```sh
@@ -165,6 +179,17 @@ Machine attestation uses Android ADI libraries (`libCoreADI.so`, `libstoreservic
 ```sh
 xcross auth --issuer-id <uuid> --key-id <id> --private-key /path/to/AuthKey.p8
 ```
+
+Non-interactive, so this is the one to use on CI. It provisions everything
+except App Groups, which Apple's public API cannot manage at all. If your app
+has a share extension, attach the group to your App IDs once (in Xcode or at
+developer.apple.com) and point xcross at it:
+
+```sh
+XCROSS_APP_GROUP=group.com.example.Shared xcross flutter run
+```
+
+See [iOS app extensions](docs/app-extensions.md) for the details.
 
 ### Sign out
 
@@ -285,7 +310,7 @@ Plugins that only ship a CocoaPods podspec are currently **skipped with a warnin
 
 Share and action extensions are built, embedded under `PlugIns/`, signed with their own provisioning profiles and installed alongside the app, so plugins like [receive_sharing_intent](https://github.com/KasemJaffer/receive_sharing_intent) put your app in the iOS share sheet. No configuration needed.
 
-Sharing data back to the app needs an App Group, which requires one manual step. See **[docs/app-extensions.md](docs/app-extensions.md)**.
+Sharing data back to the app needs an App Group. Signed in with an Apple ID, xcross registers and attaches it for you. With an App Store Connect API key, Apple's public API cannot manage App Groups at all, so attach one yourself and pass `XCROSS_APP_GROUP`. See **[docs/app-extensions.md](docs/app-extensions.md)**.
 
 ## Bundle identity
 
@@ -350,6 +375,16 @@ Yes. Use `xcross compose setup`, then `xcross compose build` or `xcross compose 
 <summary><b>Is my Apple password stored anywhere?</b></summary>
 
 No. `xcross auth` performs the login handshake locally and persists only the resulting Developer Services session token.
+</details>
+
+<details>
+<summary><b>Why does an App Store Connect API key have fewer capabilities than an Apple ID?</b></summary>
+
+Only for App Groups, and the cause is Apple's. The public App Store Connect API has no App Groups resource at all: its OpenAPI specification declares 966 paths and none of them mentions one, so a key cannot create a group or attach it to an App ID. The older protocol Xcode itself speaks does expose them, and that is what an Apple ID session uses.
+
+So the documented, officially supported credential is the less capable one here, and the undocumented path is the complete one, with the stability caveat that implies.
+
+It only matters if your app ships a share or action extension. A key still issues profiles that carry a group attached by other means, so attach one once in Xcode or at developer.apple.com and pass `XCROSS_APP_GROUP=group.your.id`. Everything else works identically. See [docs/app-extensions.md](docs/app-extensions.md).
 </details>
 
 <details>

--- a/docs/app-extensions.md
+++ b/docs/app-extensions.md
@@ -56,13 +56,19 @@ Extension versions are forced to match the host app's, which iOS requires.
 An extension runs in its own sandbox. To hand data back to the app (the file
 you shared, for example) both sides must belong to the same **App Group**.
 
-xcross does this for you. It registers the group, enables the App Groups
-capability on the app's App ID and on every extension's, links the group to
-each, and issues profiles carrying the resulting
+xcross does this for you when you sign in with an **Apple ID**
+(`xcross auth --apple-id <email>`). It registers the group, enables the App
+Groups capability on the app's App ID and on every extension's, links the
+group to each, and issues profiles carrying the resulting
 `com.apple.security.application-groups` entitlement. Nothing to configure and
 nothing to click on developer.apple.com.
 
-You can confirm it landed:
+> **App Store Connect API keys cannot provision App Groups.** This is a limit
+> of Apple's APIs, not of xcross; see below. The app and its extensions still
+> build, install and run, but they cannot share data, so the share sheet
+> hand-off will not work. xcross says so once during the run.
+
+You can confirm the entitlement landed:
 
 ```sh
 xcross flutter build ios
@@ -85,18 +91,33 @@ Plugins read the group name at runtime from the `AppGroupId` key in
 `Info.plist`, so xcross rewrites that key in the app and in every `.appex` to
 match. No source changes are needed.
 
+### Why an API key cannot do this
+
+App Groups are the one provisioning resource with no modern API. Every route
+was checked against a live key:
+
+| Route | Result |
+| --- | --- |
+| `GET /v1/appGroups` (and `/v1/applicationGroups`) | `404` — no such resource. Apple's own OpenAPI spec declares 966 paths and none mentions App Groups |
+| `POST /v1/bundleIdCapabilities` `APP_GROUPS` | `201` — the capability turns on, but nothing can be linked to it |
+| … with `settings[].key = APP_GROUP_IDENTIFIERS` | `409` — only `ICLOUD_VERSION`, `DATA_PROTECTION_PERMISSION_LEVEL`, `APPLE_ID_AUTH_APP_CONSENT` are accepted |
+| Profile issued with the capability on | grants `com.apple.security.application-groups: []`, an empty array |
+| Signing a real group against that profile | installd refuses: `0xe8008015 (A valid provisioning profile for this executable was not found)` |
+| developerservices2 `QH65B2` (which *does* expose App Groups) | `403` for API keys under every JWT audience tried |
+
+The last row is the one that would otherwise look promising: that host's 403
+quotes the same "Make sure a bearer token was provided, it is properly
+configured and signed" wording `api.appstoreconnect.apple.com` uses, but a key
+that works on the latter is still rejected by the former. The shared wording is
+coincidental.
+
+So the Apple ID session is not a preference, it is the only credential that can
+provision an App Group. Everything else about an API key build is unaffected.
+
 ### Which API this uses
 
-App Groups are the one provisioning resource with no modern representation.
-Apple's own App Store Connect OpenAPI specification declares 966 paths and
-none of them mentions App Groups, and `CapabilitySetting.key` has no
-`APP_GROUP_IDENTIFIERS` member, so even the `APP_GROUPS` capability cannot be
-pointed at a particular group there. The JSON:API surface of
-developerservices2 refuses capability changes outright with `403 The API key
-in use does not allow this request`.
-
-The only surface that can create a group and attach it to an App ID is the
-pre-JSON `QH65B2` plist protocol Xcode itself speaks:
+With an Apple ID session, App Groups go over the pre-JSON `QH65B2` plist
+protocol Xcode itself speaks:
 
 ```
 ios/listApplicationGroups.action
@@ -105,18 +126,8 @@ ios/updateAppId.action                    (feature key APG3427HIY)
 ios/assignApplicationGroupToAppId.action
 ```
 
-**Both credential types work.** That protocol accepts an Apple ID GrandSlam
-session *and* an ordinary `Authorization: Bearer <JWT>` signed with an App
-Store Connect API key: an unknown key is refused there with the identical
-"Make sure a bearer token was provided, it is properly configured and signed"
-text `api.appstoreconnect.apple.com` returns, i.e. one key validator backs
-both hosts. Resource ids are the same across the two APIs, so xcross mixes
-them freely.
-
-An API key carries no team id of its own, so xcross reads one from a bundle
-id's `seedId` (there is no `/teams` endpoint on App Store Connect) and caches
-it. A brand-new team with no registered identifiers therefore cannot resolve
-a team id yet; register one app, or use an Apple ID session.
+Resource ids are shared with the JSON:API, so xcross mixes the two: App IDs and
+profiles come from the modern endpoints, App Groups from these.
 
 ## Storyboards and asset catalogs
 
@@ -155,9 +166,9 @@ sets one from the target name, so this should not occur; please report it.
 **The extension appears but the app never receives the shared file.**
 The two are not in the same App Group. Check that the app binary and the
 `.appex` both carry `com.apple.security.application-groups` with the same
-value (see above). If they do not, xcross will have printed why on the run
-that signed them: usually rejected credentials (an expired Apple ID session
-or a revoked API key) or an identifier quota.
+value (see above). The usual cause is signing with an App Store Connect API
+key, which cannot provision App Groups at all: sign in with
+`xcross auth --apple-id <email>` and re-run.
 
 **`Could not provision the app extension …`.**
 Usually the free-account App ID quota (10 per 7 days). Either wait, or delete

--- a/docs/app-extensions.md
+++ b/docs/app-extensions.md
@@ -87,19 +87,36 @@ match. No source changes are needed.
 
 ### Which API this uses
 
-App Groups are only reachable over the pre-JSON `QH65B2` plist protocol that
-Xcode itself speaks (`ios/listApplicationGroups.action`,
-`ios/addApplicationGroup.action`, `ios/updateAppId.action`,
-`ios/assignApplicationGroupToAppId.action`). The JSON:API surface of
-developerservices2 answers `403 The API key in use does not allow this
-request` for capability changes, and App Store Connect API keys have no App
-Groups resource at all. Both protocols return the same resource ids, so
-xcross mixes them.
+App Groups are the one provisioning resource with no modern representation.
+Apple's own App Store Connect OpenAPI specification declares 966 paths and
+none of them mentions App Groups, and `CapabilitySetting.key` has no
+`APP_GROUP_IDENTIFIERS` member, so even the `APP_GROUPS` capability cannot be
+pointed at a particular group there. The JSON:API surface of
+developerservices2 refuses capability changes outright with `403 The API key
+in use does not allow this request`.
 
-This means App Groups need an **Apple ID session**
-(`xcross auth --apple-id <email>`). With an App Store Connect API key the app
-and its extensions still build, install and run, but the shared container is
-missing and xcross says so.
+The only surface that can create a group and attach it to an App ID is the
+pre-JSON `QH65B2` plist protocol Xcode itself speaks:
+
+```
+ios/listApplicationGroups.action
+ios/addApplicationGroup.action
+ios/updateAppId.action                    (feature key APG3427HIY)
+ios/assignApplicationGroupToAppId.action
+```
+
+**Both credential types work.** That protocol accepts an Apple ID GrandSlam
+session *and* an ordinary `Authorization: Bearer <JWT>` signed with an App
+Store Connect API key: an unknown key is refused there with the identical
+"Make sure a bearer token was provided, it is properly configured and signed"
+text `api.appstoreconnect.apple.com` returns, i.e. one key validator backs
+both hosts. Resource ids are the same across the two APIs, so xcross mixes
+them freely.
+
+An API key carries no team id of its own, so xcross reads one from a bundle
+id's `seedId` (there is no `/teams` endpoint on App Store Connect) and caches
+it. A brand-new team with no registered identifiers therefore cannot resolve
+a team id yet; register one app, or use an Apple ID session.
 
 ## Storyboards and asset catalogs
 
@@ -138,9 +155,9 @@ sets one from the target name, so this should not occur; please report it.
 **The extension appears but the app never receives the shared file.**
 The two are not in the same App Group. Check that the app binary and the
 `.appex` both carry `com.apple.security.application-groups` with the same
-value (see above). If they do not, you are most likely signing with an App
-Store Connect API key: sign in with `xcross auth --apple-id <email>` instead
-and re-run.
+value (see above). If they do not, xcross will have printed why on the run
+that signed them: usually rejected credentials (an expired Apple ID session
+or a revoked API key) or an identifier quota.
 
 **`Could not provision the app extension …`.**
 Usually the free-account App ID quota (10 per 7 days). Either wait, or delete

--- a/docs/app-extensions.md
+++ b/docs/app-extensions.md
@@ -76,6 +76,29 @@ strings "build/xcross-ios/<app>.app/PlugIns/<Name>.appex/<Name>" \
   | grep application-groups
 ```
 
+### The profile decides, not the request
+
+xcross signs with the App Group the **issued provisioning profile grants**,
+not the one it asked Apple for. Those differ more often than you would expect:
+a request can fail, a capability can be enabled without any group attached, or
+a group can already be there under a name xcross never chose.
+
+This matters because iOS enforces the profile. Signing an app with a group the
+profile does not grant makes `installd` refuse the install outright:
+
+```
+0xe8008015 (A valid provisioning profile for this executable was not found.)
+```
+
+So when nothing is granted, xcross leaves the entitlement out, says so once,
+and the app still installs and runs without a shared container. And when a
+group *is* granted, it is used verbatim, including the runtime `AppGroupId`
+key, which is what makes the API key workflow below possible at all.
+
+Each extension has its own profile, so xcross also checks every `.appex`
+against the app's group and warns if one is missing. Otherwise the mismatch
+would only show up as a share that silently does nothing.
+
 ### Why the group name is rewritten
 
 App Group identifiers are globally unique across **all** Apple developers, so a
@@ -141,6 +164,12 @@ ios/assignApplicationGroupToAppId.action
 
 Resource ids are shared with the JSON:API, so xcross mixes the two: App IDs and
 profiles come from the modern endpoints, App Groups from these.
+
+There is an irony worth stating plainly. The **official** App Store Connect
+API cannot manage App Groups, while the **undocumented** protocol Xcode itself
+speaks can. That is why signing in with an Apple ID gives you more capability
+than a paid API key here, and also why that path carries no stability
+guarantee: Apple can change it whenever they like.
 
 ## Storyboards and asset catalogs
 

--- a/docs/app-extensions.md
+++ b/docs/app-extensions.md
@@ -56,38 +56,19 @@ Extension versions are forced to match the host app's, which iOS requires.
 An extension runs in its own sandbox. To hand data back to the app (the file
 you shared, for example) both sides must belong to the same **App Group**.
 
-xcross registers the App Group automatically but **cannot enable the App Groups
-capability on the App IDs**: Apple's developer-session API refuses capability
-changes with `403 The API key in use does not allow this request`, on free and
-paid teams alike. You will see:
+xcross does this for you. It registers the group, enables the App Groups
+capability on the app's App ID and on every extension's, links the group to
+each, and issues profiles carrying the resulting
+`com.apple.security.application-groups` entitlement. Nothing to configure and
+nothing to click on developer.apple.com.
 
+You can confirm it landed:
+
+```sh
+xcross flutter build ios
+strings "build/xcross-ios/<app>.app/PlugIns/<Name>.appex/<Name>" \
+  | grep application-groups
 ```
-› App Groups (group.XCR-TEAMID.com.example.Shared) could not be enabled
-  automatically: Apple's developer session API refuses capability changes.
-  Add the group to the App IDs at developer.apple.com and re-run to share
-  data between the app and its extensions.
-```
-
-The app and its extensions still build, install and run. Only the shared
-container is missing.
-
-### Enabling it by hand (once per project)
-
-1. Run `xcross flutter run` once. This registers the App IDs and the App Group,
-   and prints the exact names.
-2. Go to [developer.apple.com](https://developer.apple.com/account/resources/identifiers/list)
-   → **Certificates, IDs & Profiles** → **Identifiers**.
-3. For the app **and every extension** (`XCR-<TEAM>.com.example.app`,
-   `XCR-<TEAM>.com.example.app.Share-Extension`, …):
-   * open the identifier,
-   * tick **App Groups**, click **Edit**, and select the
-     `group.XCR-<TEAM>.…` group xcross created,
-   * save.
-4. Run `xcross flutter run` again.
-
-xcross looks an App Group up before creating it, so the second run reuses your
-change and issues profiles carrying the entitlement. From then on the full
-share flow works.
 
 ### Why the group name is rewritten
 
@@ -104,7 +85,21 @@ Plugins read the group name at runtime from the `AppGroupId` key in
 `Info.plist`, so xcross rewrites that key in the app and in every `.appex` to
 match. No source changes are needed.
 
----
+### Which API this uses
+
+App Groups are only reachable over the pre-JSON `QH65B2` plist protocol that
+Xcode itself speaks (`ios/listApplicationGroups.action`,
+`ios/addApplicationGroup.action`, `ios/updateAppId.action`,
+`ios/assignApplicationGroupToAppId.action`). The JSON:API surface of
+developerservices2 answers `403 The API key in use does not allow this
+request` for capability changes, and App Store Connect API keys have no App
+Groups resource at all. Both protocols return the same resource ids, so
+xcross mixes them.
+
+This means App Groups need an **Apple ID session**
+(`xcross auth --apple-id <email>`). With an App Store Connect API key the app
+and its extensions still build, install and run, but the shared container is
+missing and xcross says so.
 
 ## Storyboards and asset catalogs
 
@@ -141,7 +136,11 @@ The extension's `Info.plist` needs a non-empty `CFBundleDisplayName`. xcross
 sets one from the target name, so this should not occur; please report it.
 
 **The extension appears but the app never receives the shared file.**
-This is the App Groups step above.
+The two are not in the same App Group. Check that the app binary and the
+`.appex` both carry `com.apple.security.application-groups` with the same
+value (see above). If they do not, you are most likely signing with an App
+Store Connect API key: sign in with `xcross auth --apple-id <email>` instead
+and re-run.
 
 **`Could not provision the app extension …`.**
 Usually the free-account App ID quota (10 per 7 days). Either wait, or delete

--- a/docs/app-extensions.md
+++ b/docs/app-extensions.md
@@ -63,10 +63,10 @@ group to each, and issues profiles carrying the resulting
 `com.apple.security.application-groups` entitlement. Nothing to configure and
 nothing to click on developer.apple.com.
 
-> **App Store Connect API keys cannot provision App Groups.** This is a limit
-> of Apple's APIs, not of xcross; see below. The app and its extensions still
-> build, install and run, but they cannot share data, so the share sheet
-> hand-off will not work. xcross says so once during the run.
+> **With an App Store Connect API key** Apple exposes no App Groups API, so
+> xcross cannot create the group for you. You can still use one you added
+> yourself: see [App Store Connect API keys](#app-store-connect-api-keys)
+> below.
 
 You can confirm the entitlement landed:
 
@@ -91,28 +91,41 @@ Plugins read the group name at runtime from the `AppGroupId` key in
 `Info.plist`, so xcross rewrites that key in the app and in every `.appex` to
 match. No source changes are needed.
 
-### Why an API key cannot do this
+### App Store Connect API keys
 
-App Groups are the one provisioning resource with no modern API. Every route
-was checked against a live key:
+An API key cannot *create* an App Group or attach one to an App ID. Every
+route was checked against a live key:
 
 | Route | Result |
 | --- | --- |
-| `GET /v1/appGroups` (and `/v1/applicationGroups`) | `404` — no such resource. Apple's own OpenAPI spec declares 966 paths and none mentions App Groups |
+| `GET /v1/appGroups`, `/v1/applicationGroups` | `404` — no such resource. Apple's own OpenAPI spec declares 966 paths and none mentions App Groups |
 | `POST /v1/bundleIdCapabilities` `APP_GROUPS` | `201` — the capability turns on, but nothing can be linked to it |
-| … with `settings[].key = APP_GROUP_IDENTIFIERS` | `409` — only `ICLOUD_VERSION`, `DATA_PROTECTION_PERMISSION_LEVEL`, `APPLE_ID_AUTH_APP_CONSENT` are accepted |
-| Profile issued with the capability on | grants `com.apple.security.application-groups: []`, an empty array |
-| Signing a real group against that profile | installd refuses: `0xe8008015 (A valid provisioning profile for this executable was not found)` |
-| developerservices2 `QH65B2` (which *does* expose App Groups) | `403` for API keys under every JWT audience tried |
+| … with `settings[].key = APP_GROUP_IDENTIFIERS` (POST and PATCH) | `409` — only `ICLOUD_VERSION`, `DATA_PROTECTION_PERMISSION_LEVEL`, `APPLE_ID_AUTH_APP_CONSENT` are accepted |
+| `POST /v1/bundleIds` with a `group.` identifier | `201` — but it is an App ID, and no relationship links it as a group |
+| Profile issued with the capability on, no group | grants `com.apple.security.application-groups: []` |
+| Signing a real group against that profile | installd refuses: `0xe8008015` |
+| developerservices2 / portal hosts (which *do* expose App Groups) | `403`/`401` for API keys under every audience and header set tried |
 
-The last row is the one that would otherwise look promising: that host's 403
-quotes the same "Make sure a bearer token was provided, it is properly
-configured and signed" wording `api.appstoreconnect.apple.com` uses, but a key
-that works on the latter is still rejected by the former. The shared wording is
-coincidental.
+**But you can still use one.** xcross reads the group out of the issued
+profile rather than assuming, so a group attached to your App IDs by any other
+means flows straight through:
 
-So the Apple ID session is not a preference, it is the only credential that can
-provision an App Group. Everything else about an API key build is unaffected.
+1. Add the App Group to the app's App ID **and every extension's** — in Xcode
+   (Signing & Capabilities) or at
+   [developer.apple.com](https://developer.apple.com/account/resources/identifiers/list).
+2. Tell xcross to use that exact group instead of qualifying its own:
+
+```sh
+XCROSS_APP_GROUP=group.com.example.Shared xcross flutter run
+```
+
+`XCROSS_APP_GROUP` skips the per-account rewrite described above, because the
+group already exists and is already yours. From then on the full share flow
+works on an API key.
+
+If no group is provisioned, xcross says so once and leaves the entitlement
+out, because signing with an ungranted group is what produces `0xe8008015`.
+The app and its extensions still build, install and run.
 
 ### Which API this uses
 
@@ -166,9 +179,9 @@ sets one from the target name, so this should not occur; please report it.
 **The extension appears but the app never receives the shared file.**
 The two are not in the same App Group. Check that the app binary and the
 `.appex` both carry `com.apple.security.application-groups` with the same
-value (see above). The usual cause is signing with an App Store Connect API
-key, which cannot provision App Groups at all: sign in with
-`xcross auth --apple-id <email>` and re-run.
+value (see above). If they carry none, xcross said so during the run: either
+sign in with an Apple ID, or attach a group yourself and pass
+`XCROSS_APP_GROUP`.
 
 **`Could not provision the app extension …`.**
 Usually the free-account App ID quota (10 per 7 days). Either wait, or delete

--- a/packages/apple_developer_kit/lib/src/appstoreconnect/appstoreconnect.dart
+++ b/packages/apple_developer_kit/lib/src/appstoreconnect/appstoreconnect.dart
@@ -151,6 +151,7 @@ abstract final class AscProvisioning {
   }) async {
     if (appGroups.isEmpty) return;
 
+    var groupsLinked = true;
     try {
       final resourceIds = <String>[];
       for (final identifier in appGroups) {
@@ -159,17 +160,36 @@ abstract final class AscProvisioning {
           resourceIds.add(existing.id);
           continue;
         }
-        final created = await client.registerAppGroup(
-          identifier: identifier,
-          name: ProvisioningIdentifiers.appName(identifier),
-        );
-        resourceIds.add(created.id);
+        try {
+          final created = await client.registerAppGroup(
+            identifier: identifier,
+            name: ProvisioningIdentifiers.appName(identifier),
+          );
+          resourceIds.add(created.id);
+        } on AppleApiError catch (error) {
+          // App Store Connect has no App Groups resource to register into.
+          // The capability can still be switched on below, which is what
+          // makes Apple issue an application-groups entitlement at all, so
+          // this is a partial success rather than a failure.
+          if (error.statusCode != 404) rethrow;
+          groupsLinked = false;
+        }
       }
 
       await client.assignAppGroups(
         bundleIdResourceId: bundleIdResource.id,
         appGroupResourceIds: resourceIds,
       );
+      if (!groupsLinked) {
+        onProgress?.call(
+          'App Groups capability enabled on ${bundleIdResource.identifier}, '
+          'but the group values (${appGroups.join(', ')}) could not be '
+          'attached: the App Store Connect API exposes no App Groups '
+          'resource. Add them to the App IDs at developer.apple.com, or sign '
+          'in with `xcross auth --apple-id`, to share data between the app '
+          'and its extensions.',
+        );
+      }
     } on Object catch (error) {
       // developerservices2 (the Apple ID path) answers 403 "The API key in
       // use does not allow this request" here on every team tried, free and

--- a/packages/apple_developer_kit/lib/src/appstoreconnect/appstoreconnect.dart
+++ b/packages/apple_developer_kit/lib/src/appstoreconnect/appstoreconnect.dart
@@ -151,21 +151,21 @@ abstract final class AscProvisioning {
   }) async {
     if (appGroups.isEmpty) return;
 
-    final resourceIds = <String>[];
-    for (final identifier in appGroups) {
-      final existing = await client.findAppGroup(identifier);
-      if (existing != null) {
-        resourceIds.add(existing.id);
-        continue;
-      }
-      final created = await client.registerAppGroup(
-        identifier: identifier,
-        name: ProvisioningIdentifiers.appName(identifier),
-      );
-      resourceIds.add(created.id);
-    }
-
     try {
+      final resourceIds = <String>[];
+      for (final identifier in appGroups) {
+        final existing = await client.findAppGroup(identifier);
+        if (existing != null) {
+          resourceIds.add(existing.id);
+          continue;
+        }
+        final created = await client.registerAppGroup(
+          identifier: identifier,
+          name: ProvisioningIdentifiers.appName(identifier),
+        );
+        resourceIds.add(created.id);
+      }
+
       await client.assignAppGroups(
         bundleIdResourceId: bundleIdResource.id,
         appGroupResourceIds: resourceIds,
@@ -178,18 +178,35 @@ abstract final class AscProvisioning {
       // hand on developer.apple.com works and is picked up on the next run,
       // since the group is looked up before being registered.
       //
+      // The App Store Connect key path cannot do this at all: api.apple.com
+      // exposes no App Groups resource, so even looking one up 404s. That is
+      // a permanent property of the API rather than a transient failure, and
+      // it used to abort the whole install because only the capability
+      // assignment below was guarded, not the lookup and registration above.
+      //
       // Never fatal: the app, its extensions and their profiles are all
       // valid without it. Only the shared container is missing.
       final forbidden = error is AppleApiError && error.statusCode == 403;
+      final unsupported = error is AppleApiError && error.statusCode == 404;
       onProgress?.call(
-        forbidden
-            ? 'App Groups (${appGroups.join(', ')}) could not be enabled '
-                  "automatically: Apple's developer session API refuses "
-                  'capability changes. Add the group to the App IDs at '
-                  'developer.apple.com and re-run to share data between the '
-                  'app and its extensions.'
-            : 'Could not enable App Groups (${appGroups.join(', ')}) on '
-                  '${bundleIdResource.identifier}: $error',
+        switch ((forbidden, unsupported)) {
+          (true, _) =>
+            'App Groups (${appGroups.join(', ')}) could not be enabled '
+                "automatically: Apple's developer session API refuses "
+                'capability changes. Add the group to the App IDs at '
+                'developer.apple.com and re-run to share data between the '
+                'app and its extensions.',
+          (_, true) =>
+            'App Groups (${appGroups.join(', ')}) could not be enabled '
+                'automatically: the App Store Connect API exposes no App '
+                'Groups resource. Add the group to the App IDs at '
+                'developer.apple.com, or sign in with `xcross auth '
+                '--apple-id`, to share data between the app and its '
+                'extensions.',
+          _ =>
+            'Could not enable App Groups (${appGroups.join(', ')}) on '
+                '${bundleIdResource.identifier}: $error',
+        },
       );
     }
   }

--- a/packages/apple_developer_kit/lib/src/appstoreconnect/appstoreconnect.dart
+++ b/packages/apple_developer_kit/lib/src/appstoreconnect/appstoreconnect.dart
@@ -151,7 +151,6 @@ abstract final class AscProvisioning {
   }) async {
     if (appGroups.isEmpty) return;
 
-    var groupsLinked = true;
     try {
       final resourceIds = <String>[];
       for (final identifier in appGroups) {
@@ -160,73 +159,38 @@ abstract final class AscProvisioning {
           resourceIds.add(existing.id);
           continue;
         }
-        try {
-          final created = await client.registerAppGroup(
-            identifier: identifier,
-            name: ProvisioningIdentifiers.appName(identifier),
-          );
-          resourceIds.add(created.id);
-        } on AppleApiError catch (error) {
-          // App Store Connect has no App Groups resource to register into.
-          // The capability can still be switched on below, which is what
-          // makes Apple issue an application-groups entitlement at all, so
-          // this is a partial success rather than a failure.
-          if (error.statusCode != 404) rethrow;
-          groupsLinked = false;
-        }
+        final created = await client.registerAppGroup(
+          identifier: identifier,
+          name: ProvisioningIdentifiers.appName(identifier),
+        );
+        resourceIds.add(created.id);
       }
 
       await client.assignAppGroups(
         bundleIdResourceId: bundleIdResource.id,
         appGroupResourceIds: resourceIds,
       );
-      if (!groupsLinked) {
-        onProgress?.call(
-          'App Groups capability enabled on ${bundleIdResource.identifier}, '
-          'but the group values (${appGroups.join(', ')}) could not be '
-          'attached: the App Store Connect API exposes no App Groups '
-          'resource. Add them to the App IDs at developer.apple.com, or sign '
-          'in with `xcross auth --apple-id`, to share data between the app '
-          'and its extensions.',
-        );
-      }
     } on Object catch (error) {
-      // developerservices2 (the Apple ID path) answers 403 "The API key in
-      // use does not allow this request" here on every team tried, free and
-      // company alike: this legacy endpoint appears not to expose capability
-      // management to Xcode-style sessions at all. Enabling App Groups by
-      // hand on developer.apple.com works and is picked up on the next run,
-      // since the group is looked up before being registered.
-      //
-      // The App Store Connect key path cannot do this at all: api.apple.com
-      // exposes no App Groups resource, so even looking one up 404s. That is
-      // a permanent property of the API rather than a transient failure, and
-      // it used to abort the whole install because only the capability
-      // assignment below was guarded, not the lookup and registration above.
-      //
       // Never fatal: the app, its extensions and their profiles are all
-      // valid without it. Only the shared container is missing.
-      final forbidden = error is AppleApiError && error.statusCode == 403;
-      final unsupported = error is AppleApiError && error.statusCode == 404;
+      // valid without a shared container. Only the data hand-off between an
+      // extension and its host app is missing, so an App Groups problem must
+      // not cost the user their build.
+      //
+      // Both backends reach App Groups over the same legacy protocol now, so
+      // a failure here is a real error (an expired session, a revoked key, a
+      // team that cannot register more identifiers) rather than the API
+      // simply not supporting it.
+      final unauthorized =
+          error is AppleApiError &&
+          (error.statusCode == 401 || error.statusCode == 403);
       onProgress?.call(
-        switch ((forbidden, unsupported)) {
-          (true, _) =>
-            'App Groups (${appGroups.join(', ')}) could not be enabled '
-                "automatically: Apple's developer session API refuses "
-                'capability changes. Add the group to the App IDs at '
-                'developer.apple.com and re-run to share data between the '
-                'app and its extensions.',
-          (_, true) =>
-            'App Groups (${appGroups.join(', ')}) could not be enabled '
-                'automatically: the App Store Connect API exposes no App '
-                'Groups resource. Add the group to the App IDs at '
-                'developer.apple.com, or sign in with `xcross auth '
-                '--apple-id`, to share data between the app and its '
-                'extensions.',
-          _ =>
-            'Could not enable App Groups (${appGroups.join(', ')}) on '
-                '${bundleIdResource.identifier}: $error',
-        },
+        unauthorized
+            ? 'App Groups (${appGroups.join(', ')}) could not be enabled: '
+                  'Apple rejected the credentials for the legacy provisioning '
+                  'endpoint ($error). The app and its extensions still '
+                  'install, but they cannot share data until this is fixed.'
+            : 'Could not enable App Groups (${appGroups.join(', ')}) on '
+                  '${bundleIdResource.identifier}: $error',
       );
     }
   }

--- a/packages/apple_developer_kit/lib/src/appstoreconnect/appstoreconnect.dart
+++ b/packages/apple_developer_kit/lib/src/appstoreconnect/appstoreconnect.dart
@@ -170,25 +170,25 @@ abstract final class AscProvisioning {
         bundleIdResourceId: bundleIdResource.id,
         appGroupResourceIds: resourceIds,
       );
+    } on AppGroupsUnsupported catch (error) {
+      // Not a failure to retry: this credential type simply cannot do it.
+      // Said once, plainly, with the fix.
+      onProgress?.call('$error');
     } on Object catch (error) {
-      // Never fatal: the app, its extensions and their profiles are all
-      // valid without a shared container. Only the data hand-off between an
+      // Never fatal: the app, its extensions and their profiles are all valid
+      // without a shared container. Only the data hand-off between an
       // extension and its host app is missing, so an App Groups problem must
       // not cost the user their build.
-      //
-      // Both backends reach App Groups over the same legacy protocol now, so
-      // a failure here is a real error (an expired session, a revoked key, a
-      // team that cannot register more identifiers) rather than the API
-      // simply not supporting it.
       final unauthorized =
           error is AppleApiError &&
           (error.statusCode == 401 || error.statusCode == 403);
       onProgress?.call(
         unauthorized
             ? 'App Groups (${appGroups.join(', ')}) could not be enabled: '
-                  'Apple rejected the credentials for the legacy provisioning '
-                  'endpoint ($error). The app and its extensions still '
-                  'install, but they cannot share data until this is fixed.'
+                  'Apple rejected these credentials for the legacy '
+                  'provisioning endpoint ($error). The app and its extensions '
+                  'still install, but they cannot share data until this is '
+                  'fixed.'
             : 'Could not enable App Groups (${appGroups.join(', ')}) on '
                   '${bundleIdResource.identifier}: $error',
       );

--- a/packages/apple_developer_kit/lib/src/appstoreconnect/appstoreconnect.dart
+++ b/packages/apple_developer_kit/lib/src/appstoreconnect/appstoreconnect.dart
@@ -170,10 +170,11 @@ abstract final class AscProvisioning {
         bundleIdResourceId: bundleIdResource.id,
         appGroupResourceIds: resourceIds,
       );
-    } on AppGroupsUnsupported catch (error) {
-      // Not a failure to retry: this credential type simply cannot do it.
-      // Said once, plainly, with the fix.
-      onProgress?.call('$error');
+    } on AppGroupsUnsupported {
+      // Not a failure to retry: this credential type simply cannot attach a
+      // group. Stay quiet here — the caller inspects the issued profile and
+      // reports what was actually granted, which is the fact that matters and
+      // covers the case where a group was attached by other means.
     } on Object catch (error) {
       // Never fatal: the app, its extensions and their profiles are all valid
       // without a shared container. Only the data hand-off between an

--- a/packages/apple_developer_kit/lib/src/appstoreconnect/asc_client.dart
+++ b/packages/apple_developer_kit/lib/src/appstoreconnect/asc_client.dart
@@ -5,6 +5,7 @@ import 'package:apple_developer_kit/src/appstoreconnect/asc_config.dart';
 import 'package:apple_developer_kit/src/appstoreconnect/asc_jwt.dart';
 import 'package:apple_developer_kit/src/appstoreconnect/asc_models.dart';
 import 'package:apple_developer_kit/src/appstoreconnect/asc_payloads.dart';
+import 'package:apple_developer_kit/src/appstoreconnect/legacy_app_groups.dart';
 import 'package:apple_developer_kit/src/errors.dart';
 import 'package:http/http.dart' as http;
 
@@ -181,52 +182,74 @@ final class AscClient implements DevelopmentProvisioningClient {
     ),
   );
 
+  /// App Groups over the pre-JSON `QH65B2` protocol.
+  ///
+  /// `api.appstoreconnect.apple.com` has no App Groups resource at all:
+  /// Apple's own OpenAPI specification declares 966 paths and none of them
+  /// mentions one, and `CapabilitySetting.key` has no
+  /// `APP_GROUP_IDENTIFIERS` member, so even the `APP_GROUPS` capability
+  /// cannot be pointed at a specific group there.
+  ///
+  /// developerservices2's legacy endpoints can, and they accept an ordinary
+  /// App Store Connect API key: an unknown key is refused with the identical
+  /// "Make sure a bearer token was provided, it is properly configured and
+  /// signed" text `api.appstoreconnect.apple.com` returns, i.e. the same key
+  /// validator backs both hosts. Resource ids match across the two APIs, so
+  /// an App ID registered here can be handed straight to the legacy call.
   @override
-  Future<AscAppGroup?> findAppGroup(String identifier) async {
-    // App Store Connect exposes no App Groups resource: every spelling and
-    // version of `/appGroups` answers 404. Groups therefore cannot be looked
-    // up or created with an API key, only enabled as a capability (see
-    // [assignAppGroups]), so report "not registered" instead of failing.
-    return null;
-  }
+  Future<AscAppGroup?> findAppGroup(String identifier) =>
+      _appGroups.find(identifier);
 
   @override
   Future<AscAppGroup> registerAppGroup({
     required String identifier,
     required String name,
-  }) => Future.error(
-    // There is no `/appGroups` resource to POST to; the request would only
-    // ever come back 404. Reporting it directly keeps the caller's handling
-    // identical without a pointless round-trip. It is a rejected future
-    // rather than a synchronous throw so callers can rely on the usual
-    // async error path.
-    const AppleApiError(
-      404,
-      'The App Store Connect API exposes no App Groups resource, so groups '
-      'cannot be registered with an API key. Add the group to the App ID at '
-      'developer.apple.com, or sign in with `xcross auth --apple-id`.',
-    ),
-  );
+  }) => _appGroups.register(identifier: identifier, name: name);
 
   @override
   Future<void> assignAppGroups({
     required String bundleIdResourceId,
     required List<String> appGroupResourceIds,
-  }) async {
-    // With no App Groups resource to relate to, the most an API key can do is
-    // turn the capability on for the App ID. That alone makes Apple issue
-    // profiles carrying `com.apple.security.application-groups`, which is what
-    // lets the app and its extensions be signed with a shared-container
-    // entitlement at all. The concrete group values still have to be attached
-    // on developer.apple.com or through an Apple ID session.
-    await _post(
-      '/bundleIdCapabilities',
-      AscPayloads.enableCapability(
-        bundleIdResourceId: bundleIdResourceId,
-        capabilityType: 'APP_GROUPS',
-      ),
+  }) => _appGroups.assign(
+    appIdResourceId: bundleIdResourceId,
+    appGroupResourceIds: appGroupResourceIds,
+  );
+
+  late final LegacyAppGroups _appGroups = LegacyAppGroups(
+    httpClient: _http,
+    authHeaders: () async => {
+      'Authorization': 'Bearer ${await AscJwt.generate(credentials)}',
+    },
+    teamId: _resolveTeamId,
+  );
+
+  /// The team the API key belongs to, which the legacy protocol wants in
+  /// every request body.
+  ///
+  /// An API key is already team-scoped, so unlike an Apple ID session it
+  /// never carries a team id of its own. Apple returns it as a bundle id's
+  /// `seedId`, which is why this reads one rather than asking for a team
+  /// resource: there is no `/teams` endpoint on App Store Connect.
+  Future<String> _resolveTeamId() async {
+    final cached = _teamId;
+    if (cached != null) return cached;
+
+    final page = (await _get('/bundleIds?limit=1'))['data'];
+    if (page is List) {
+      for (final entry in page) {
+        if (entry is! Map) continue;
+        final seedId = (entry['attributes'] as Map?)?['seedId'];
+        if (seedId is String && seedId.isNotEmpty) return _teamId = seedId;
+      }
+    }
+    throw const AppleError(
+      'Could not determine the team id for this App Store Connect API key: '
+      'the team has no bundle ids to read a seedId from. Register one app '
+      'first, or sign in with `xcross auth --apple-id`.',
     );
   }
+
+  String? _teamId;
 
   @override
   Future<List<String>> listProfileIdsForBundle(

--- a/packages/apple_developer_kit/lib/src/appstoreconnect/asc_client.dart
+++ b/packages/apple_developer_kit/lib/src/appstoreconnect/asc_client.dart
@@ -5,7 +5,6 @@ import 'package:apple_developer_kit/src/appstoreconnect/asc_config.dart';
 import 'package:apple_developer_kit/src/appstoreconnect/asc_jwt.dart';
 import 'package:apple_developer_kit/src/appstoreconnect/asc_models.dart';
 import 'package:apple_developer_kit/src/appstoreconnect/asc_payloads.dart';
-import 'package:apple_developer_kit/src/appstoreconnect/legacy_app_groups.dart';
 import 'package:apple_developer_kit/src/errors.dart';
 import 'package:http/http.dart' as http;
 
@@ -182,74 +181,49 @@ final class AscClient implements DevelopmentProvisioningClient {
     ),
   );
 
-  /// App Groups over the pre-JSON `QH65B2` protocol.
+  /// App Groups cannot be provisioned with an App Store Connect API key.
   ///
-  /// `api.appstoreconnect.apple.com` has no App Groups resource at all:
-  /// Apple's own OpenAPI specification declares 966 paths and none of them
-  /// mentions one, and `CapabilitySetting.key` has no
-  /// `APP_GROUP_IDENTIFIERS` member, so even the `APP_GROUPS` capability
-  /// cannot be pointed at a specific group there.
+  /// Every route was tried against a live key and each is a dead end:
   ///
-  /// developerservices2's legacy endpoints can, and they accept an ordinary
-  /// App Store Connect API key: an unknown key is refused with the identical
-  /// "Make sure a bearer token was provided, it is properly configured and
-  /// signed" text `api.appstoreconnect.apple.com` returns, i.e. the same key
-  /// validator backs both hosts. Resource ids match across the two APIs, so
-  /// an App ID registered here can be handed straight to the legacy call.
+  /// * `api.appstoreconnect.apple.com` has no App Groups resource. Apple's
+  ///   own OpenAPI specification declares 966 paths and not one mentions App
+  ///   Groups; `/v1/appGroups` and `/v1/applicationGroups` both 404.
+  /// * The `APP_GROUPS` capability *can* be switched on through
+  ///   `/v1/bundleIdCapabilities` (it answers 201), but it cannot be pointed
+  ///   at a group: `CapabilitySetting.key` accepts only `ICLOUD_VERSION`,
+  ///   `DATA_PROTECTION_PERMISSION_LEVEL` and `APPLE_ID_AUTH_APP_CONSENT`,
+  ///   and Apple rejects `APP_GROUP_IDENTIFIERS` with a 409 naming those
+  ///   three.
+  /// * With the capability on but no group linked, an issued profile grants
+  ///   `com.apple.security.application-groups: []`, an empty array. Signing
+  ///   an app with a real group against such a profile is refused by installd
+  ///   with `0xe8008015 (A valid provisioning profile for this executable was
+  ///   not found)`, so the empty array cannot be worked around locally.
+  /// * developerservices2, which does expose App Groups, refuses API keys.
+  ///   Its 403 quotes the same "properly configured and signed" wording
+  ///   api.appstoreconnect.apple.com uses, but a key that works there is
+  ///   rejected here under every JWT audience tried, so the shared wording is
+  ///   coincidental rather than a shared validator.
+  ///
+  /// Reporting this as a distinct error lets the provisioning layer print one
+  /// clear message instead of a confusing HTTP failure. Signing in with
+  /// `xcross auth --apple-id` is the only path that provisions App Groups.
   @override
   Future<AscAppGroup?> findAppGroup(String identifier) =>
-      _appGroups.find(identifier);
+      Future.error(const AppGroupsUnsupported());
 
   @override
   Future<AscAppGroup> registerAppGroup({
     required String identifier,
     required String name,
-  }) => _appGroups.register(identifier: identifier, name: name);
+  }) => Future.error(const AppGroupsUnsupported());
 
   @override
   Future<void> assignAppGroups({
     required String bundleIdResourceId,
     required List<String> appGroupResourceIds,
-  }) => _appGroups.assign(
-    appIdResourceId: bundleIdResourceId,
-    appGroupResourceIds: appGroupResourceIds,
-  );
+  }) => Future.error(const AppGroupsUnsupported());
 
-  late final LegacyAppGroups _appGroups = LegacyAppGroups(
-    httpClient: _http,
-    authHeaders: () async => {
-      'Authorization': 'Bearer ${await AscJwt.generate(credentials)}',
-    },
-    teamId: _resolveTeamId,
-  );
-
-  /// The team the API key belongs to, which the legacy protocol wants in
-  /// every request body.
-  ///
-  /// An API key is already team-scoped, so unlike an Apple ID session it
-  /// never carries a team id of its own. Apple returns it as a bundle id's
-  /// `seedId`, which is why this reads one rather than asking for a team
-  /// resource: there is no `/teams` endpoint on App Store Connect.
-  Future<String> _resolveTeamId() async {
-    final cached = _teamId;
-    if (cached != null) return cached;
-
-    final page = (await _get('/bundleIds?limit=1'))['data'];
-    if (page is List) {
-      for (final entry in page) {
-        if (entry is! Map) continue;
-        final seedId = (entry['attributes'] as Map?)?['seedId'];
-        if (seedId is String && seedId.isNotEmpty) return _teamId = seedId;
-      }
-    }
-    throw const AppleError(
-      'Could not determine the team id for this App Store Connect API key: '
-      'the team has no bundle ids to read a seedId from. Register one app '
-      'first, or sign in with `xcross auth --apple-id`.',
-    );
-  }
-
-  String? _teamId;
 
   @override
   Future<List<String>> listProfileIdsForBundle(

--- a/packages/apple_developer_kit/lib/src/appstoreconnect/asc_client.dart
+++ b/packages/apple_developer_kit/lib/src/appstoreconnect/asc_client.dart
@@ -149,12 +149,24 @@ final class AscClient implements DevelopmentProvisioningClient {
   );
 
   @override
-  Future<AscBundleId?> findBundleId(String identifier) async => _firstOrNull(
-    await _get(
-      '/bundleIds?filter[identifier]=${Uri.encodeQueryComponent(identifier)}',
-    ),
-    AscBundleId.fromJson,
-  );
+  Future<AscBundleId?> findBundleId(String identifier) async {
+    // `filter[identifier]` is a prefix match, not an exact one: querying
+    // `com.example.App` also returns `com.example.App.Share-Extension`, and
+    // the app's own id is not necessarily first. Taking the first row would
+    // sign the app with an extension's App ID, so the exact match is picked
+    // out here (mirroring the developerservices2 client).
+    final page = await _get(
+      '/bundleIds?filter[identifier]=${Uri.encodeQueryComponent(identifier)}'
+      '&limit=200',
+    );
+    for (final entry in page['data'] as List) {
+      final bundleId = AscBundleId.fromJson(
+        (entry as Map).cast<String, dynamic>(),
+      );
+      if (bundleId.identifier == identifier) return bundleId;
+    }
+    return null;
+  }
 
   @override
   Future<AscBundleId> registerBundleId({
@@ -170,23 +182,29 @@ final class AscClient implements DevelopmentProvisioningClient {
   );
 
   @override
-  Future<AscAppGroup?> findAppGroup(String identifier) async => _firstOrNull(
-    await _get(
-      '/appGroups?filter[identifier]=${Uri.encodeQueryComponent(identifier)}',
-    ),
-    AscAppGroup.fromJson,
-  );
+  Future<AscAppGroup?> findAppGroup(String identifier) async {
+    // App Store Connect exposes no App Groups resource: every spelling and
+    // version of `/appGroups` answers 404. Groups therefore cannot be looked
+    // up or created with an API key, only enabled as a capability (see
+    // [assignAppGroups]), so report "not registered" instead of failing.
+    return null;
+  }
 
   @override
   Future<AscAppGroup> registerAppGroup({
     required String identifier,
     required String name,
-  }) async => AscAppGroup.fromJson(
-    _data(
-      await _post(
-        '/appGroups',
-        AscPayloads.appGroup(identifier: identifier, name: name),
-      ),
+  }) => Future.error(
+    // There is no `/appGroups` resource to POST to; the request would only
+    // ever come back 404. Reporting it directly keeps the caller's handling
+    // identical without a pointless round-trip. It is a rejected future
+    // rather than a synchronous throw so callers can rely on the usual
+    // async error path.
+    const AppleApiError(
+      404,
+      'The App Store Connect API exposes no App Groups resource, so groups '
+      'cannot be registered with an API key. Add the group to the App ID at '
+      'developer.apple.com, or sign in with `xcross auth --apple-id`.',
     ),
   );
 
@@ -195,11 +213,17 @@ final class AscClient implements DevelopmentProvisioningClient {
     required String bundleIdResourceId,
     required List<String> appGroupResourceIds,
   }) async {
+    // With no App Groups resource to relate to, the most an API key can do is
+    // turn the capability on for the App ID. That alone makes Apple issue
+    // profiles carrying `com.apple.security.application-groups`, which is what
+    // lets the app and its extensions be signed with a shared-container
+    // entitlement at all. The concrete group values still have to be attached
+    // on developer.apple.com or through an Apple ID session.
     await _post(
       '/bundleIdCapabilities',
-      AscPayloads.appGroupsCapability(
+      AscPayloads.enableCapability(
         bundleIdResourceId: bundleIdResourceId,
-        appGroupResourceIds: appGroupResourceIds,
+        capabilityType: 'APP_GROUPS',
       ),
     );
   }

--- a/packages/apple_developer_kit/lib/src/appstoreconnect/asc_payloads.dart
+++ b/packages/apple_developer_kit/lib/src/appstoreconnect/asc_payloads.dart
@@ -40,47 +40,6 @@ abstract final class AscPayloads {
     },
   };
 
-  static Map<String, dynamic> appGroup({
-    required String identifier,
-    required String name,
-  }) => {
-    'data': {
-      'type': 'appGroups',
-      'attributes': {'identifier': identifier, 'name': name},
-    },
-  };
-
-  /// Turns on the App Groups capability for a bundle id and links the groups.
-  ///
-  /// Posted to `/bundleIds/<id>/bundleIdCapabilities`: the capability is a
-  /// sub-resource of the bundle id, not an inline relationship on it. Without
-  /// it the groups never reach the issued profile's entitlements, and the app
-  /// and its extensions stay in separate containers.
-  static Map<String, dynamic> appGroupsCapability({
-    required String bundleIdResourceId,
-    required List<String> appGroupResourceIds,
-  }) => {
-    'data': {
-      'type': 'bundleIdCapabilities',
-      'attributes': {
-        'capabilityType': 'APP_GROUPS',
-        'settings': [
-          {
-            'key': 'APP_GROUP_IDENTIFIERS',
-            'options': [
-              for (final id in appGroupResourceIds) {'key': id},
-            ],
-          },
-        ],
-      },
-      'relationships': {
-        'bundleId': {
-          'data': {'type': 'bundleIds', 'id': bundleIdResourceId},
-        },
-      },
-    },
-  };
-
   static Map<String, dynamic> profile({
     required String name,
     required String bundleIdResourceId,

--- a/packages/apple_developer_kit/lib/src/appstoreconnect/asc_payloads.dart
+++ b/packages/apple_developer_kit/lib/src/appstoreconnect/asc_payloads.dart
@@ -108,4 +108,25 @@ abstract final class AscPayloads {
       },
     },
   };
+
+  /// Turns a capability on for a bundle id without configuring it.
+  ///
+  /// Used for `APP_GROUPS` on the App Store Connect key path, where the
+  /// groups themselves cannot be enumerated (`/appGroups` does not exist) and
+  /// so cannot be linked. Enabling the capability is still what makes Apple
+  /// issue profiles carrying `com.apple.security.application-groups`.
+  static Map<String, dynamic> enableCapability({
+    required String bundleIdResourceId,
+    required String capabilityType,
+  }) => {
+    'data': {
+      'type': 'bundleIdCapabilities',
+      'attributes': {'capabilityType': capabilityType},
+      'relationships': {
+        'bundleId': {
+          'data': {'type': 'bundleIds', 'id': bundleIdResourceId},
+        },
+      },
+    },
+  };
 }

--- a/packages/apple_developer_kit/lib/src/appstoreconnect/asc_payloads.dart
+++ b/packages/apple_developer_kit/lib/src/appstoreconnect/asc_payloads.dart
@@ -67,25 +67,4 @@ abstract final class AscPayloads {
       },
     },
   };
-
-  /// Turns a capability on for a bundle id without configuring it.
-  ///
-  /// Used for `APP_GROUPS` on the App Store Connect key path, where the
-  /// groups themselves cannot be enumerated (`/appGroups` does not exist) and
-  /// so cannot be linked. Enabling the capability is still what makes Apple
-  /// issue profiles carrying `com.apple.security.application-groups`.
-  static Map<String, dynamic> enableCapability({
-    required String bundleIdResourceId,
-    required String capabilityType,
-  }) => {
-    'data': {
-      'type': 'bundleIdCapabilities',
-      'attributes': {'capabilityType': capabilityType},
-      'relationships': {
-        'bundleId': {
-          'data': {'type': 'bundleIds', 'id': bundleIdResourceId},
-        },
-      },
-    },
-  };
 }

--- a/packages/apple_developer_kit/lib/src/appstoreconnect/developer_services_client.dart
+++ b/packages/apple_developer_kit/lib/src/appstoreconnect/developer_services_client.dart
@@ -56,8 +56,15 @@ final class DeveloperServicesClient implements DevelopmentProvisioningClient {
   );
 
   static const _baseUrl = 'https://developerservices2.apple.com/services';
+  static const _legacyBaseUrl = '$_baseUrl/QH65B2';
+  static const _legacyClientId = 'XABBG36SBA';
   static const _appIdentifier = 'com.apple.gs.xcode.auth';
   static const _xcodeVersion = '16.2 (16C5031c)';
+
+  /// Apple's internal feature key for the App Groups capability, as sent by
+  /// Xcode to `ios/updateAppId.action`. Cross-checked against AltSign's
+  /// `ALTFeatureAppGroups`.
+  static const _appGroupsFeature = 'APG3427HIY';
   static const _clientInfo =
       '<VirtualMac2,1> <macOS;15.1.1;24B91> '
       '<com.apple.AuthKit/1 (com.apple.dt.Xcode/23505)>';
@@ -199,19 +206,23 @@ final class DeveloperServicesClient implements DevelopmentProvisioningClient {
     ),
   );
 
-  /// developerservices2 filters App Groups by prefix like it does bundle ids,
-  /// so the exact identifier is picked out of the returned page.
+  /// App Groups live only on the pre-JSON `QH65B2` plist protocol.
+  ///
+  /// The JSON:API surface of developerservices2 answers 403 "The API key in
+  /// use does not allow this request" for every capability mutation, and
+  /// api.apple.com has no `/appGroups` resource at all. The legacy actions
+  /// Xcode itself uses (`ios/listApplicationGroups.action` and friends) work
+  /// on the same Apple ID session, and return the very same resource ids the
+  /// JSON:API returns, so the two can be mixed freely.
   @override
   Future<AscAppGroup?> findAppGroup(String identifier) async {
-    final page = await _getCollection(
-      '/v1/appGroups?filter[identifier]='
-      '${Uri.encodeQueryComponent(identifier)}',
-    );
-    for (final entry in page) {
-      final group = AscAppGroup.fromJson(
-        (entry! as Map).cast<String, dynamic>(),
-      );
-      if (group.identifier == identifier) return group;
+    final response = await _legacyAction('ios/listApplicationGroups.action');
+    final groups = response['applicationGroupList'];
+    if (groups is! List) return null;
+    for (final entry in groups) {
+      if (entry is! Map) continue;
+      if (entry['identifier'] != identifier) continue;
+      return _appGroupFromLegacy(entry);
     }
     return null;
   }
@@ -220,30 +231,65 @@ final class DeveloperServicesClient implements DevelopmentProvisioningClient {
   Future<AscAppGroup> registerAppGroup({
     required String identifier,
     required String name,
-  }) async => AscAppGroup.fromJson(
-    _data(
-      await _post(
-        '/v1/appGroups',
-        AscPayloads.appGroup(identifier: identifier, name: name),
-      ),
-    ),
-  );
+  }) async {
+    final response = await _legacyAction('ios/addApplicationGroup.action', {
+      'identifier': identifier,
+      // Apple rejects punctuation in App Group names the same way it does
+      // App ID names.
+      'name': _sanitizeName(name),
+    });
+    final group = response['applicationGroup'];
+    if (group is! Map) {
+      throw const AppleError(
+        'Developer Services add App Group response is missing the group',
+      );
+    }
+    return _appGroupFromLegacy(group);
+  }
 
+  /// Turns the App Groups capability on for the App ID and links the groups.
+  ///
+  /// Both steps are required: `updateAppId.action` flips the feature flag
+  /// that makes Apple issue an `com.apple.security.application-groups`
+  /// entitlement at all, while `assignApplicationGroupToAppId.action`
+  /// decides which groups end up inside it.
   @override
   Future<void> assignAppGroups({
     required String bundleIdResourceId,
     required List<String> appGroupResourceIds,
   }) async {
-    // The capability is its own sub-resource of the bundle id. Patching the
-    // bundle id with an inline relationship is rejected ("relationship with
-    // an invalid value"), and the parent resource refuses POST outright.
-    await _post(
-      '/v1/bundleIds/$bundleIdResourceId/bundleIdCapabilities',
-      AscPayloads.appGroupsCapability(
-        bundleIdResourceId: bundleIdResourceId,
-        appGroupResourceIds: appGroupResourceIds,
-      ),
+    await _legacyAction('ios/updateAppId.action', {
+      'appIdId': bundleIdResourceId,
+      _appGroupsFeature: true,
+    });
+    if (appGroupResourceIds.isEmpty) return;
+    await _legacyAction('ios/assignApplicationGroupToAppId.action', {
+      'appIdId': bundleIdResourceId,
+      'applicationGroups': appGroupResourceIds,
+    });
+  }
+
+  /// A legacy group entry names the resource id `applicationGroup` and the
+  /// `group.…` string `identifier`, the opposite way round from JSON:API.
+  static AscAppGroup _appGroupFromLegacy(Map<dynamic, dynamic> entry) {
+    final id = entry['applicationGroup'];
+    final identifier = entry['identifier'];
+    if (id is! String || identifier is! String) {
+      throw const AppleError(
+        'Developer Services App Group entry is missing an identifier',
+      );
+    }
+    return AscAppGroup(
+      id: id,
+      identifier: identifier,
+      name: entry['name'] as String? ?? '',
     );
+  }
+
+  /// Apple's App ID/App Group names accept alphanumerics and spaces only.
+  static String _sanitizeName(String name) {
+    final sanitized = name.replaceAll(RegExp('[^A-Za-z0-9 ]'), ' ').trim();
+    return sanitized.isEmpty ? 'xcross group' : sanitized;
   }
 
   @override
@@ -288,6 +334,41 @@ final class DeveloperServicesClient implements DevelopmentProvisioningClient {
 
   Future<Map<String, dynamic>> _get(String path) =>
       _withMethodOverride(path, 'GET');
+
+  /// Calls one of the pre-JSON `QH65B2` actions.
+  ///
+  /// This protocol POSTs an XML plist, always answers HTTP 200, and reports
+  /// failure through `resultCode` rather than a status code, exactly like
+  /// [listTeams]. It is the only surface that exposes App Groups.
+  Future<Map<String, Object?>> _legacyAction(
+    String action, [
+    Map<String, Object?> parameters = const {},
+  ]) async {
+    _rejectExpired(token);
+    final response = await _http.post(
+      Uri.parse('$_legacyBaseUrl/$action?clientId=$_legacyClientId'),
+      headers: {..._legacyHeaders(token), ...await _fetchAnisetteHeaders()},
+      body: PropertyListSerialization.stringWithPropertyList({
+        'clientId': _legacyClientId,
+        'protocolVersion': 'QH65B2',
+        'requestId': AnisetteState.generateUuidV4().toUpperCase(),
+        'teamId': teamId,
+        ...parameters,
+      }),
+    );
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw AppleApiError(
+        response.statusCode,
+        'Developer Services $action failed (HTTP ${response.statusCode})',
+      );
+    }
+    final plist = GrandSlamResponse.decodePlist(
+      response.body,
+      context: 'Developer Services $action response',
+    );
+    _rejectLegacyFailure(plist, action: action);
+    return plist;
+  }
 
   /// developerservices2 only accepts POST; other verbs ride along in
   /// `X-HTTP-Method-Override`, with the query string moved into the body.
@@ -466,22 +547,25 @@ final class DeveloperServicesClient implements DevelopmentProvisioningClient {
   /// The legacy protocol always answers HTTP 200 and reports failure through
   /// `resultCode` instead - and sends it as an int or a string depending on
   /// the error.
-  static void _rejectLegacyFailure(Map<String, Object?> plist) {
+  static void _rejectLegacyFailure(
+    Map<String, Object?> plist, {
+    String action = 'list teams',
+  }) {
     final resultCode = switch (plist['resultCode']) {
       final int value => value,
       final String value => int.tryParse(value),
       _ => null,
     };
     if (resultCode == null) {
-      throw const AppleError(
-        'Developer Services list teams response has an invalid resultCode',
+      throw AppleError(
+        'Developer Services $action response has an invalid resultCode',
       );
     }
     if (resultCode != 0) {
       final message =
           plist['userString'] ?? plist['resultString'] ?? 'unknown error';
       throw AppleError(
-        'Developer Services list teams failed ($resultCode): $message',
+        'Developer Services $action failed ($resultCode): $message',
       );
     }
   }

--- a/packages/apple_developer_kit/lib/src/appstoreconnect/developer_services_client.dart
+++ b/packages/apple_developer_kit/lib/src/appstoreconnect/developer_services_client.dart
@@ -5,6 +5,7 @@ import 'package:apple_developer_kit/src/apple_http_client.dart';
 import 'package:apple_developer_kit/src/appstoreconnect/asc_client.dart';
 import 'package:apple_developer_kit/src/appstoreconnect/asc_models.dart';
 import 'package:apple_developer_kit/src/appstoreconnect/asc_payloads.dart';
+import 'package:apple_developer_kit/src/appstoreconnect/legacy_app_groups.dart';
 import 'package:apple_developer_kit/src/errors.dart';
 import 'package:apple_developer_kit/src/grandslam/anisette/anisette_state.dart';
 import 'package:apple_developer_kit/src/grandslam/app_token_exchange.dart';
@@ -56,15 +57,9 @@ final class DeveloperServicesClient implements DevelopmentProvisioningClient {
   );
 
   static const _baseUrl = 'https://developerservices2.apple.com/services';
-  static const _legacyBaseUrl = '$_baseUrl/QH65B2';
   static const _legacyClientId = 'XABBG36SBA';
   static const _appIdentifier = 'com.apple.gs.xcode.auth';
   static const _xcodeVersion = '16.2 (16C5031c)';
-
-  /// Apple's internal feature key for the App Groups capability, as sent by
-  /// Xcode to `ios/updateAppId.action`. Cross-checked against AltSign's
-  /// `ALTFeatureAppGroups`.
-  static const _appGroupsFeature = 'APG3427HIY';
   static const _clientInfo =
       '<VirtualMac2,1> <macOS;15.1.1;24B91> '
       '<com.apple.AuthKit/1 (com.apple.dt.Xcode/23505)>';
@@ -90,11 +85,13 @@ final class DeveloperServicesClient implements DevelopmentProvisioningClient {
     final client = httpClient ?? AppleHttp.createAppleHttpClient();
     try {
       final response = await client.post(
-        Uri.parse('$_baseUrl/QH65B2/listTeams.action?clientId=XABBG36SBA'),
+        Uri.parse(
+          '$_baseUrl/QH65B2/listTeams.action?clientId=$_legacyClientId',
+        ),
         headers: {...anisette, ..._legacyHeaders(token)},
         body: PropertyListSerialization.stringWithPropertyList({
           'requestId': AnisetteState.generateUuidV4(),
-          'clientId': 'XABBG36SBA',
+          'clientId': _legacyClientId,
           'protocolVersion': 'QH65B2',
           'userLocale': [Platform.localeName],
         }),
@@ -206,91 +203,36 @@ final class DeveloperServicesClient implements DevelopmentProvisioningClient {
     ),
   );
 
-  /// App Groups live only on the pre-JSON `QH65B2` plist protocol.
-  ///
-  /// The JSON:API surface of developerservices2 answers 403 "The API key in
-  /// use does not allow this request" for every capability mutation, and
-  /// api.apple.com has no `/appGroups` resource at all. The legacy actions
-  /// Xcode itself uses (`ios/listApplicationGroups.action` and friends) work
-  /// on the same Apple ID session, and return the very same resource ids the
-  /// JSON:API returns, so the two can be mixed freely.
+  /// App Groups live only on the pre-JSON `QH65B2` plist protocol, which
+  /// this session authenticates with its GrandSlam token plus Anisette
+  /// headers. See [LegacyAppGroups] for why no modern surface can do it.
   @override
-  Future<AscAppGroup?> findAppGroup(String identifier) async {
-    final response = await _legacyAction('ios/listApplicationGroups.action');
-    final groups = response['applicationGroupList'];
-    if (groups is! List) return null;
-    for (final entry in groups) {
-      if (entry is! Map) continue;
-      if (entry['identifier'] != identifier) continue;
-      return _appGroupFromLegacy(entry);
-    }
-    return null;
-  }
+  Future<AscAppGroup?> findAppGroup(String identifier) =>
+      _appGroups.find(identifier);
 
   @override
   Future<AscAppGroup> registerAppGroup({
     required String identifier,
     required String name,
-  }) async {
-    final response = await _legacyAction('ios/addApplicationGroup.action', {
-      'identifier': identifier,
-      // Apple rejects punctuation in App Group names the same way it does
-      // App ID names.
-      'name': _sanitizeName(name),
-    });
-    final group = response['applicationGroup'];
-    if (group is! Map) {
-      throw const AppleError(
-        'Developer Services add App Group response is missing the group',
-      );
-    }
-    return _appGroupFromLegacy(group);
-  }
+  }) => _appGroups.register(identifier: identifier, name: name);
 
-  /// Turns the App Groups capability on for the App ID and links the groups.
-  ///
-  /// Both steps are required: `updateAppId.action` flips the feature flag
-  /// that makes Apple issue an `com.apple.security.application-groups`
-  /// entitlement at all, while `assignApplicationGroupToAppId.action`
-  /// decides which groups end up inside it.
   @override
   Future<void> assignAppGroups({
     required String bundleIdResourceId,
     required List<String> appGroupResourceIds,
-  }) async {
-    await _legacyAction('ios/updateAppId.action', {
-      'appIdId': bundleIdResourceId,
-      _appGroupsFeature: true,
-    });
-    if (appGroupResourceIds.isEmpty) return;
-    await _legacyAction('ios/assignApplicationGroupToAppId.action', {
-      'appIdId': bundleIdResourceId,
-      'applicationGroups': appGroupResourceIds,
-    });
-  }
+  }) => _appGroups.assign(
+    appIdResourceId: bundleIdResourceId,
+    appGroupResourceIds: appGroupResourceIds,
+  );
 
-  /// A legacy group entry names the resource id `applicationGroup` and the
-  /// `group.…` string `identifier`, the opposite way round from JSON:API.
-  static AscAppGroup _appGroupFromLegacy(Map<dynamic, dynamic> entry) {
-    final id = entry['applicationGroup'];
-    final identifier = entry['identifier'];
-    if (id is! String || identifier is! String) {
-      throw const AppleError(
-        'Developer Services App Group entry is missing an identifier',
-      );
-    }
-    return AscAppGroup(
-      id: id,
-      identifier: identifier,
-      name: entry['name'] as String? ?? '',
-    );
-  }
-
-  /// Apple's App ID/App Group names accept alphanumerics and spaces only.
-  static String _sanitizeName(String name) {
-    final sanitized = name.replaceAll(RegExp('[^A-Za-z0-9 ]'), ' ').trim();
-    return sanitized.isEmpty ? 'xcross group' : sanitized;
-  }
+  late final LegacyAppGroups _appGroups = LegacyAppGroups(
+    httpClient: _http,
+    authHeaders: () async => {
+      ..._legacyHeaders(token),
+      ...await _fetchAnisetteHeaders(),
+    },
+    teamId: () => Future.value(teamId),
+  );
 
   @override
   Future<List<String>> listProfileIdsForBundle(
@@ -334,41 +276,6 @@ final class DeveloperServicesClient implements DevelopmentProvisioningClient {
 
   Future<Map<String, dynamic>> _get(String path) =>
       _withMethodOverride(path, 'GET');
-
-  /// Calls one of the pre-JSON `QH65B2` actions.
-  ///
-  /// This protocol POSTs an XML plist, always answers HTTP 200, and reports
-  /// failure through `resultCode` rather than a status code, exactly like
-  /// [listTeams]. It is the only surface that exposes App Groups.
-  Future<Map<String, Object?>> _legacyAction(
-    String action, [
-    Map<String, Object?> parameters = const {},
-  ]) async {
-    _rejectExpired(token);
-    final response = await _http.post(
-      Uri.parse('$_legacyBaseUrl/$action?clientId=$_legacyClientId'),
-      headers: {..._legacyHeaders(token), ...await _fetchAnisetteHeaders()},
-      body: PropertyListSerialization.stringWithPropertyList({
-        'clientId': _legacyClientId,
-        'protocolVersion': 'QH65B2',
-        'requestId': AnisetteState.generateUuidV4().toUpperCase(),
-        'teamId': teamId,
-        ...parameters,
-      }),
-    );
-    if (response.statusCode < 200 || response.statusCode >= 300) {
-      throw AppleApiError(
-        response.statusCode,
-        'Developer Services $action failed (HTTP ${response.statusCode})',
-      );
-    }
-    final plist = GrandSlamResponse.decodePlist(
-      response.body,
-      context: 'Developer Services $action response',
-    );
-    _rejectLegacyFailure(plist, action: action);
-    return plist;
-  }
 
   /// developerservices2 only accepts POST; other verbs ride along in
   /// `X-HTTP-Method-Override`, with the query string moved into the body.
@@ -525,7 +432,7 @@ final class DeveloperServicesClient implements DevelopmentProvisioningClient {
       response.body,
       context: 'Developer Services list teams response',
     );
-    _rejectLegacyFailure(plist);
+    LegacyAppGroups.rejectFailure(plist, action: 'list teams');
 
     final teams = plist['teams'];
     if (teams is! List) {
@@ -542,32 +449,6 @@ final class DeveloperServicesClient implements DevelopmentProvisioningClient {
             status: _requiredString(team, 'status'),
           ),
     ];
-  }
-
-  /// The legacy protocol always answers HTTP 200 and reports failure through
-  /// `resultCode` instead - and sends it as an int or a string depending on
-  /// the error.
-  static void _rejectLegacyFailure(
-    Map<String, Object?> plist, {
-    String action = 'list teams',
-  }) {
-    final resultCode = switch (plist['resultCode']) {
-      final int value => value,
-      final String value => int.tryParse(value),
-      _ => null,
-    };
-    if (resultCode == null) {
-      throw AppleError(
-        'Developer Services $action response has an invalid resultCode',
-      );
-    }
-    if (resultCode != 0) {
-      final message =
-          plist['userString'] ?? plist['resultString'] ?? 'unknown error';
-      throw AppleError(
-        'Developer Services $action failed ($resultCode): $message',
-      );
-    }
   }
 
   static Map<String, dynamic> _decode(http.Response response) {

--- a/packages/apple_developer_kit/lib/src/appstoreconnect/legacy_app_groups.dart
+++ b/packages/apple_developer_kit/lib/src/appstoreconnect/legacy_app_groups.dart
@@ -1,0 +1,224 @@
+/// App Groups over Apple's pre-JSON `QH65B2` protocol.
+///
+/// App Groups are the one provisioning resource that has no modern
+/// representation at all: Apple's own App Store Connect OpenAPI specification
+/// declares 966 paths and not one of them mentions App Groups, and
+/// developerservices2's JSON:API surface answers
+/// `403 The API key in use does not allow this request` to any capability
+/// change. The only surface that can create a group and attach it to an App ID
+/// is the pre-JSON plist protocol Xcode itself speaks.
+///
+/// That protocol authenticates two ways, and this class deliberately knows
+/// about neither: callers hand it a header provider. A GrandSlam (Apple ID)
+/// session supplies `X-Apple-GS-Token` plus Anisette headers, while an App
+/// Store Connect API key supplies an ordinary `Authorization: Bearer <JWT>` —
+/// the same host validates both, answering an unknown key with the identical
+/// "properly configured and signed" text `api.appstoreconnect.apple.com`
+/// returns.
+///
+/// Without this, an app and its share extension are each sandboxed into their
+/// own container and cannot exchange the data an extension exists to hand
+/// over.
+library;
+
+import 'package:apple_developer_kit/src/appstoreconnect/asc_client.dart';
+import 'package:apple_developer_kit/src/appstoreconnect/asc_models.dart';
+import 'package:apple_developer_kit/src/errors.dart';
+import 'package:apple_developer_kit/src/grandslam/anisette/anisette_state.dart';
+import 'package:apple_developer_kit/src/grandslam/internal/grandslam_response_decoder.dart';
+import 'package:http/http.dart' as http;
+import 'package:meta/meta.dart';
+import 'package:propertylistserialization/propertylistserialization.dart';
+
+/// Supplies the auth (and, for GrandSlam, Anisette) headers for one request.
+typedef LegacyAuthHeaders = Future<Map<String, String>> Function();
+
+/// Resolves the team the request acts on. An Apple ID session carries it
+/// directly; an API key has to look it up (see `AscClient`).
+typedef LegacyTeamId = Future<String> Function();
+
+/// The `QH65B2` App Groups actions, shared by both provisioning backends.
+@internal
+final class LegacyAppGroups {
+  const LegacyAppGroups({
+    required http.Client httpClient,
+    required LegacyAuthHeaders authHeaders,
+    required LegacyTeamId teamId,
+  }) : _http = httpClient,
+       _authHeaders = authHeaders,
+       _teamId = teamId;
+
+  static const _baseUrl = 'https://developerservices2.apple.com/services/QH65B2';
+  static const _clientId = 'XABBG36SBA';
+
+  /// Apple's internal feature key for the App Groups capability, as sent by
+  /// Xcode to `ios/updateAppId.action`. Cross-checked against AltSign's
+  /// `ALTFeatureAppGroups`.
+  static const appGroupsFeature = 'APG3427HIY';
+
+  final http.Client _http;
+  final LegacyAuthHeaders _authHeaders;
+  final LegacyTeamId _teamId;
+
+  /// The App Group on the team whose `identifier` is [identifier], or null.
+  ///
+  /// The protocol has no filter parameter, so the match happens here.
+  Future<AscAppGroup?> find(String identifier) async {
+    final response = await _action('ios/listApplicationGroups.action');
+    final groups = response['applicationGroupList'];
+    if (groups is! List) return null;
+    for (final entry in groups) {
+      if (entry is! Map) continue;
+      if (entry['identifier'] != identifier) continue;
+      return _fromLegacy(entry);
+    }
+    return null;
+  }
+
+  /// Registers a new App Group.
+  Future<AscAppGroup> register({
+    required String identifier,
+    required String name,
+  }) async {
+    final response = await _action('ios/addApplicationGroup.action', {
+      'identifier': identifier,
+      // Apple rejects punctuation in group names the same way it does in
+      // App ID names.
+      'name': sanitizeName(name),
+    });
+    final group = response['applicationGroup'];
+    if (group is! Map) {
+      throw const AppleError(
+        'Developer Services add App Group response is missing the group',
+      );
+    }
+    return _fromLegacy(group);
+  }
+
+  /// Turns the App Groups capability on for [appIdResourceId] and links
+  /// [appGroupResourceIds] to it.
+  ///
+  /// Both steps are required: `updateAppId.action` flips the feature flag
+  /// that makes Apple issue a `com.apple.security.application-groups`
+  /// entitlement at all, while `assignApplicationGroupToAppId.action` decides
+  /// which groups end up inside it.
+  Future<void> assign({
+    required String appIdResourceId,
+    required List<String> appGroupResourceIds,
+  }) async {
+    await _action('ios/updateAppId.action', {
+      'appIdId': appIdResourceId,
+      appGroupsFeature: true,
+    });
+    if (appGroupResourceIds.isEmpty) return;
+    await _action('ios/assignApplicationGroupToAppId.action', {
+      'appIdId': appIdResourceId,
+      'applicationGroups': appGroupResourceIds,
+    });
+  }
+
+  /// Apple's App ID and App Group names accept alphanumerics and spaces only.
+  static String sanitizeName(String name) {
+    final sanitized = name.replaceAll(RegExp('[^A-Za-z0-9 ]'), ' ').trim();
+    return sanitized.isEmpty ? 'xcross group' : sanitized;
+  }
+
+  /// A legacy group entry names the resource id `applicationGroup` and the
+  /// `group.…` string `identifier`, the opposite way round from JSON:API.
+  static AscAppGroup _fromLegacy(Map<dynamic, dynamic> entry) {
+    final id = entry['applicationGroup'];
+    final identifier = entry['identifier'];
+    if (id is! String || identifier is! String) {
+      throw const AppleError(
+        'Developer Services App Group entry is missing an identifier',
+      );
+    }
+    return AscAppGroup(
+      id: id,
+      identifier: identifier,
+      name: entry['name'] as String? ?? '',
+    );
+  }
+
+  /// Performs one `QH65B2` action.
+  ///
+  /// The protocol POSTs an XML plist, always answers HTTP 200 on the
+  /// application path, and reports failure through `resultCode` rather than a
+  /// status code. Transport-level auth failures do use real status codes.
+  Future<Map<String, Object?>> _action(
+    String action, [
+    Map<String, Object?> parameters = const {},
+  ]) async {
+    final response = await _http.post(
+      Uri.parse('$_baseUrl/$action?clientId=$_clientId'),
+      headers: {..._protocolHeaders, ...await _authHeaders()},
+      body: PropertyListSerialization.stringWithPropertyList({
+        'clientId': _clientId,
+        'protocolVersion': 'QH65B2',
+        'requestId': AnisetteState.generateUuidV4().toUpperCase(),
+        'teamId': await _teamId(),
+        ...parameters,
+      }),
+    );
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw AppleApiError(
+        response.statusCode,
+        'Developer Services $action failed (HTTP ${response.statusCode}): '
+        '${_legacyMessage(response.body) ?? response.body}',
+      );
+    }
+    final plist = GrandSlamResponse.decodePlist(
+      response.body,
+      context: 'Developer Services $action response',
+    );
+    rejectFailure(plist, action: action);
+    return plist;
+  }
+
+  static const _protocolHeaders = {
+    'Accept': 'text/x-xml-plist',
+    'Content-Type': 'text/x-xml-plist',
+    'Accept-Language': 'en-us',
+    'User-Agent': 'Xcode',
+    'X-Xcode-Version': '11.2 (11B41)',
+    'X-Apple-App-Info': 'com.apple.gs.xcode.auth',
+  };
+
+  /// The protocol reports application failures through `resultCode`, and
+  /// sends it as an int or a string depending on the error.
+  static void rejectFailure(
+    Map<String, Object?> plist, {
+    required String action,
+  }) {
+    final resultCode = switch (plist['resultCode']) {
+      final int value => value,
+      final String value => int.tryParse(value),
+      _ => null,
+    };
+    if (resultCode == null) {
+      throw AppleError(
+        'Developer Services $action response has an invalid resultCode',
+      );
+    }
+    if (resultCode != 0) {
+      final message =
+          plist['userString'] ?? plist['resultString'] ?? 'unknown error';
+      throw AppleError(
+        'Developer Services $action failed ($resultCode): $message',
+      );
+    }
+  }
+
+  /// An auth rejection still comes back as a plist, so pull the human-readable
+  /// string out rather than dumping XML at the user.
+  static String? _legacyMessage(String body) {
+    try {
+      final plist =
+          PropertyListSerialization.propertyListWithString(body) as Map;
+      final message = plist['userString'] ?? plist['resultString'];
+      return message is String && message.isNotEmpty ? message : null;
+    } on Object {
+      return null;
+    }
+  }
+}

--- a/packages/apple_developer_kit/lib/src/errors.dart
+++ b/packages/apple_developer_kit/lib/src/errors.dart
@@ -10,3 +10,24 @@ base class AppleError implements Exception {
   @override
   String toString() => message;
 }
+
+/// The signing credentials in use cannot provision App Groups at all.
+///
+/// This is a property of Apple's APIs rather than a transient failure: an App
+/// Store Connect API key has no way to create an App Group or attach one to an
+/// App ID, and a profile issued without one grants an empty
+/// `com.apple.security.application-groups` array that iOS refuses to accept a
+/// real group against. See `AscClient.findAppGroup` for the full evidence.
+///
+/// Callers should treat it as "this credential type cannot do this", not as an
+/// error to retry, and point the user at `xcross auth --apple-id`.
+final class AppGroupsUnsupported extends AppleError {
+  const AppGroupsUnsupported()
+    : super(
+        'App Groups cannot be provisioned with an App Store Connect API key: '
+        'Apple exposes no App Groups resource to API keys, and a profile '
+        'issued without a group grants an empty application-groups array that '
+        'iOS rejects. Sign in with `xcross auth --apple-id <email>` to let an '
+        'app and its extensions share data.',
+      );
+}

--- a/packages/apple_developer_kit/lib/src/signing/signing_asset.dart
+++ b/packages/apple_developer_kit/lib/src/signing/signing_asset.dart
@@ -37,6 +37,23 @@ class SigningAsset {
   final Uint8List profilePlistBytes;
   final Map<String, Object?> profile;
   final Map<String, Object?> entitlements;
+
+  /// App Groups this profile actually grants.
+  ///
+  /// Authoritative in a way the provisioning calls are not: iOS honours what
+  /// the profile says, not what xcross asked for. A profile whose App ID has
+  /// the App Groups capability enabled but no group attached carries an empty
+  /// list, and signing a real group against it makes installd reject the app
+  /// with `0xe8008015`. Callers can therefore check here whether a shared
+  /// container will actually work before promising the user one.
+  List<String> get grantedAppGroups => switch (entitlements['com.apple.security'
+      '.application-groups']) {
+    final List<Object?> groups => [
+      for (final group in groups)
+        if (group is String && group.isNotEmpty) group,
+    ],
+    _ => const [],
+  };
   final String teamIdentifier;
   final String applicationIdentifier;
   final String applicationIdentifierPrefix;

--- a/packages/apple_developer_kit/test/appstoreconnect/appstoreconnect_test.dart
+++ b/packages/apple_developer_kit/test/appstoreconnect/appstoreconnect_test.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:apple_developer_kit/src/appstoreconnect/appstoreconnect.dart';
 import 'package:apple_developer_kit/src/appstoreconnect/asc_client.dart';
 import 'package:apple_developer_kit/src/appstoreconnect/asc_models.dart';
+import 'package:apple_developer_kit/src/errors.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
@@ -162,8 +163,7 @@ void main() {
   test('keeps installing when Apple rejects the credentials', () async {
     final temp = Directory.systemTemp.createTempSync('xcross_app_groups_403');
     addTearDown(() => temp.deleteSync(recursive: true));
-    // Both backends now reach App Groups over the same legacy protocol, so a
-    // 401/403 means the session or key was refused rather than the API not
+    // A 401/403 means the session was refused rather than the API not
     // supporting the operation. It must still never cost the user the build:
     // only the shared container is lost.
     final client = _FakeProvisioningClient()
@@ -184,7 +184,31 @@ void main() {
     );
 
     expect(File(result.profilePath).existsSync(), isTrue);
-    expect(warnings, anyElement(contains('Apple rejected the credentials')));
+    expect(warnings, anyElement(contains('Apple rejected these credentials')));
+  });
+
+  test('states the API key limitation once, and still installs', () async {
+    final temp = Directory.systemTemp.createTempSync('xcross_app_groups_unsup');
+    addTearDown(() => temp.deleteSync(recursive: true));
+    // An App Store Connect API key cannot provision App Groups at all, which
+    // is a property of Apple's APIs rather than a failure to retry. The user
+    // gets one plain sentence naming the fix, and still gets their build.
+    final client = _FakeProvisioningClient()
+      ..findAppGroupFailure = const AppGroupsUnsupported();
+    final warnings = <String>[];
+
+    final result = await AscProvisioning.provisionDevelopmentIdentity(
+      client: client,
+      bundleId: 'com.example.app',
+      deviceUdids: const ['UDID'],
+      outputDir: temp.path,
+      appGroups: const ['group.com.example.Shared'],
+      onProgress: warnings.add,
+    );
+
+    expect(File(result.profilePath).existsSync(), isTrue);
+    expect(warnings, hasLength(1));
+    expect(warnings.single, contains('xcross auth --apple-id'));
   });
 
   test('installs anyway when an App Group lookup fails', () async {

--- a/packages/apple_developer_kit/test/appstoreconnect/appstoreconnect_test.dart
+++ b/packages/apple_developer_kit/test/appstoreconnect/appstoreconnect_test.dart
@@ -159,19 +159,22 @@ void main() {
     expect(warnings, anyElement(contains('App Groups')));
   });
 
-  test('explains how to add App Groups by hand when refused', () async {
+  test('keeps installing when Apple rejects the credentials', () async {
     final temp = Directory.systemTemp.createTempSync('xcross_app_groups_403');
     addTearDown(() => temp.deleteSync(recursive: true));
+    // Both backends now reach App Groups over the same legacy protocol, so a
+    // 401/403 means the session or key was refused rather than the API not
+    // supporting the operation. It must still never cost the user the build:
+    // only the shared container is lost.
     final client = _FakeProvisioningClient()
       ..assignAppGroupsFailure = const AppleApiError(
         403,
-        'The API key in use does not allow this request',
+        'Make sure a bearer token was provided, it is properly configured '
+        'and signed, and it has not expired.',
       );
     final warnings = <String>[];
 
-    // Apple answers 403 "The API key in use does not allow this request";
-    // the raw message is useless, so it becomes an actionable instruction.
-    await AscProvisioning.provisionDevelopmentIdentity(
+    final result = await AscProvisioning.provisionDevelopmentIdentity(
       client: client,
       bundleId: 'com.example.app',
       deviceUdids: const ['UDID'],
@@ -180,15 +183,15 @@ void main() {
       onProgress: warnings.add,
     );
 
-    expect(warnings, anyElement(contains('developer.apple.com')));
+    expect(File(result.profilePath).existsSync(), isTrue);
+    expect(warnings, anyElement(contains('Apple rejected the credentials')));
   });
 
-  test('installs anyway when the API has no App Groups resource', () async {
+  test('installs anyway when an App Group lookup fails', () async {
     final temp = Directory.systemTemp.createTempSync('xcross_app_groups_404');
     addTearDown(() => temp.deleteSync(recursive: true));
-    // App Store Connect exposes no /appGroups resource at all, so the very
-    // first lookup 404s. That used to escape and abort the whole install,
-    // because only the capability assignment was guarded.
+    // A lookup failure used to escape and abort the whole install, because
+    // only the capability assignment was guarded, not the lookup.
     final client = _FakeProvisioningClient()
       ..findAppGroupFailure = const AppleApiError(
         404,
@@ -207,7 +210,6 @@ void main() {
 
     expect(File(result.profilePath).existsSync(), isTrue);
     expect(warnings, anyElement(contains('App Groups')));
-    expect(warnings, anyElement(contains('developer.apple.com')));
   });
 
   test('survives a failure while registering a new App Group', () async {

--- a/packages/apple_developer_kit/test/appstoreconnect/appstoreconnect_test.dart
+++ b/packages/apple_developer_kit/test/appstoreconnect/appstoreconnect_test.dart
@@ -183,6 +183,53 @@ void main() {
     expect(warnings, anyElement(contains('developer.apple.com')));
   });
 
+  test('installs anyway when the API has no App Groups resource', () async {
+    final temp = Directory.systemTemp.createTempSync('xcross_app_groups_404');
+    addTearDown(() => temp.deleteSync(recursive: true));
+    // App Store Connect exposes no /appGroups resource at all, so the very
+    // first lookup 404s. That used to escape and abort the whole install,
+    // because only the capability assignment was guarded.
+    final client = _FakeProvisioningClient()
+      ..findAppGroupFailure = const AppleApiError(
+        404,
+        'The path provided does not match a defined resource type.',
+      );
+    final warnings = <String>[];
+
+    final result = await AscProvisioning.provisionDevelopmentIdentity(
+      client: client,
+      bundleId: 'com.example.app',
+      deviceUdids: const ['UDID'],
+      outputDir: temp.path,
+      appGroups: const ['group.com.example.Shared'],
+      onProgress: warnings.add,
+    );
+
+    expect(File(result.profilePath).existsSync(), isTrue);
+    expect(warnings, anyElement(contains('App Groups')));
+    expect(warnings, anyElement(contains('developer.apple.com')));
+  });
+
+  test('survives a failure while registering a new App Group', () async {
+    final temp = Directory.systemTemp.createTempSync('xcross_app_groups_reg');
+    addTearDown(() => temp.deleteSync(recursive: true));
+    final client = _FakeProvisioningClient()
+      ..registerAppGroupFailure = Exception('boom');
+    final warnings = <String>[];
+
+    final result = await AscProvisioning.provisionDevelopmentIdentity(
+      client: client,
+      bundleId: 'com.example.app',
+      deviceUdids: const ['UDID'],
+      outputDir: temp.path,
+      appGroups: const ['group.com.example.Shared'],
+      onProgress: warnings.add,
+    );
+
+    expect(File(result.profilePath).existsSync(), isTrue);
+    expect(warnings, anyElement(contains('App Groups')));
+  });
+
   test('revokes team certificates and reissues on create 409', () async {
     final temp = Directory.systemTemp.createTempSync('xcross_cert_409');
     addTearDown(() => temp.deleteSync(recursive: true));
@@ -311,6 +358,8 @@ class _FakeProvisioningClient implements DevelopmentProvisioningClient {
   List<String>? assignedAppGroupIds;
   String? appGroupsBundleResourceId;
   Object? assignAppGroupsFailure;
+  Object? findAppGroupFailure;
+  Object? registerAppGroupFailure;
   final teamSerials = <String, String>{};
   int certificateCreations = 0;
   String? registeredBundleName;
@@ -319,14 +368,21 @@ class _FakeProvisioningClient implements DevelopmentProvisioningClient {
   List<String>? lastProfileDeviceIds;
 
   @override
-  Future<AscAppGroup?> findAppGroup(String identifier) async =>
-      existingAppGroups[identifier];
+  Future<AscAppGroup?> findAppGroup(String identifier) async {
+    final failure = findAppGroupFailure;
+    // ignore: only_throw_errors
+    if (failure != null) throw failure;
+    return existingAppGroups[identifier];
+  }
 
   @override
   Future<AscAppGroup> registerAppGroup({
     required String identifier,
     required String name,
   }) async {
+    final failure = registerAppGroupFailure;
+    // ignore: only_throw_errors
+    if (failure != null) throw failure;
     registeredAppGroups.add(identifier);
     final group = AscAppGroup(
       id: 'group-resource-$identifier',

--- a/packages/apple_developer_kit/test/appstoreconnect/appstoreconnect_test.dart
+++ b/packages/apple_developer_kit/test/appstoreconnect/appstoreconnect_test.dart
@@ -187,12 +187,14 @@ void main() {
     expect(warnings, anyElement(contains('Apple rejected these credentials')));
   });
 
-  test('states the API key limitation once, and still installs', () async {
+  test('stays silent when the credentials simply cannot do it', () async {
     final temp = Directory.systemTemp.createTempSync('xcross_app_groups_unsup');
     addTearDown(() => temp.deleteSync(recursive: true));
-    // An App Store Connect API key cannot provision App Groups at all, which
-    // is a property of Apple's APIs rather than a failure to retry. The user
-    // gets one plain sentence naming the fix, and still gets their build.
+    // An App Store Connect API key cannot attach an App Group. That is not
+    // worth a warning here: the caller inspects the issued profile and reports
+    // what was actually granted, which also covers a group attached by other
+    // means. Warning here too would say the same thing twice, and would be
+    // wrong whenever the profile does carry a group.
     final client = _FakeProvisioningClient()
       ..findAppGroupFailure = const AppGroupsUnsupported();
     final warnings = <String>[];
@@ -207,8 +209,7 @@ void main() {
     );
 
     expect(File(result.profilePath).existsSync(), isTrue);
-    expect(warnings, hasLength(1));
-    expect(warnings.single, contains('xcross auth --apple-id'));
+    expect(warnings, isEmpty);
   });
 
   test('installs anyway when an App Group lookup fails', () async {

--- a/packages/apple_developer_kit/test/appstoreconnect/asc_client_test.dart
+++ b/packages/apple_developer_kit/test/appstoreconnect/asc_client_test.dart
@@ -1,0 +1,177 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:apple_developer_kit/src/appstoreconnect/asc_client.dart';
+import 'package:apple_developer_kit/src/appstoreconnect/asc_config.dart';
+import 'package:basic_utils/basic_utils.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late Directory tmp;
+  late AscCredentials credentials;
+
+  setUp(() async {
+    tmp = await Directory.systemTemp.createTemp('xcross_asc_client-');
+    // A throwaway EC keypair stands in for a real Apple .p8 key: these tests
+    // never reach Apple, they only check what the client sends and accepts.
+    final keyPair = CryptoUtils.generateEcKeyPair();
+    final keyFile = File('${tmp.path}/AuthKey_TESTKEY123.p8');
+    await keyFile.writeAsString(
+      CryptoUtils.encodeEcPrivateKeyToPem(keyPair.privateKey as ECPrivateKey),
+    );
+    credentials = AscCredentials(
+      issuerId: 'issuer-1234',
+      keyId: 'TESTKEY123',
+      privateKeyPath: keyFile.path,
+    );
+  });
+
+  tearDown(() => tmp.delete(recursive: true));
+
+  Map<String, dynamic> bundle(String id, String identifier) => {
+    'id': id,
+    'attributes': {'identifier': identifier, 'name': identifier},
+  };
+
+  group('findBundleId', () {
+    test('picks the exact match out of a prefix-matched page', () async {
+      // Apple treats filter[identifier] as a prefix match, so an app's query
+      // also returns its extensions. Taking the first row would sign the app
+      // with an extension's App ID.
+      final client = AscClient(
+        credentials,
+        httpClient: MockClient((request) async {
+          expect(request.url.path, '/v1/bundleIds');
+          return http.Response(
+            jsonEncode({
+              'data': [
+                bundle('EXT1', 'com.example.App.ActionExtension'),
+                bundle('APP', 'com.example.App'),
+                bundle('EXT2', 'com.example.App.Share-Extension'),
+              ],
+            }),
+            200,
+          );
+        }),
+      );
+      addTearDown(client.close);
+
+      final found = await client.findBundleId('com.example.App');
+
+      expect(found?.id, 'APP');
+      expect(found?.identifier, 'com.example.App');
+    });
+
+    test('resolves an extension id that shares the app prefix', () async {
+      final client = AscClient(
+        credentials,
+        httpClient: MockClient(
+          (_) async => http.Response(
+            jsonEncode({
+              'data': [
+                bundle('EXT1', 'com.example.App.ActionExtension'),
+                bundle('EXT2', 'com.example.App.Share-Extension'),
+              ],
+            }),
+            200,
+          ),
+        ),
+      );
+      addTearDown(client.close);
+
+      final found = await client.findBundleId(
+        'com.example.App.Share-Extension',
+      );
+
+      expect(found?.id, 'EXT2');
+    });
+
+    test('returns null when only prefix neighbours come back', () async {
+      final client = AscClient(
+        credentials,
+        httpClient: MockClient(
+          (_) async => http.Response(
+            jsonEncode({
+              'data': [bundle('EXT1', 'com.example.App.ActionExtension')],
+            }),
+            200,
+          ),
+        ),
+      );
+      addTearDown(client.close);
+
+      // Registering must not be skipped just because a longer id exists.
+      expect(await client.findBundleId('com.example.App'), isNull);
+    });
+  });
+
+  group('App Groups', () {
+    test('reports no group instead of calling a missing resource', () async {
+      var called = false;
+      final client = AscClient(
+        credentials,
+        httpClient: MockClient((_) async {
+          called = true;
+          return http.Response('{}', 404);
+        }),
+      );
+      addTearDown(client.close);
+
+      expect(await client.findAppGroup('group.com.example.Shared'), isNull);
+      expect(called, isFalse, reason: '/appGroups does not exist');
+    });
+
+    test('registering reports 404 without a round-trip', () async {
+      var called = false;
+      final client = AscClient(
+        credentials,
+        httpClient: MockClient((_) async {
+          called = true;
+          return http.Response('{}', 200);
+        }),
+      );
+      addTearDown(client.close);
+
+      await expectLater(
+        client.registerAppGroup(
+          identifier: 'group.com.example.Shared',
+          name: 'Shared',
+        ),
+        throwsA(
+          isA<AppleApiError>().having((e) => e.statusCode, 'status', 404),
+        ),
+      );
+      expect(called, isFalse);
+    });
+
+    test('enables the capability without linking group resources', () async {
+      Map<String, dynamic>? posted;
+      final client = AscClient(
+        credentials,
+        httpClient: MockClient((request) async {
+          expect(request.url.path, '/v1/bundleIdCapabilities');
+          posted = jsonDecode(request.body) as Map<String, dynamic>;
+          return http.Response(jsonEncode({'data': <String, Object>{}}), 201);
+        }),
+      );
+      addTearDown(client.close);
+
+      await client.assignAppGroups(
+        bundleIdResourceId: 'APP',
+        appGroupResourceIds: const [],
+      );
+
+      final data = posted!['data'] as Map<String, dynamic>;
+      final attributes = data['attributes'] as Map<String, dynamic>;
+      expect(attributes['capabilityType'], 'APP_GROUPS');
+      // Group ids cannot be enumerated, so no settings may be sent: Apple
+      // rejects a settings block referencing resources that do not exist.
+      expect(attributes.containsKey('settings'), isFalse);
+      final relationships = data['relationships'] as Map<String, dynamic>;
+      final bundleId = relationships['bundleId'] as Map<String, dynamic>;
+      expect((bundleId['data'] as Map)['id'], 'APP');
+    });
+  });
+}

--- a/packages/apple_developer_kit/test/appstoreconnect/asc_client_test.dart
+++ b/packages/apple_developer_kit/test/appstoreconnect/asc_client_test.dart
@@ -3,9 +3,11 @@ import 'dart:io';
 
 import 'package:apple_developer_kit/src/appstoreconnect/asc_client.dart';
 import 'package:apple_developer_kit/src/appstoreconnect/asc_config.dart';
+import 'package:apple_developer_kit/src/errors.dart';
 import 'package:basic_utils/basic_utils.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
+import 'package:propertylistserialization/propertylistserialization.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -108,70 +110,222 @@ void main() {
   });
 
   group('App Groups', () {
-    test('reports no group instead of calling a missing resource', () async {
-      var called = false;
-      final client = AscClient(
-        credentials,
-        httpClient: MockClient((_) async {
-          called = true;
-          return http.Response('{}', 404);
-        }),
-      );
-      addTearDown(client.close);
+    // App Store Connect has no App Groups resource, so the client reaches
+    // them over the legacy developerservices2 protocol, authenticated with
+    // the same API key JWT. These tests pin the host, the auth header and
+    // the team id lookup that protocol needs.
+    Map<String, dynamic> bundlePage(String seedId) => {
+      'data': [
+        {
+          'id': 'APP',
+          'attributes': {
+            'identifier': 'com.example.App',
+            'name': 'App',
+            'seedId': seedId,
+          },
+        },
+      ],
+    };
 
-      expect(await client.findAppGroup('group.com.example.Shared'), isNull);
-      expect(called, isFalse, reason: '/appGroups does not exist');
-    });
+    String legacyPlist(Map<String, Object?> body) =>
+        PropertyListSerialization.stringWithPropertyList({
+          'resultCode': 0,
+          ...body,
+        });
 
-    test('registering reports 404 without a round-trip', () async {
-      var called = false;
-      final client = AscClient(
-        credentials,
-        httpClient: MockClient((_) async {
-          called = true;
-          return http.Response('{}', 200);
-        }),
-      );
-      addTearDown(client.close);
-
-      await expectLater(
-        client.registerAppGroup(
-          identifier: 'group.com.example.Shared',
-          name: 'Shared',
-        ),
-        throwsA(
-          isA<AppleApiError>().having((e) => e.statusCode, 'status', 404),
-        ),
-      );
-      expect(called, isFalse);
-    });
-
-    test('enables the capability without linking group resources', () async {
-      Map<String, dynamic>? posted;
+    test('looks a group up on developerservices2 with the key', () async {
+      final urls = <String>[];
+      String? authorization;
       final client = AscClient(
         credentials,
         httpClient: MockClient((request) async {
-          expect(request.url.path, '/v1/bundleIdCapabilities');
-          posted = jsonDecode(request.body) as Map<String, dynamic>;
-          return http.Response(jsonEncode({'data': <String, Object>{}}), 201);
+          urls.add(request.url.toString());
+          if (request.url.host == 'api.appstoreconnect.apple.com') {
+            return http.Response(jsonEncode(bundlePage('TEAMSEED')), 200);
+          }
+          authorization = request.headers['Authorization'];
+          final body =
+              PropertyListSerialization.propertyListWithString(request.body)
+                  as Map;
+          // The legacy protocol needs the team explicitly; an API key has
+          // none of its own, so it comes from the bundle id's seedId.
+          expect(body['teamId'], 'TEAMSEED');
+          return http.Response(
+            legacyPlist({
+              'applicationGroupList': [
+                {
+                  'applicationGroup': 'GROUPID',
+                  'identifier': 'group.com.example.Shared',
+                  'name': 'Shared',
+                },
+              ],
+            }),
+            200,
+          );
+        }),
+      );
+      addTearDown(client.close);
+
+      final group = await client.findAppGroup('group.com.example.Shared');
+      expect(group?.id, 'GROUPID');
+      expect(group?.identifier, 'group.com.example.Shared');
+      expect(authorization, startsWith('Bearer '));
+      expect(
+        urls.last,
+        'https://developerservices2.apple.com/services/QH65B2/'
+        'ios/listApplicationGroups.action?clientId=XABBG36SBA',
+      );
+    });
+
+    test('caches the team id across calls', () async {
+      var seedLookups = 0;
+      final client = AscClient(
+        credentials,
+        httpClient: MockClient((request) async {
+          if (request.url.host == 'api.appstoreconnect.apple.com') {
+            seedLookups++;
+            return http.Response(jsonEncode(bundlePage('TEAMSEED')), 200);
+          }
+          return http.Response(
+            legacyPlist({'applicationGroupList': <Object>[]}),
+            200,
+          );
+        }),
+      );
+      addTearDown(client.close);
+
+      await client.findAppGroup('group.com.example.Shared');
+      await client.findAppGroup('group.com.example.Other');
+      expect(seedLookups, 1);
+    });
+
+    test('registers a group over the legacy protocol', () async {
+      final client = AscClient(
+        credentials,
+        httpClient: MockClient((request) async {
+          if (request.url.host == 'api.appstoreconnect.apple.com') {
+            return http.Response(jsonEncode(bundlePage('TEAMSEED')), 200);
+          }
+          expect(request.url.path, endsWith('addApplicationGroup.action'));
+          final body =
+              PropertyListSerialization.propertyListWithString(request.body)
+                  as Map;
+          expect(body['identifier'], 'group.com.example.Shared');
+          // Apple rejects punctuation in group names.
+          expect(body['name'], 'xcross group com example Shared');
+          return http.Response(
+            legacyPlist({
+              'applicationGroup': {
+                'applicationGroup': 'NEWID',
+                'identifier': 'group.com.example.Shared',
+                'name': 'xcross group com example Shared',
+              },
+            }),
+            200,
+          );
+        }),
+      );
+      addTearDown(client.close);
+
+      final group = await client.registerAppGroup(
+        identifier: 'group.com.example.Shared',
+        name: 'xcross group.com.example.Shared',
+      );
+      expect(group.id, 'NEWID');
+    });
+
+    test('enables the capability and links the group', () async {
+      final actions = <String>[];
+      final client = AscClient(
+        credentials,
+        httpClient: MockClient((request) async {
+          if (request.url.host == 'api.appstoreconnect.apple.com') {
+            return http.Response(jsonEncode(bundlePage('TEAMSEED')), 200);
+          }
+          final action = request.url.pathSegments.last;
+          actions.add(action);
+          final body =
+              PropertyListSerialization.propertyListWithString(request.body)
+                  as Map;
+          expect(body['appIdId'], 'APP');
+          if (action == 'updateAppId.action') {
+            // Apple's internal feature key for App Groups.
+            expect(body['APG3427HIY'], true);
+          } else {
+            expect(body['applicationGroups'], ['GROUPID']);
+          }
+          return http.Response(legacyPlist(const {}), 200);
         }),
       );
       addTearDown(client.close);
 
       await client.assignAppGroups(
         bundleIdResourceId: 'APP',
-        appGroupResourceIds: const [],
+        appGroupResourceIds: ['GROUPID'],
       );
+      // The feature flag has to come first: it is what makes Apple issue an
+      // application-groups entitlement at all.
+      expect(actions, [
+        'updateAppId.action',
+        'assignApplicationGroupToAppId.action',
+      ]);
+    });
 
-      final data = posted!['data'] as Map<String, dynamic>;
-      final attributes = data['attributes'] as Map<String, dynamic>;
-      expect(attributes['capabilityType'], 'APP_GROUPS');
-      // Group ids cannot be enumerated, so no settings may be sent: Apple
-      // rejects a settings block referencing resources that do not exist.
-      expect(attributes.containsKey('settings'), isFalse);
-      final relationships = data['relationships'] as Map<String, dynamic>;
-      final bundleId = relationships['bundleId'] as Map<String, dynamic>;
-      expect((bundleId['data'] as Map)['id'], 'APP');
+    test('surfaces a rejected key from the legacy host', () async {
+      final client = AscClient(
+        credentials,
+        httpClient: MockClient((request) async {
+          if (request.url.host == 'api.appstoreconnect.apple.com') {
+            return http.Response(jsonEncode(bundlePage('TEAMSEED')), 200);
+          }
+          // What developerservices2 really answers for an unknown key: the
+          // same text api.appstoreconnect.apple.com uses.
+          return http.Response(
+            PropertyListSerialization.stringWithPropertyList({
+              'resultCode': 403,
+              'userString':
+                  'Make sure a bearer token was provided, it is properly '
+                  'configured and signed, and it has not expired.',
+            }),
+            403,
+          );
+        }),
+      );
+      addTearDown(client.close);
+
+      await expectLater(
+        client.findAppGroup('group.com.example.Shared'),
+        throwsA(
+          isA<AppleApiError>()
+              .having((error) => error.statusCode, 'status', 403)
+              .having(
+                (error) => error.toString(),
+                'message',
+                contains('properly configured and signed'),
+              ),
+        ),
+      );
+    });
+
+    test('explains a team with no bundle ids to read a seedId from', () async {
+      final client = AscClient(
+        credentials,
+        httpClient: MockClient(
+          (_) async => http.Response(jsonEncode({'data': <Object>[]}), 200),
+        ),
+      );
+      addTearDown(client.close);
+
+      await expectLater(
+        client.findAppGroup('group.com.example.Shared'),
+        throwsA(
+          isA<AppleError>().having(
+            (error) => error.toString(),
+            'message',
+            contains('Could not determine the team id'),
+          ),
+        ),
+      );
     });
   });
 }

--- a/packages/apple_developer_kit/test/appstoreconnect/asc_client_test.dart
+++ b/packages/apple_developer_kit/test/appstoreconnect/asc_client_test.dart
@@ -7,7 +7,6 @@ import 'package:apple_developer_kit/src/errors.dart';
 import 'package:basic_utils/basic_utils.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
-import 'package:propertylistserialization/propertylistserialization.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -110,219 +109,59 @@ void main() {
   });
 
   group('App Groups', () {
-    // App Store Connect has no App Groups resource, so the client reaches
-    // them over the legacy developerservices2 protocol, authenticated with
-    // the same API key JWT. These tests pin the host, the auth header and
-    // the team id lookup that protocol needs.
-    Map<String, dynamic> bundlePage(String seedId) => {
-      'data': [
-        {
-          'id': 'APP',
-          'attributes': {
-            'identifier': 'com.example.App',
-            'name': 'App',
-            'seedId': seedId,
-          },
-        },
-      ],
-    };
-
-    String legacyPlist(Map<String, Object?> body) =>
-        PropertyListSerialization.stringWithPropertyList({
-          'resultCode': 0,
-          ...body,
-        });
-
-    test('looks a group up on developerservices2 with the key', () async {
-      final urls = <String>[];
-      String? authorization;
+    // App Groups are unreachable with an API key, and this is a property of
+    // Apple's APIs rather than a transient failure. Each route was checked
+    // against a live key: api.appstoreconnect.apple.com 404s /appGroups, the
+    // APP_GROUPS capability cannot name a group, the resulting profile grants
+    // an empty application-groups array, and developerservices2 (which does
+    // expose App Groups) refuses API keys outright. So the client must report
+    // the limitation without spending a request on it.
+    test('reports App Groups as unsupported without any request', () async {
+      var called = false;
       final client = AscClient(
         credentials,
-        httpClient: MockClient((request) async {
-          urls.add(request.url.toString());
-          if (request.url.host == 'api.appstoreconnect.apple.com') {
-            return http.Response(jsonEncode(bundlePage('TEAMSEED')), 200);
-          }
-          authorization = request.headers['Authorization'];
-          final body =
-              PropertyListSerialization.propertyListWithString(request.body)
-                  as Map;
-          // The legacy protocol needs the team explicitly; an API key has
-          // none of its own, so it comes from the bundle id's seedId.
-          expect(body['teamId'], 'TEAMSEED');
-          return http.Response(
-            legacyPlist({
-              'applicationGroupList': [
-                {
-                  'applicationGroup': 'GROUPID',
-                  'identifier': 'group.com.example.Shared',
-                  'name': 'Shared',
-                },
-              ],
-            }),
-            200,
-          );
-        }),
-      );
-      addTearDown(client.close);
-
-      final group = await client.findAppGroup('group.com.example.Shared');
-      expect(group?.id, 'GROUPID');
-      expect(group?.identifier, 'group.com.example.Shared');
-      expect(authorization, startsWith('Bearer '));
-      expect(
-        urls.last,
-        'https://developerservices2.apple.com/services/QH65B2/'
-        'ios/listApplicationGroups.action?clientId=XABBG36SBA',
-      );
-    });
-
-    test('caches the team id across calls', () async {
-      var seedLookups = 0;
-      final client = AscClient(
-        credentials,
-        httpClient: MockClient((request) async {
-          if (request.url.host == 'api.appstoreconnect.apple.com') {
-            seedLookups++;
-            return http.Response(jsonEncode(bundlePage('TEAMSEED')), 200);
-          }
-          return http.Response(
-            legacyPlist({'applicationGroupList': <Object>[]}),
-            200,
-          );
-        }),
-      );
-      addTearDown(client.close);
-
-      await client.findAppGroup('group.com.example.Shared');
-      await client.findAppGroup('group.com.example.Other');
-      expect(seedLookups, 1);
-    });
-
-    test('registers a group over the legacy protocol', () async {
-      final client = AscClient(
-        credentials,
-        httpClient: MockClient((request) async {
-          if (request.url.host == 'api.appstoreconnect.apple.com') {
-            return http.Response(jsonEncode(bundlePage('TEAMSEED')), 200);
-          }
-          expect(request.url.path, endsWith('addApplicationGroup.action'));
-          final body =
-              PropertyListSerialization.propertyListWithString(request.body)
-                  as Map;
-          expect(body['identifier'], 'group.com.example.Shared');
-          // Apple rejects punctuation in group names.
-          expect(body['name'], 'xcross group com example Shared');
-          return http.Response(
-            legacyPlist({
-              'applicationGroup': {
-                'applicationGroup': 'NEWID',
-                'identifier': 'group.com.example.Shared',
-                'name': 'xcross group com example Shared',
-              },
-            }),
-            200,
-          );
-        }),
-      );
-      addTearDown(client.close);
-
-      final group = await client.registerAppGroup(
-        identifier: 'group.com.example.Shared',
-        name: 'xcross group.com.example.Shared',
-      );
-      expect(group.id, 'NEWID');
-    });
-
-    test('enables the capability and links the group', () async {
-      final actions = <String>[];
-      final client = AscClient(
-        credentials,
-        httpClient: MockClient((request) async {
-          if (request.url.host == 'api.appstoreconnect.apple.com') {
-            return http.Response(jsonEncode(bundlePage('TEAMSEED')), 200);
-          }
-          final action = request.url.pathSegments.last;
-          actions.add(action);
-          final body =
-              PropertyListSerialization.propertyListWithString(request.body)
-                  as Map;
-          expect(body['appIdId'], 'APP');
-          if (action == 'updateAppId.action') {
-            // Apple's internal feature key for App Groups.
-            expect(body['APG3427HIY'], true);
-          } else {
-            expect(body['applicationGroups'], ['GROUPID']);
-          }
-          return http.Response(legacyPlist(const {}), 200);
-        }),
-      );
-      addTearDown(client.close);
-
-      await client.assignAppGroups(
-        bundleIdResourceId: 'APP',
-        appGroupResourceIds: ['GROUPID'],
-      );
-      // The feature flag has to come first: it is what makes Apple issue an
-      // application-groups entitlement at all.
-      expect(actions, [
-        'updateAppId.action',
-        'assignApplicationGroupToAppId.action',
-      ]);
-    });
-
-    test('surfaces a rejected key from the legacy host', () async {
-      final client = AscClient(
-        credentials,
-        httpClient: MockClient((request) async {
-          if (request.url.host == 'api.appstoreconnect.apple.com') {
-            return http.Response(jsonEncode(bundlePage('TEAMSEED')), 200);
-          }
-          // What developerservices2 really answers for an unknown key: the
-          // same text api.appstoreconnect.apple.com uses.
-          return http.Response(
-            PropertyListSerialization.stringWithPropertyList({
-              'resultCode': 403,
-              'userString':
-                  'Make sure a bearer token was provided, it is properly '
-                  'configured and signed, and it has not expired.',
-            }),
-            403,
-          );
+        httpClient: MockClient((_) async {
+          called = true;
+          return http.Response('{}', 200);
         }),
       );
       addTearDown(client.close);
 
       await expectLater(
         client.findAppGroup('group.com.example.Shared'),
-        throwsA(
-          isA<AppleApiError>()
-              .having((error) => error.statusCode, 'status', 403)
-              .having(
-                (error) => error.toString(),
-                'message',
-                contains('properly configured and signed'),
-              ),
-        ),
+        throwsA(isA<AppGroupsUnsupported>()),
       );
+      await expectLater(
+        client.registerAppGroup(
+          identifier: 'group.com.example.Shared',
+          name: 'Shared',
+        ),
+        throwsA(isA<AppGroupsUnsupported>()),
+      );
+      await expectLater(
+        client.assignAppGroups(
+          bundleIdResourceId: 'APP',
+          appGroupResourceIds: const ['GROUP'],
+        ),
+        throwsA(isA<AppGroupsUnsupported>()),
+      );
+      expect(called, isFalse, reason: 'no API can satisfy this');
     });
 
-    test('explains a team with no bundle ids to read a seedId from', () async {
+    test('names the Apple ID sign-in that does work', () async {
       final client = AscClient(
         credentials,
-        httpClient: MockClient(
-          (_) async => http.Response(jsonEncode({'data': <Object>[]}), 200),
-        ),
+        httpClient: MockClient((_) async => http.Response('{}', 200)),
       );
       addTearDown(client.close);
 
       await expectLater(
         client.findAppGroup('group.com.example.Shared'),
         throwsA(
-          isA<AppleError>().having(
+          isA<AppGroupsUnsupported>().having(
             (error) => error.toString(),
             'message',
-            contains('Could not determine the team id'),
+            contains('xcross auth --apple-id'),
           ),
         ),
       );

--- a/packages/apple_developer_kit/test/appstoreconnect/developer_services_client_test.dart
+++ b/packages/apple_developer_kit/test/appstoreconnect/developer_services_client_test.dart
@@ -273,6 +273,214 @@ void main() {
     });
   });
 
+  group('DeveloperServicesClient App Groups', () {
+    test('looks a group up over the legacy plist protocol', () async {
+      final client = DeveloperServicesClient(
+        token: _token(),
+        teamId: 'TEAM',
+        fetchAnisetteHeaders: () async => {'X-Apple-I-MD': 'fresh'},
+        httpClient: MockClient((request) async {
+          expect(
+            request.url.toString(),
+            'https://developerservices2.apple.com/services/QH65B2/'
+            'ios/listApplicationGroups.action?clientId=XABBG36SBA',
+          );
+          expect(request.headers['X-Apple-I-MD'], 'fresh');
+          final body =
+              PropertyListSerialization.propertyListWithString(request.body)
+                  as Map;
+          expect(body['teamId'], 'TEAM');
+          expect(body['protocolVersion'], 'QH65B2');
+          return http.Response(
+            PropertyListSerialization.stringWithPropertyList({
+              'resultCode': 0,
+              'applicationGroupList': [
+                {
+                  'applicationGroup': 'OTHERID',
+                  'identifier': 'group.com.example.Other',
+                  'name': 'Other',
+                },
+                {
+                  'applicationGroup': 'GROUPID',
+                  'identifier': 'group.com.example.Shared',
+                  'name': 'Shared',
+                },
+              ],
+            }),
+            200,
+          );
+        }),
+      );
+
+      final group = await client.findAppGroup('group.com.example.Shared');
+      // The legacy protocol swaps the two names: the resource id arrives as
+      // `applicationGroup` and the `group.…` string as `identifier`.
+      expect(group?.id, 'GROUPID');
+      expect(group?.identifier, 'group.com.example.Shared');
+      client.close();
+    });
+
+    test('reports no group when the team has none matching', () async {
+      final client = DeveloperServicesClient(
+        token: _token(),
+        teamId: 'TEAM',
+        fetchAnisetteHeaders: () async => {},
+        httpClient: MockClient(
+          (_) async => http.Response(
+            PropertyListSerialization.stringWithPropertyList({
+              'resultCode': 0,
+              'applicationGroupList': <Object>[],
+            }),
+            200,
+          ),
+        ),
+      );
+
+      expect(await client.findAppGroup('group.com.example.Shared'), isNull);
+      client.close();
+    });
+
+    test('registers a group with a punctuation-free name', () async {
+      final client = DeveloperServicesClient(
+        token: _token(),
+        teamId: 'TEAM',
+        fetchAnisetteHeaders: () async => {},
+        httpClient: MockClient((request) async {
+          expect(
+            request.url.toString(),
+            'https://developerservices2.apple.com/services/QH65B2/'
+            'ios/addApplicationGroup.action?clientId=XABBG36SBA',
+          );
+          final body =
+              PropertyListSerialization.propertyListWithString(request.body)
+                  as Map;
+          expect(body['identifier'], 'group.com.example.Shared');
+          // Apple rejects punctuation in group names.
+          expect(body['name'], 'xcross group com example Shared');
+          return http.Response(
+            PropertyListSerialization.stringWithPropertyList({
+              'resultCode': 0,
+              'applicationGroup': {
+                'applicationGroup': 'NEWID',
+                'identifier': 'group.com.example.Shared',
+                'name': 'xcross group com example Shared',
+              },
+            }),
+            200,
+          );
+        }),
+      );
+
+      final group = await client.registerAppGroup(
+        identifier: 'group.com.example.Shared',
+        name: 'xcross group.com.example.Shared',
+      );
+      expect(group.id, 'NEWID');
+      client.close();
+    });
+
+    test('enables the capability and links the groups', () async {
+      final actions = <String>[];
+      final client = DeveloperServicesClient(
+        token: _token(),
+        teamId: 'TEAM',
+        fetchAnisetteHeaders: () async => {},
+        httpClient: MockClient((request) async {
+          final action = request.url.pathSegments.last;
+          actions.add(action);
+          final body =
+              PropertyListSerialization.propertyListWithString(request.body)
+                  as Map;
+          expect(body['appIdId'], 'APPID');
+          if (action == 'updateAppId.action') {
+            // Apple's internal feature key for App Groups.
+            expect(body['APG3427HIY'], true);
+          } else {
+            expect(body['applicationGroups'], ['GROUPID']);
+          }
+          return http.Response(
+            PropertyListSerialization.stringWithPropertyList({
+              'resultCode': 0,
+            }),
+            200,
+          );
+        }),
+      );
+
+      await client.assignAppGroups(
+        bundleIdResourceId: 'APPID',
+        appGroupResourceIds: ['GROUPID'],
+      );
+      // Enabling the feature must come first: it is what makes Apple issue an
+      // application-groups entitlement at all.
+      expect(actions, [
+        'updateAppId.action',
+        'assignApplicationGroupToAppId.action',
+      ]);
+      client.close();
+    });
+
+    test('only enables the capability when no groups resolved', () async {
+      final actions = <String>[];
+      final client = DeveloperServicesClient(
+        token: _token(),
+        teamId: 'TEAM',
+        fetchAnisetteHeaders: () async => {},
+        httpClient: MockClient((request) async {
+          actions.add(request.url.pathSegments.last);
+          return http.Response(
+            PropertyListSerialization.stringWithPropertyList({
+              'resultCode': 0,
+            }),
+            200,
+          );
+        }),
+      );
+
+      await client.assignAppGroups(
+        bundleIdResourceId: 'APPID',
+        appGroupResourceIds: const [],
+      );
+      expect(actions, ['updateAppId.action']);
+      client.close();
+    });
+
+    test('surfaces a legacy resultCode failure', () async {
+      final client = DeveloperServicesClient(
+        token: _token(),
+        teamId: 'TEAM',
+        fetchAnisetteHeaders: () async => {},
+        httpClient: MockClient(
+          (_) async => http.Response(
+            PropertyListSerialization.stringWithPropertyList({
+              'resultCode': 9401,
+              'userString': 'App Group unavailable',
+            }),
+            200,
+          ),
+        ),
+      );
+
+      await expectLater(
+        client.registerAppGroup(
+          identifier: 'group.com.example.Shared',
+          name: 'Shared',
+        ),
+        throwsA(
+          isA<AppleError>().having(
+            (error) => error.toString(),
+            'message',
+            allOf(
+              contains('addApplicationGroup.action'),
+              contains('App Group unavailable'),
+            ),
+          ),
+        ),
+      );
+      client.close();
+    });
+  });
+
   group('DeveloperServicesClient.listTeams', () {
     test('sends legacy plist request and parses teams', () async {
       var anisetteCalls = 0;

--- a/packages/apple_developer_kit/test/signing/signing_asset_test.dart
+++ b/packages/apple_developer_kit/test/signing/signing_asset_test.dart
@@ -70,6 +70,75 @@ void main() {
     expect(asset.certificateCommonName, 'xcross Test Developer');
   });
 
+  group('grantedAppGroups', () {
+    // Only the profile decides what iOS accepts. An App ID with the App
+    // Groups capability enabled but no group attached yields an empty array,
+    // and signing a real group against that makes installd reject the app
+    // with 0xe8008015 — so "capability enabled" must never be mistaken for
+    // "group available".
+    test('reads the groups the profile actually grants', () async {
+      final paths = await _writeFixture(
+        temporaryDirectory,
+        'groups-granted',
+        privateKeyPem: privateKeyPem,
+        certificatePem: certificatePem,
+        developerCertificates: [certificateDer],
+        appGroups: const ['group.dev.xcross.shared'],
+      );
+
+      final asset = await SigningAsset.load(
+        privateKeyPemPath: paths.key,
+        certificatePemPath: paths.certificate,
+        provisioningProfilePath: paths.profile,
+        now: now,
+        trustedRootCertificates: [certificateDer],
+      );
+
+      expect(asset.grantedAppGroups, ['group.dev.xcross.shared']);
+    });
+
+    test('treats an empty array as no group', () async {
+      final paths = await _writeFixture(
+        temporaryDirectory,
+        'groups-empty',
+        privateKeyPem: privateKeyPem,
+        certificatePem: certificatePem,
+        developerCertificates: [certificateDer],
+        appGroups: const [],
+      );
+
+      final asset = await SigningAsset.load(
+        privateKeyPemPath: paths.key,
+        certificatePemPath: paths.certificate,
+        provisioningProfilePath: paths.profile,
+        now: now,
+        trustedRootCertificates: [certificateDer],
+      );
+
+      expect(asset.grantedAppGroups, isEmpty);
+    });
+
+    test('treats a missing entitlement as no group', () async {
+      final paths = await _writeFixture(
+        temporaryDirectory,
+        'groups-absent',
+        privateKeyPem: privateKeyPem,
+        certificatePem: certificatePem,
+        developerCertificates: [certificateDer],
+      );
+
+      final asset = await SigningAsset.load(
+        privateKeyPemPath: paths.key,
+        certificatePemPath: paths.certificate,
+        provisioningProfilePath: paths.profile,
+        now: now,
+        trustedRootCertificates: [certificateDer],
+      );
+
+      expect(asset.grantedAppGroups, isEmpty);
+    });
+  });
+
   test('loads a binary profile plist', () async {
     final paths = await _writeFixture(
       temporaryDirectory,
@@ -567,6 +636,7 @@ Future<({String key, String certificate, String profile})> _writeFixture(
   DateTime? expirationDate,
   bool binaryPlist = false,
   Uint8List? profileCmsOverride,
+  List<String>? appGroups,
 }) async {
   final directory = Directory('${root.path}/$name')..createSync();
   final keyPath = '${directory.path}/key.pem';
@@ -584,6 +654,8 @@ Future<({String key, String certificate, String profile})> _writeFixture(
     'Entitlements': <String, Object>{
       'application-identifier': 'TESTTEAM123.dev.xcross.test',
       'get-task-allow': true,
+      if (appGroups != null)
+        'com.apple.security.application-groups': appGroups,
     },
     'DeveloperCertificates': [
       for (final certificate in developerCertificates)

--- a/packages/xcross/CHANGELOG.md
+++ b/packages/xcross/CHANGELOG.md
@@ -25,16 +25,22 @@
   App Groups are reached over the pre-JSON `QH65B2` protocol Xcode itself
   uses, because they have no modern API at all: Apple's App Store Connect
   OpenAPI specification declares 966 paths and none mentions App Groups.
-- **App Groups require an Apple ID session.** An App Store Connect API key
-  cannot provision them, and xcross now says so in one clear sentence instead
-  of failing obscurely. Verified against a live key: `/v1/appGroups` 404s, the
-  `APP_GROUPS` capability can be enabled but not pointed at a group
-  (`settings[].key` accepts only `ICLOUD_VERSION`,
-  `DATA_PROTECTION_PERMISSION_LEVEL`, `APPLE_ID_AUTH_APP_CONSENT`), the
-  resulting profile grants an empty `application-groups` array, and signing a
-  real group against it is refused by iOS with `0xe8008015`.
-  developerservices2 does expose App Groups but rejects API keys under every
-  JWT audience tried. Everything else about an API key build is unaffected.
+- Take the App Group from the **issued provisioning profile** rather than
+  assuming the request succeeded. Only the profile decides what iOS accepts,
+  so this both avoids promising a container that does not exist and picks up a
+  group attached by any other means. Signing with an ungranted group is what
+  makes iOS refuse an install with `0xe8008015`.
+- **App Groups with an App Store Connect API key.** Apple exposes no App
+  Groups API to keys, so xcross cannot create the group, but it can now use
+  one you attached yourself: add the group to your App IDs in Xcode or at
+  developer.apple.com and pass `XCROSS_APP_GROUP=group.your.id`, which skips
+  the per-account rewrite. Verified against a live key that no route exists to
+  create one: `/v1/appGroups` 404s, the `APP_GROUPS` capability enables but
+  cannot name a group (`settings[].key` accepts only `ICLOUD_VERSION`,
+  `DATA_PROTECTION_PERMISSION_LEVEL`, `APPLE_ID_AUTH_APP_CONSENT`, on POST and
+  PATCH alike), a `group.` identifier registers as an App ID but cannot be
+  linked, and the developerservices2/portal hosts that do expose App Groups
+  reject API keys under every audience tried.
 - Warnings that describe an account-wide condition are printed once per run
   rather than once per App ID (an app with two extensions provisions three).
 

--- a/packages/xcross/CHANGELOG.md
+++ b/packages/xcross/CHANGELOG.md
@@ -22,14 +22,21 @@
   developer.apple.com. Without the shared container a share extension can
   hand nothing back to the app, which is the whole point of
   `receive_sharing_intent`. (#23)
-- This works with **both** credential types. App Groups have no modern API at
-  all (Apple's App Store Connect OpenAPI spec declares 966 paths and none
-  mentions them; `CapabilitySetting.key` has no `APP_GROUP_IDENTIFIERS`), so
-  xcross reaches them over the pre-JSON `QH65B2` protocol Xcode itself uses.
-  That protocol authenticates with an Apple ID session *or* an ordinary
-  `Authorization: Bearer` App Store Connect API key JWT, and returns the same
-  resource ids the JSON:API does. An API key carries no team id, so xcross
-  reads one from a bundle id's `seedId` and caches it.
+  App Groups are reached over the pre-JSON `QH65B2` protocol Xcode itself
+  uses, because they have no modern API at all: Apple's App Store Connect
+  OpenAPI specification declares 966 paths and none mentions App Groups.
+- **App Groups require an Apple ID session.** An App Store Connect API key
+  cannot provision them, and xcross now says so in one clear sentence instead
+  of failing obscurely. Verified against a live key: `/v1/appGroups` 404s, the
+  `APP_GROUPS` capability can be enabled but not pointed at a group
+  (`settings[].key` accepts only `ICLOUD_VERSION`,
+  `DATA_PROTECTION_PERMISSION_LEVEL`, `APPLE_ID_AUTH_APP_CONSENT`), the
+  resulting profile grants an empty `application-groups` array, and signing a
+  real group against it is refused by iOS with `0xe8008015`.
+  developerservices2 does expose App Groups but rejects API keys under every
+  JWT audience tried. Everything else about an API key build is unaffected.
+- Warnings that describe an account-wide condition are printed once per run
+  rather than once per App ID (an app with two extensions provisions three).
 
 ## 1.1.1
 

--- a/packages/xcross/CHANGELOG.md
+++ b/packages/xcross/CHANGELOG.md
@@ -19,12 +19,17 @@
   account (`group.XCR-<TEAM>.…`) because App Group ids are globally unique,
   and enable the App Groups capability on every App ID automatically, so the
   app and its extensions share a container with no manual step on
-  developer.apple.com. App Groups are reached over the pre-JSON `QH65B2`
-  protocol Xcode itself uses: the JSON:API surface refuses capability changes
-  with `403 The API key in use does not allow this request`, and App Store
-  Connect exposes no App Groups resource at all. Without the shared container
-  a share extension can hand nothing back to the app, which is the whole
-  point of `receive_sharing_intent`. (#23)
+  developer.apple.com. Without the shared container a share extension can
+  hand nothing back to the app, which is the whole point of
+  `receive_sharing_intent`. (#23)
+- This works with **both** credential types. App Groups have no modern API at
+  all (Apple's App Store Connect OpenAPI spec declares 966 paths and none
+  mentions them; `CapabilitySetting.key` has no `APP_GROUP_IDENTIFIERS`), so
+  xcross reaches them over the pre-JSON `QH65B2` protocol Xcode itself uses.
+  That protocol authenticates with an Apple ID session *or* an ordinary
+  `Authorization: Bearer` App Store Connect API key JWT, and returns the same
+  resource ids the JSON:API does. An API key carries no team id, so xcross
+  reads one from a bundle id's `seedId` and caches it.
 
 ## 1.1.1
 

--- a/packages/xcross/CHANGELOG.md
+++ b/packages/xcross/CHANGELOG.md
@@ -16,10 +16,15 @@
   their version string. Embedded extensions inherit the app's versions, which
   iOS requires them to match.
 - Register App Groups declared by an app or its extensions, qualified per
-  account (`group.XCR-<TEAM>.…`) because App Group ids are globally unique.
-  Enabling the capability on the App IDs is still a manual step on
-  developer.apple.com; xcross reuses an existing group, so the next run picks
-  it up.
+  account (`group.XCR-<TEAM>.…`) because App Group ids are globally unique,
+  and enable the App Groups capability on every App ID automatically, so the
+  app and its extensions share a container with no manual step on
+  developer.apple.com. App Groups are reached over the pre-JSON `QH65B2`
+  protocol Xcode itself uses: the JSON:API surface refuses capability changes
+  with `403 The API key in use does not allow this request`, and App Store
+  Connect exposes no App Groups resource at all. Without the shared container
+  a share extension can hand nothing back to the app, which is the whole
+  point of `receive_sharing_intent`. (#23)
 
 ## 1.1.1
 

--- a/packages/xcross/lib/src/device/device_backend.dart
+++ b/packages/xcross/lib/src/device/device_backend.dart
@@ -72,6 +72,17 @@ final class NativeBackend implements DeviceBackend {
           'App ID',
           '$bundleId ${Log.ansi.subtle('→')} $signedBundleId',
         );
+        // Custom URL schemes are conventionally derived from the bundle id
+        // (`ShareMedia-<bundle id>`), and an extension builds the URL it
+        // opens from its *own* qualified host id at runtime. Leaving the
+        // app's declared scheme on the unqualified id means nothing is
+        // registered to handle that URL, so the hand-off back into the app
+        // silently does nothing.
+        await _rewriteUrlSchemes(
+          appOrIpaPath,
+          from: bundleId,
+          to: signedBundleId,
+        );
       }
       // Embedded extensions must be renamed under the qualified app id and
       // provisioned in their own right before the app can be signed.
@@ -381,6 +392,23 @@ final class NativeBackend implements DeviceBackend {
       bundleId,
     );
     await plist.writeAsString(updated);
+  }
+
+  /// Re-point `CFBundleURLSchemes` entries that embed the unqualified bundle
+  /// id at the qualified one.
+  ///
+  /// Only schemes containing [from] are touched, so unrelated schemes (OAuth
+  /// callbacks, `fb<app-id>`, deep links) are left exactly as declared.
+  static Future<void> _rewriteUrlSchemes(
+    String appPath, {
+    required String from,
+    required String to,
+  }) async {
+    final plist = File(p.join(appPath, 'Info.plist'));
+    if (!plist.existsSync()) return;
+    final xml = await plist.readAsString();
+    final rewritten = InfoPlist.rewriteUrlSchemes(xml, from: from, to: to);
+    if (rewritten != xml) await plist.writeAsString(rewritten);
   }
 
   static AnisetteProvider _anisetteForSession(GrandSlamSession session) {

--- a/packages/xcross/lib/src/device/device_backend.dart
+++ b/packages/xcross/lib/src/device/device_backend.dart
@@ -34,6 +34,18 @@ final class NativeBackend implements DeviceBackend {
 
   final PymdDeviceResolver _resolver;
 
+  /// Warnings already shown this install.
+  ///
+  /// Provisioning runs once per App ID (the app plus one per extension), so a
+  /// condition that is really a property of the account — App Groups being
+  /// unavailable to API keys, say — would otherwise be printed three times in
+  /// a row.
+  final Set<String> _warned = {};
+
+  void _warnOnce(String message) {
+    if (_warned.add(message)) Log.logWarn(message);
+  }
+
   @override
   Future<Device> resolveDevice({
     required DeviceSearchMode mode,
@@ -121,7 +133,7 @@ final class NativeBackend implements DeviceBackend {
         outputDir: outputDir,
         identityDir: signing.identityDir,
         appGroups: appGroups,
-        onProgress: Log.logWarn,
+        onProgress: _warnOnce,
       );
       final asset = await SigningAsset.load(
         privateKeyPemPath: identity.privateKeyPemPath,
@@ -339,7 +351,7 @@ final class NativeBackend implements DeviceBackend {
   /// Each extension is a separate App ID on the portal, so it gets its own
   /// profile. Free Apple developer accounts cap App IDs, hence the explicit
   /// hint when the portal refuses one.
-  static Future<Map<String, SigningAsset>> _provisionExtensions(
+  Future<Map<String, SigningAsset>> _provisionExtensions(
     List<EmbeddedExtension> extensions, {
     required SigningSession signing,
     required String udid,
@@ -360,7 +372,7 @@ final class NativeBackend implements DeviceBackend {
           outputDir: p.join(profilesDir, extensionBundleId),
           identityDir: signing.identityDir,
           appGroups: appGroups,
-          onProgress: Log.logWarn,
+          onProgress: _warnOnce,
         );
         assets[extensionBundleId] = await SigningAsset.load(
           privateKeyPemPath: identity.privateKeyPemPath,

--- a/packages/xcross/lib/src/device/device_backend.dart
+++ b/packages/xcross/lib/src/device/device_backend.dart
@@ -105,27 +105,30 @@ final class NativeBackend implements DeviceBackend {
       );
       // The app and its extensions must share the same App Groups, or the
       // extension has no way to hand data back to the app.
-      // App Group ids are globally unique across all developers, so the
-      // project's literal group is usually taken. Qualify it per account the
-      // same way the App ID is.
-      final appGroups =
+      final declaredGroups =
           {
-                ...AppExtensionEntitlements.appGroupsOf(appOrIpaPath),
-                for (final extension in extensions) ...extension.appGroups,
-              }
-              .map(
-                (group) => ProvisioningIdentifiers.qualifyAppGroup(
-                  group,
-                  signing.identityId,
-                ),
-              )
-              .toList()
+            ...AppExtensionEntitlements.appGroupsOf(appOrIpaPath),
+            for (final extension in extensions) ...extension.appGroups,
+          }.toList()
             ..sort();
-      // The app and extension read the group name back at runtime from the
-      // AppGroupId Info.plist key, so it has to be rewritten to match.
-      if (appGroups.isNotEmpty) {
-        await _rewriteAppGroupId(appOrIpaPath, appGroups.first);
-      }
+      // App Group ids are globally unique across all developers, so a
+      // project's literal `group.com.example.Shared` is usually already
+      // registered to somebody else and xcross qualifies it per account.
+      //
+      // XCROSS_APP_GROUP opts out of that. It names a group the account
+      // already owns, which is the only way an App Store Connect API key can
+      // get one: keys cannot create or attach App Groups, but they do issue
+      // profiles that carry a group attached by other means. Set it to a
+      // group you added to these App IDs in Xcode or at developer.apple.com
+      // and the whole share flow works on an API key.
+      final override = Platform.environment['XCROSS_APP_GROUP']?.trim();
+      final appGroups = switch (override) {
+        final String group when group.isNotEmpty => [group],
+        _ => [
+          for (final group in declaredGroups)
+            ProvisioningIdentifiers.qualifyAppGroup(group, signing.identityId),
+        ],
+      };
       final identity = await AscProvisioning.provisionDevelopmentIdentity(
         client: signing.client,
         bundleId: signedBundleId,
@@ -147,6 +150,36 @@ final class NativeBackend implements DeviceBackend {
         profilesDir: profilesDir,
         appGroups: appGroups,
       );
+      // Trust the profile over our own request. Provisioning may have failed
+      // to attach a group (an API key cannot attach one at all), and it may
+      // equally have granted a group that was attached by other means under a
+      // name we never asked for. Only the profile decides what iOS will
+      // accept, so the runtime `AppGroupId` is taken from it.
+      final granted = asset.grantedAppGroups;
+      if (granted.isNotEmpty) {
+        await _rewriteAppGroupId(appOrIpaPath, granted.first);
+        // Each extension is signed with its own profile, so a group the app
+        // has but an extension lacks would silently break the hand-off at
+        // runtime rather than at install time.
+        for (final entry in extensionAssets.entries) {
+          if (entry.value.grantedAppGroups.contains(granted.first)) continue;
+          _warnOnce(
+            '"${entry.key}" is not provisioned for ${granted.first}, so it '
+            'cannot share data with the app. Re-run to re-issue its profile, '
+            'or add the group to that App ID at developer.apple.com.',
+          );
+        }
+      } else if (appGroups.isNotEmpty) {
+        _warnOnce(
+          'No App Group is provisioned, so the app and its extensions cannot '
+          'share data. Everything else still installs and runs.\n'
+          '  Apple exposes no App Groups API to App Store Connect keys. Add a '
+          'group to these App IDs in Xcode or at developer.apple.com, then '
+          'set XCROSS_APP_GROUP=<group.your.id> to use it, or sign in with '
+          '`xcross auth --apple-id <email>` and xcross will do it all for '
+          'you.',
+        );
+      }
       await Log.logStep(
         'Signing app',
         () => BundleSigner(

--- a/packages/xcross/lib/src/flutter/build/app_extension_builder.dart
+++ b/packages/xcross/lib/src/flutter/build/app_extension_builder.dart
@@ -132,6 +132,7 @@ abstract final class AppExtensionBuilder {
       pluginsLibrary: pluginsLibrary,
       pluginModulesDir: pluginModulesDir,
       moduleCache: p.join(outputDir, '.module-cache'),
+      moduleName: extension.moduleName,
     );
 
     await _writeInfoPlist(
@@ -153,6 +154,7 @@ abstract final class AppExtensionBuilder {
     required IosDeploymentTarget deploymentTarget,
     required String flutterXcframework,
     required String moduleCache,
+    required String moduleName,
     String? pluginsLibrary,
     String? pluginModulesDir,
   }) async {
@@ -171,6 +173,7 @@ abstract final class AppExtensionBuilder {
       deploymentTarget: deploymentTarget,
       flutterSlice: flutterSlice,
       moduleCache: moduleCache,
+      moduleName: moduleName,
       ld64lld: await DarwinSdk.resolveLd64Lld(sdk),
       sdkVersion: _sdkVersion(iosSdk) ?? '26.5',
       pluginsLibrary: pluginsLibrary,
@@ -209,6 +212,7 @@ abstract final class AppExtensionBuilder {
     required String moduleCache,
     required String ld64lld,
     required String sdkVersion,
+    required String moduleName,
     String? clangBuiltins,
     String? compilerRtIos,
     String? pluginsLibrary,
@@ -218,6 +222,14 @@ abstract final class AppExtensionBuilder {
     iosSdk,
     '-target',
     deploymentTarget.buildTriple,
+    // Without this swiftc infers the module name from the output file, and
+    // falls back to `main` whenever that is not a valid Swift identifier —
+    // which is exactly the case for a target named `Share Extension`. The
+    // principal class would then really be `main.ShareViewController` while
+    // the Info.plist names `Share_Extension.ShareViewController`, so iOS
+    // fails to instantiate it and the extension shows a black screen.
+    '-module-name',
+    moduleName,
     // Without the Darwin SDK's own Swift resources the host toolchain tries
     // to rebuild the SDK's `Swift.swiftmodule` from its .swiftinterface and
     // fails ("no such module 'SwiftShims'" / SDK-compiler version mismatch).

--- a/packages/xcross/lib/src/flutter/build/app_extension_builder.dart
+++ b/packages/xcross/lib/src/flutter/build/app_extension_builder.dart
@@ -140,7 +140,7 @@ abstract final class AppExtensionBuilder {
       deploymentTarget: target,
       versions: versions,
     );
-    await _copyResources(extension: extension, bundleDir: bundleDir);
+    await copyResources(extension: extension, bundleDir: bundleDir);
 
     return BuiltAppExtension(extension: extension, bundlePath: bundleDir);
   }
@@ -427,19 +427,24 @@ abstract final class AppExtensionBuilder {
   /// only, so uncompiled `.storyboard`/`.xcassets` inputs are skipped with a
   /// warning rather than shipped in a form iOS cannot read. A precompiled
   /// `.storyboardc`/`.car` sitting next to the source is used when present.
-  static Future<void> _copyResources({
+  @visibleForTesting
+  static Future<void> copyResources({
     required IosAppExtension extension,
     required String bundleDir,
   }) async {
     for (final resource in extension.resources) {
       final name = p.basename(resource);
+      // Localized resources keep their `<lang>.lproj` directory: it is how
+      // iOS selects a language, and flattening it would also make every
+      // language's copy of a file collide on one bundle-root name.
+      final destination = p.joinAll([bundleDir, ?_lprojOf(resource), name]);
       if (name.endsWith('.storyboard')) {
         // Handled by replaceStoryboardWithPrincipalClass above.
         final compiled = '${p.withoutExtension(resource)}.storyboardc';
         if (Directory(compiled).existsSync()) {
           await _copyDirectory(
             compiled,
-            p.join(bundleDir, p.basename(compiled)),
+            p.join(p.dirname(destination), p.basename(compiled)),
           );
         } else {
           Log.logWarn(
@@ -459,11 +464,19 @@ abstract final class AppExtensionBuilder {
       }
 
       if (Directory(resource).existsSync()) {
-        await _copyDirectory(resource, p.join(bundleDir, name));
+        await _copyDirectory(resource, destination);
       } else if (File(resource).existsSync()) {
-        await File(resource).copy(p.join(bundleDir, name));
+        await Directory(p.dirname(destination)).create(recursive: true);
+        await File(resource).copy(destination);
       }
     }
+  }
+
+  /// The `<lang>.lproj` directory [resource] sits in, or null when it is not
+  /// a localized resource.
+  static String? _lprojOf(String resource) {
+    final parent = p.basename(p.dirname(resource));
+    return parent.endsWith('.lproj') ? parent : null;
   }
 
   /// Locate `swiftc`, which the Swift toolchain puts on PATH.

--- a/packages/xcross/lib/src/flutter/build/flutter_packer.dart
+++ b/packages/xcross/lib/src/flutter/build/flutter_packer.dart
@@ -483,6 +483,16 @@ final class FlutterPacker {
       'CURRENT_PROJECT_VERSION': _versions.bundleVersion,
     };
 
+    // `receive_sharing_intent` and friends point the app's `AppGroupId` key
+    // at `$(CUSTOM_GROUP_ID)`, which Xcode expands from the target's build
+    // settings. The extension build already substitutes it; doing the same
+    // here keeps both sides naming one container, instead of the app reading
+    // back the literal `$(CUSTOM_GROUP_ID)` and finding nothing shared.
+    final hostGroups = _hostAppGroups();
+    if (hostGroups.isNotEmpty) {
+      subs['CUSTOM_GROUP_ID'] = hostGroups.first;
+    }
+
     final xcconfigFile = File(
       p.join(projectRoot, 'ios', 'Flutter', 'Generated.xcconfig'),
     );

--- a/packages/xcross/lib/src/flutter/build/info_plist.dart
+++ b/packages/xcross/lib/src/flutter/build/info_plist.dart
@@ -28,6 +28,36 @@ abstract final class InfoPlist {
     return (value == null || value.isEmpty) ? null : value;
   }
 
+  /// Replace [from] with [to] inside `CFBundleURLSchemes` values only.
+  ///
+  /// Schemes are conventionally derived from the bundle id
+  /// (`ShareMedia-<bundle id>`), so qualifying the App ID at sign time also
+  /// has to qualify the scheme, or the extension's redirect back into the
+  /// app resolves to a scheme nothing has registered.
+  ///
+  /// The rewrite is deliberately confined to the scheme arrays: replacing
+  /// [from] across the whole plist would also rewrite unrelated keys that
+  /// legitimately mention the original bundle id.
+  static String rewriteUrlSchemes(
+    String plistXml, {
+    required String from,
+    required String to,
+  }) {
+    if (from == to || from.isEmpty) return plistXml;
+
+    final arrays = RegExp(
+      r'(<key>\s*CFBundleURLSchemes\s*</key>\s*<array>)(.*?)(</array>)',
+      dotAll: true,
+    );
+    return plistXml.replaceAllMapped(arrays, (match) {
+      final body = match.group(2)!.replaceAllMapped(
+        RegExp('<string>([^<]*)</string>'),
+        (scheme) => '<string>${scheme.group(1)!.replaceAll(from, to)}</string>',
+      );
+      return '${match.group(1)}$body${match.group(3)}';
+    });
+  }
+
   /// Keys Xcode would inject at build time, added only when the template
   /// doesn't already declare them, in this exact order.
   ///
@@ -132,7 +162,11 @@ abstract final class InfoPlist {
     );
     final replacement = '<key>$key</key>\n\t<string>$value</string>';
     if (xml.contains('<key>$key</key>')) {
-      return xml.replaceFirst(pattern, replacement);
+      // Every occurrence, not just the first: a template that declares the
+      // same key twice (hand-edited plists do) would otherwise keep a stale
+      // second copy, and CFBundle resolves duplicates to the *last* one, so
+      // the value actually read back at runtime would be the one left behind.
+      return xml.replaceAll(pattern, replacement);
     }
     return _insertBeforeEnd(xml, '\t$replacement\n');
   }

--- a/packages/xcross/lib/src/flutter/build/ios_app_extensions.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_app_extensions.dart
@@ -13,6 +13,22 @@ const _extensionProductTypes = {'com.apple.product-type.app-extension'};
 
 const _applicationProductType = 'com.apple.product-type.application';
 
+/// Extensions of files that belong in a target's compile-sources phase.
+const _sourceExtensions = {'.swift', '.m', '.mm', '.c', '.cpp'};
+
+/// Extensions that are never a compiled source nor a copyable resource:
+/// build inputs Xcode consumes itself.
+const _nonResourceExtensions = {
+  '.h',
+  '.hpp',
+  '.plist',
+  '.entitlements',
+  '.modulemap',
+  '.xcconfig',
+  '.md',
+  '.swiftinterface',
+};
+
 /// One iOS app-extension target discovered in `project.pbxproj`.
 @immutable
 final class IosAppExtension {
@@ -113,6 +129,24 @@ abstract final class IosAppExtensions {
         project.buildSetting(target, 'CODE_SIGN_ENTITLEMENTS'),
       );
 
+      // Xcode 16 targets may list files explicitly, via a synchronized folder
+      // group, or both; merging the two keeps either project style building.
+      final synchronized = project.synchronizedFiles(target);
+      final sources = <String>{
+        ...project.buildPhaseFiles(target, 'PBXSourcesBuildPhase'),
+        ...synchronized.where(
+          (file) => _sourceExtensions.contains(p.extension(file)),
+        ),
+      }.toList();
+      final resources = <String>{
+        ...project.buildPhaseFiles(target, 'PBXResourcesBuildPhase'),
+        ...synchronized.where((file) {
+          final extension = p.extension(file);
+          return !_sourceExtensions.contains(extension) &&
+              !_nonResourceExtensions.contains(extension);
+        }),
+      }.toList();
+
       extensions.add(
         IosAppExtension(
           name: name,
@@ -121,8 +155,8 @@ abstract final class IosAppExtensions {
             project,
             project.buildSetting(target, 'INFOPLIST_FILE'),
           ),
-          sources: project.buildPhaseFiles(target, 'PBXSourcesBuildPhase'),
-          resources: project.buildPhaseFiles(target, 'PBXResourcesBuildPhase'),
+          sources: sources,
+          resources: resources,
           entitlementsPath: entitlements,
           swiftVersion: project.buildSetting(target, 'SWIFT_VERSION') ?? '5.0',
           deploymentTarget: project.buildSetting(

--- a/packages/xcross/lib/src/flutter/build/pbxproj.dart
+++ b/packages/xcross/lib/src/flutter/build/pbxproj.dart
@@ -174,6 +174,93 @@ final class PbxProject {
     return null;
   }
 
+  /// Absolute on-disk paths contributed to [target] by Xcode 16 synchronized
+  /// folder groups (`PBXFileSystemSynchronizedRootGroup`).
+  ///
+  /// Xcode 16 stopped listing every file in `PBXSourcesBuildPhase`: a target
+  /// can instead point at a folder whose contents are members implicitly, so
+  /// the build phase is empty and only the folder is named. Walking the folder
+  /// is therefore the only way to recover the target's files, and skipping it
+  /// is what makes such a target look like it has no sources at all.
+  ///
+  /// Files listed in a `membershipExceptions` set for [target] are excluded,
+  /// matching Xcode's own "remove from target" behaviour.
+  List<String> synchronizedFiles(PbxObject target) {
+    final paths = <String>[];
+    for (final groupId in target.stringList('fileSystemSynchronizedGroups')) {
+      final group = object(groupId);
+      if (group == null) continue;
+      final root = resolveFileReference(groupId);
+      if (root == null || !Directory(root).existsSync()) continue;
+
+      final excluded = _membershipExceptions(group, target);
+      for (final path in _walkSynchronizedRoot(root)) {
+        final relative = p.relative(path, from: root);
+        if (excluded.contains(relative)) continue;
+        paths.add(path);
+      }
+    }
+    paths.sort();
+    return paths;
+  }
+
+  /// Group-relative paths [group] excludes from [target].
+  Set<String> _membershipExceptions(PbxObject group, PbxObject target) {
+    final excluded = <String>{};
+    for (final exceptionId in group.stringList('exceptions')) {
+      final exception = object(exceptionId);
+      if (exception == null) continue;
+      // An exception set names the one target it applies to; sets belonging to
+      // a sibling target must not hide files from this one.
+      if (exception.string('target') != target.id) continue;
+      excluded.addAll(
+        exception.stringList('membershipExceptions').map(p.normalize),
+      );
+    }
+    return excluded;
+  }
+
+  /// Files under a synchronized root, treating bundle-shaped directories as
+  /// single entries so an `.xcassets` is one resource, not its loose contents.
+  static List<String> _walkSynchronizedRoot(String root) {
+    const bundleDirectories = {
+      '.xcassets',
+      '.storyboardc',
+      '.framework',
+      '.bundle',
+      '.xcdatamodeld',
+      '.docc',
+    };
+
+    final found = <String>[];
+    final pending = <String>[root];
+    // Bounded walk: pbxproj folders are shallow and this never follows links.
+    while (pending.isNotEmpty) {
+      final directory = Directory(pending.removeLast());
+      final List<FileSystemEntity> entries;
+      try {
+        entries = directory.listSync(followLinks: false);
+      } on FileSystemException {
+        continue;
+      }
+      for (final entry in entries) {
+        final name = p.basename(entry.path);
+        // Xcode ignores dotfiles in synchronized folders.
+        if (name.startsWith('.')) continue;
+        if (entry is Directory) {
+          if (bundleDirectories.contains(p.extension(name))) {
+            found.add(entry.path);
+          } else {
+            pending.add(entry.path);
+          }
+          continue;
+        }
+        if (entry is File) found.add(entry.path);
+      }
+    }
+    return found;
+  }
+
   /// Path prefix contributed by the `PBXGroup` chain above the object [id].
   String? _groupPrefix(String id) {
     final segments = <String>[];

--- a/packages/xcross/test/flutter/build/app_extension_builder_test.dart
+++ b/packages/xcross/test/flutter/build/app_extension_builder_test.dart
@@ -316,4 +316,114 @@ void main() {
       expect(RegExp('<key>CFBundleIdentifier</key>').allMatches(xml).length, 1);
     });
   });
+
+  group('copyResources', () {
+    late Directory tmp;
+    late Directory bundle;
+
+    setUp(() async {
+      tmp = await Directory.systemTemp.createTemp('xcross_copy_resources-');
+      bundle = Directory(p.join(tmp.path, 'Share Extension.appex'));
+      await bundle.create(recursive: true);
+    });
+
+    tearDown(() async {
+      if (tmp.existsSync()) await tmp.delete(recursive: true);
+    });
+
+    Future<String> writeResource(String relative, String contents) async {
+      final file = File(p.join(tmp.path, 'src', relative));
+      await file.parent.create(recursive: true);
+      await file.writeAsString(contents);
+      return file.path;
+    }
+
+    test('keeps localized resources inside their .lproj directory', () async {
+      final english = await writeResource(
+        p.join('en.lproj', 'Localizable.strings'),
+        '"key" = "english";',
+      );
+      final german = await writeResource(
+        p.join('de.lproj', 'Localizable.strings'),
+        '"key" = "german";',
+      );
+
+      await AppExtensionBuilder.copyResources(
+        extension: _extension(resources: [english, german]),
+        bundleDir: bundle.path,
+      );
+
+      // Flattening onto the bundle root would make one language overwrite the
+      // other, and iOS would find no localization at all.
+      expect(
+        File(
+          p.join(bundle.path, 'en.lproj', 'Localizable.strings'),
+        ).readAsStringSync(),
+        '"key" = "english";',
+      );
+      expect(
+        File(
+          p.join(bundle.path, 'de.lproj', 'Localizable.strings'),
+        ).readAsStringSync(),
+        '"key" = "german";',
+      );
+    });
+
+    test('copies unlocalized resources to the bundle root', () async {
+      final resource = await writeResource('config.json', '{}');
+
+      await AppExtensionBuilder.copyResources(
+        extension: _extension(resources: [resource]),
+        bundleDir: bundle.path,
+      );
+
+      expect(File(p.join(bundle.path, 'config.json')).existsSync(), isTrue);
+    });
+
+    test('places a compiled storyboard next to its localization', () async {
+      final storyboard = await writeResource(
+        p.join('Base.lproj', 'MainInterface.storyboard'),
+        '<document/>',
+      );
+      final compiled = Directory(
+        p.join(p.dirname(storyboard), 'MainInterface.storyboardc'),
+      );
+      await compiled.create(recursive: true);
+      await File(p.join(compiled.path, 'Info.plist')).writeAsString('<plist/>');
+
+      await AppExtensionBuilder.copyResources(
+        extension: _extension(resources: [storyboard]),
+        bundleDir: bundle.path,
+      );
+
+      expect(
+        File(
+          p.join(
+            bundle.path,
+            'Base.lproj',
+            'MainInterface.storyboardc',
+            'Info.plist',
+          ),
+        ).existsSync(),
+        isTrue,
+      );
+    });
+
+    test('skips an uncompiled storyboard rather than shipping it', () async {
+      final storyboard = await writeResource(
+        'MainInterface.storyboard',
+        '<document/>',
+      );
+
+      await AppExtensionBuilder.copyResources(
+        extension: _extension(resources: [storyboard]),
+        bundleDir: bundle.path,
+      );
+
+      expect(
+        File(p.join(bundle.path, 'MainInterface.storyboard')).existsSync(),
+        isFalse,
+      );
+    });
+  });
 }

--- a/packages/xcross/test/flutter/build/app_extension_builder_test.dart
+++ b/packages/xcross/test/flutter/build/app_extension_builder_test.dart
@@ -33,6 +33,7 @@ void main() {
     List<String> argumentsWith({
       String? pluginsLibrary,
       String? pluginModulesDir,
+      String moduleName = 'Share_Extension',
     }) => AppExtensionBuilder.compileArguments(
       iosSdk: '/sdk/iPhoneOS.sdk',
       resourceDir: '/sdk/toolchain/usr/lib/swift',
@@ -41,11 +42,23 @@ void main() {
       deploymentTarget: const IosDeploymentTarget('15.0'),
       flutterSlice: '/engine/Flutter.xcframework/ios-arm64',
       moduleCache: '/out/.module-cache',
+      moduleName: moduleName,
       ld64lld: '/usr/bin/ld64.lld',
       sdkVersion: '26.5',
       pluginsLibrary: pluginsLibrary,
       pluginModulesDir: pluginModulesDir,
     );
+
+    test('names the Swift module after the target', () {
+      // swiftc otherwise infers the module from the output file name and
+      // falls back to `main` for `Share Extension`, so the real principal
+      // class stops matching the one written into the Info.plist and iOS
+      // shows a black screen instead of the share sheet.
+      expect(
+        argumentsWith(),
+        containsAllInOrder(['-module-name', 'Share_Extension']),
+      );
+    });
 
     test('marks the binary as app-extension safe', () {
       final arguments = argumentsWith();

--- a/packages/xcross/test/flutter/build/info_plist_test.dart
+++ b/packages/xcross/test/flutter/build/info_plist_test.dart
@@ -232,6 +232,121 @@ BAZ = a=b
     });
   });
 
+  group('setPlistString', () {
+    test('replaces every occurrence of a duplicated key', () {
+      // Apple's plist parser resolves a duplicated key to the *last* entry,
+      // so rewriting only the first would leave the stale value in force.
+      const xml =
+          '<?xml version="1.0"?>\n'
+          '<plist version="1.0">\n'
+          '<dict>\n'
+          '\t<key>AppGroupId</key>\n'
+          '\t<string>group.original</string>\n'
+          '\t<key>AppGroupId</key>\n'
+          '\t<string>group.original</string>\n'
+          '</dict>\n'
+          '</plist>\n';
+
+      final updated = InfoPlist.setPlistString(
+        xml,
+        'AppGroupId',
+        'group.qualified',
+      );
+
+      expect(updated, isNot(contains('group.original')));
+      expect(
+        RegExp('group.qualified').allMatches(updated).length,
+        2,
+        reason: 'both declarations must be rewritten',
+      );
+    });
+
+    test('inserts the key when the template lacks it', () {
+      final updated = InfoPlist.setPlistString(
+        _minimalPlist,
+        'AppGroupId',
+        'group.qualified',
+      );
+
+      expect(updated, contains('<key>AppGroupId</key>'));
+      expect(updated, contains('<string>group.qualified</string>'));
+    });
+  });
+
+  group('rewriteUrlSchemes', () {
+    const xml =
+        '<?xml version="1.0"?>\n'
+        '<plist version="1.0">\n'
+        '<dict>\n'
+        '\t<key>CFBundleIdentifier</key>\n'
+        '\t<string>com.example.App</string>\n'
+        '\t<key>CFBundleURLTypes</key>\n'
+        '\t<array>\n'
+        '\t\t<dict>\n'
+        '\t\t\t<key>CFBundleURLSchemes</key>\n'
+        '\t\t\t<array>\n'
+        '\t\t\t\t<string>ShareMedia-com.example.App</string>\n'
+        '\t\t\t\t<string>myapp</string>\n'
+        '\t\t\t</array>\n'
+        '\t\t</dict>\n'
+        '\t</array>\n'
+        '</dict>\n'
+        '</plist>\n';
+
+    test('qualifies a scheme derived from the bundle id', () {
+      // The extension opens ShareMedia-<qualified id> at runtime, so the app
+      // has to declare that exact scheme or nothing handles the redirect.
+      final updated = InfoPlist.rewriteUrlSchemes(
+        xml,
+        from: 'com.example.App',
+        to: 'XCR-ABC.com.example.App',
+      );
+
+      expect(
+        updated,
+        contains('<string>ShareMedia-XCR-ABC.com.example.App</string>'),
+      );
+    });
+
+    test('leaves unrelated schemes alone', () {
+      final updated = InfoPlist.rewriteUrlSchemes(
+        xml,
+        from: 'com.example.App',
+        to: 'XCR-ABC.com.example.App',
+      );
+
+      expect(updated, contains('<string>myapp</string>'));
+    });
+
+    test('never touches values outside the scheme arrays', () {
+      // CFBundleIdentifier is rewritten by its own dedicated step; a blanket
+      // replace would corrupt any key that mentions the original id.
+      final updated = InfoPlist.rewriteUrlSchemes(
+        xml,
+        from: 'com.example.App',
+        to: 'XCR-ABC.com.example.App',
+      );
+
+      expect(
+        updated,
+        contains(
+          '<key>CFBundleIdentifier</key>\n\t<string>com.example.App</string>',
+        ),
+      );
+    });
+
+    test('is a no-op when the id is unchanged', () {
+      expect(
+        InfoPlist.rewriteUrlSchemes(
+          xml,
+          from: 'com.example.App',
+          to: 'com.example.App',
+        ),
+        xml,
+      );
+    });
+  });
+
   group('fallback', () {
     test('is a well-formed plist that includes UILaunchScreen', () {
       expect(InfoPlist.fallback, contains('UILaunchScreen'));

--- a/packages/xcross/test/flutter/build/ios_app_extensions_test.dart
+++ b/packages/xcross/test/flutter/build/ios_app_extensions_test.dart
@@ -230,4 +230,157 @@ void main() {
   test('finds the application target name', () {
     expect(IosAppExtensions.applicationTargetName(tmp.path), 'Runner');
   });
+
+  group('Xcode 16 synchronized folder groups', () {
+    late Directory synced;
+
+    /// A project whose extension target lists no files in its build phases and
+    /// instead points at a synchronized folder group, the shape Xcode 16
+    /// writes for a target added with "folder" references.
+    Future<void> writeSyncedProject({String exceptions = ''}) async {
+      await File(
+        p.join(tmp.path, 'ios', 'Runner.xcodeproj', 'project.pbxproj'),
+      ).writeAsString('''
+// !\$*UTF8*\$!
+{
+	archiveVersion = 1;
+	objectVersion = 77;
+	objects = {
+		AA01 = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BB01;
+			buildPhases = (
+				SS01,
+			);
+			fileSystemSynchronizedGroups = (
+				SG01,
+			);
+			name = "Share Extension";
+			productType = "com.apple.product-type.app-extension";
+		};
+		SG01 = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "Share Extension";
+			sourceTree = "<group>";
+$exceptions
+		};
+		SS01 = {
+			isa = PBXSourcesBuildPhase;
+			files = (
+			);
+		};
+		CC01 = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.App.Share-Extension";
+			};
+			name = Debug;
+		};
+		BB01 = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CC01,
+			);
+		};
+	};
+	rootObject = PP01;
+}
+''');
+    }
+
+    setUp(() async {
+      synced = Directory(p.join(tmp.path, 'ios', 'Share Extension'));
+      await Directory(p.join(synced.path, 'Base.lproj')).create(recursive: true);
+      await File(
+        p.join(synced.path, 'ShareViewController.swift'),
+      ).writeAsString('class ShareViewController {}');
+      await File(
+        p.join(synced.path, 'Base.lproj', 'MainInterface.storyboard'),
+      ).writeAsString('<document/>');
+      await File(p.join(synced.path, 'Info.plist')).writeAsString('<plist/>');
+    });
+
+    test('recovers sources from a synchronized folder group', () async {
+      await writeSyncedProject();
+
+      final extension = IosAppExtensions.discover(tmp.path).single;
+
+      expect(extension.sources, [
+        p.join(synced.path, 'ShareViewController.swift'),
+      ]);
+    });
+
+    test('classifies synchronized files as sources or resources', () async {
+      await writeSyncedProject();
+
+      final extension = IosAppExtensions.discover(tmp.path).single;
+
+      // Nested folders contribute, and Info.plist is a build input, not a
+      // resource to copy: the builder writes the bundle's plist itself.
+      expect(extension.resources, [
+        p.join(synced.path, 'Base.lproj', 'MainInterface.storyboard'),
+      ]);
+      expect(extension.resources, isNot(contains(endsWith('Info.plist'))));
+    });
+
+    test('honours membership exceptions for this target', () async {
+      await writeSyncedProject(
+        exceptions: '''
+			exceptions = (
+				EX01,
+			);''',
+      );
+      final pbxproj = File(
+        p.join(tmp.path, 'ios', 'Runner.xcodeproj', 'project.pbxproj'),
+      );
+      await pbxproj.writeAsString(
+        pbxproj.readAsStringSync().replaceFirst('		SS01 = {', '''
+		EX01 = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			target = AA01;
+			membershipExceptions = (
+				ShareViewController.swift,
+			);
+		};
+		SS01 = {'''),
+      );
+
+      expect(IosAppExtensions.discover(tmp.path).single.sources, isEmpty);
+    });
+
+    test('ignores exceptions belonging to a different target', () async {
+      await writeSyncedProject(
+        exceptions: '''
+			exceptions = (
+				EX01,
+			);''',
+      );
+      final pbxproj = File(
+        p.join(tmp.path, 'ios', 'Runner.xcodeproj', 'project.pbxproj'),
+      );
+      await pbxproj.writeAsString(
+        pbxproj.readAsStringSync().replaceFirst('		SS01 = {', '''
+		EX01 = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			target = AA99;
+			membershipExceptions = (
+				ShareViewController.swift,
+			);
+		};
+		SS01 = {'''),
+      );
+
+      expect(IosAppExtensions.discover(tmp.path).single.sources, hasLength(1));
+    });
+
+    test('tolerates a synchronized group with no folder on disk', () async {
+      await writeSyncedProject();
+      await synced.delete(recursive: true);
+
+      final extension = IosAppExtensions.discover(tmp.path).single;
+
+      expect(extension.sources, isEmpty);
+      expect(extension.resources, isEmpty);
+    });
+  });
 }


### PR DESCRIPTION
An app using [receive_sharing_intent](https://github.com/KasemJaffer/receive_sharing_intent) installed and launched its **Share Extension** instead of the main app, showing a blank screen.

Verified end to end on a physical iPhone with the plugin's own example app: the app installs and launches, both extensions appear, and the share sheet hand-off works.

## The reported bug

`ios/Runner.xcodeproj` lists several `PRODUCT_BUNDLE_IDENTIFIER`s and the extension's often comes first. xcross took the first match, so it signed, installed and launched the extension. The bundle id now comes from the `com.apple.product-type.application` target.

## Making the extension actually useful

An extension in the share sheet is pointless if it cannot hand the shared file back to the app, and that needs a shared **App Group** container. Several things were in the way:

- **App Groups were never enabled.** xcross registered the group but asked for the capability over developerservices2's JSON:API, which answers `403 The API key in use does not allow this request` for any capability change. App Groups only exist on the pre-JSON `QH65B2` protocol Xcode itself speaks (`listApplicationGroups`, `addApplicationGroup`, `updateAppId` with feature key `APG3427HIY`, `assignApplicationGroupToAppId`). Resource ids are shared between the two protocols, so xcross mixes them.
- **The granted group was assumed, not checked.** xcross wrote the group it *asked* for into the entitlements. Only the profile decides what iOS accepts, and signing with an ungranted group makes installd refuse the install with `0xe8008015`. The group is now read back off the issued profile.
- **Extensions could silently diverge.** Each extension has its own profile; one lacking the app's group broke the hand-off at runtime rather than at install time. Now warned about.

Also here: Swift module naming for extension targets, Xcode 16 synced-folder targets, `$(MARKETING_VERSION)`/`$(CURRENT_PROJECT_VERSION)` expansion, and one URL scheme shared between app and extension.

## App Store Connect API keys

Apple's official API **cannot** provision App Groups. Its OpenAPI spec declares 966 paths and none mentions them. Checked against a live key:

| Route | Result |
| --- | --- |
| `GET /v1/appGroups`, `/v1/applicationGroups` | `404`, no such resource |
| `POST /v1/bundleIdCapabilities` `APP_GROUPS` | `201`, but nothing linkable |
| `settings[].key = APP_GROUP_IDENTIFIERS` (POST and PATCH) | `409`, only `ICLOUD_VERSION`, `DATA_PROTECTION_PERMISSION_LEVEL`, `APPLE_ID_AUTH_APP_CONSENT` |
| `POST /v1/bundleIds` with a `group.` identifier | `201`, but no relationship links it as a group |
| Profile with the capability on, no group | grants `application-groups: []` |
| Signing a real group against it | installd `0xe8008015` |
| developerservices2 / portal hosts | `403`/`401` for keys under every audience tried |

A key still issues profiles carrying a group attached by other means, so `XCROSS_APP_GROUP` lets you use one:

```sh
XCROSS_APP_GROUP=group.com.example.Shared xcross flutter run
```

Attach the group to your App IDs once in Xcode or at developer.apple.com, then CI signs with the key and the full share flow works. Without it, xcross says so once and everything still builds, installs and runs.

## Verification

- `receive_sharing_intent/example` on a real iPhone: app installs as the main app, both `.appex` register with PlugInKit, all three binaries carry the same `com.apple.security.application-groups`, iOS reports `ProfileValidated = True` and allocates a shared container, and the share sheet flow was confirmed by hand.
- The API key path was re-run on device: one clear message, app and extensions install and run.
- 680 tests pass.

Docs: `docs/app-extensions.md`.
