### PR TITLE
fix(device): launch the app by exact signed `bundleId`

### DIFF
--- a/packages/apple_developer_kit/lib/src/appstoreconnect/provisioning_identifiers.dart
+++ b/packages/apple_developer_kit/lib/src/appstoreconnect/provisioning_identifiers.dart
@@ -56,4 +56,19 @@ abstract final class ProvisioningIdentifiers {
     ).replaceAll(RegExp('[^A-Za-z0-9]+'), ' ').trim();
     return '$namePrefix$words';
   }
+
+  /// Whether [identifier] is an xcross-qualified form of [base]
+  /// (`XCR-<identity>.<base>`).
+  ///
+  /// Deliberately strict: a device can carry the user's *production* build
+  /// under the bare `base` id, and that one is signed without
+  /// `get-task-allow`. Treating it as xcross' app makes the debugger fail
+  /// with "Permission to debug … was denied".
+  @useResult
+  static bool isQualifiedForm(String identifier, String base) {
+    if (!identifier.startsWith(idPrefix)) return false;
+    final dot = identifier.indexOf('.');
+    if (dot < 0 || dot == idPrefix.length) return false;
+    return identifier.substring(dot + 1) == sanitize(base);
+  }
 }

--- a/packages/apple_developer_kit/test/appstoreconnect/provisioning_identifiers_test.dart
+++ b/packages/apple_developer_kit/test/appstoreconnect/provisioning_identifiers_test.dart
@@ -40,4 +40,35 @@ void main() {
       'xcross com example my app',
     );
   });
+
+  test('isQualifiedForm only matches XCR-prefixed forms of the base id', () {
+    expect(
+      ProvisioningIdentifiers.isQualifiedForm(
+        'XCR-ABCD.com.example.App',
+        'com.example.App',
+      ),
+      isTrue,
+    );
+    expect(
+      ProvisioningIdentifiers.isQualifiedForm(
+        'com.example.App',
+        'com.example.App',
+      ),
+      isFalse,
+    );
+    expect(
+      ProvisioningIdentifiers.isQualifiedForm(
+        'XCR-ABCD.com.example.App.Share-Extension',
+        'com.example.App',
+      ),
+      isFalse,
+    );
+    expect(
+      ProvisioningIdentifiers.isQualifiedForm(
+        'other.com.example.App',
+        'com.example.App',
+      ),
+      isFalse,
+    );
+  });
 }

--- a/packages/xcross/lib/src/device/core_device_launcher.dart
+++ b/packages/xcross/lib/src/device/core_device_launcher.dart
@@ -29,6 +29,8 @@ const _terminateDiscoveryTimeout = Duration(seconds: 8);
 abstract final class CoreDeviceLauncher {
   static bool get _isDap => Platform.environment['XCROSS_DAP'] == '1';
 
+  /// [bundleId] must be the id the app is actually installed under — the
+  /// value returned by `DeviceBackend.install`. Nothing here guesses it.
   static Future<void> launch({
     required String udid,
     required String bundleId,
@@ -113,15 +115,11 @@ abstract final class CoreDeviceLauncher {
     required HotReloadConfig? hotReload,
     Future<bool> Function()? onRestartRequested,
   }) async {
-    final resolvedBundleId = await _resolveBundleId(
-      bundleId,
-      transport: transport,
-    );
     final debugproxy = await transport.debugproxyEndpoint();
 
     final pid = await _launchSuspended(
       transport: transport,
-      bundleId: resolvedBundleId,
+      bundleId: bundleId,
       appArgs: arguments,
     );
 
@@ -224,6 +222,9 @@ abstract final class CoreDeviceLauncher {
   }
 
   /// Resolve the qualified bundle id from the installed-app list.
+  ///
+  /// Only [terminateIfRunning] needs this: it runs *before* install, so the
+  /// signing identity (and with it the qualified id) is not known yet.
   /// Returns [bundleId] unchanged on failure.
   static Future<String> _resolveBundleId(
     String bundleId, {

--- a/packages/xcross/lib/src/device/core_device_launcher.dart
+++ b/packages/xcross/lib/src/device/core_device_launcher.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:apple_developer_kit/apple_developer_kit.dart';
 import 'package:cli_kit/cli_kit.dart';
 import 'package:dart_mobile_device/dart_mobile_device.dart';
+import 'package:meta/meta.dart';
 import 'package:pure/pure.dart';
 import 'package:xcross/src/constants.dart';
 import 'package:xcross/src/device/core_device_launch_profile.dart';
@@ -222,7 +223,7 @@ abstract final class CoreDeviceLauncher {
     }
   }
 
-  /// Resolve team-prefixed bundle id from the installed-app list.
+  /// Resolve the qualified bundle id from the installed-app list.
   /// Returns [bundleId] unchanged on failure.
   static Future<String> _resolveBundleId(
     String bundleId, {
@@ -250,13 +251,32 @@ abstract final class CoreDeviceLauncher {
     final ids = await Pymd.listInstalledApps(
       deviceArgs: transport.sideChannelDeviceArgs ?? const [],
     );
-    if (ids.contains(requested)) return requested;
+    return pickInstalledBundleId(installed: ids, requested: requested);
+  }
+
+  /// Pick the installed app that belongs to xcross.
+  ///
+  /// An `XCR-<identity>.<base>` entry always wins over a bare `<base>` one:
+  /// the bare id is typically the user's App Store/TestFlight build, which is
+  /// signed without `get-task-allow` and cannot be debugged (issue #26).
+  /// Only when no qualified build is installed do we fall back to the exact
+  /// requested id.
+  @visibleForTesting
+  static String pickInstalledBundleId({
+    required List<String> installed,
+    required String requested,
+  }) {
     final base = ProvisioningIdentifiers.sanitize(requested);
-    final suffix = '.$base';
-    // Shortest suffix match wins: on a device carrying several team-prefixed
-    // builds of the same app, the longest match resolves to the wrong one.
-    final matches =
-        ids.where((id) => id == base || id.endsWith(suffix)).toList()
+    if (installed.contains(requested) &&
+        requested.startsWith(ProvisioningIdentifiers.idPrefix)) {
+      return requested;
+    }
+    // Shortest match wins: on a device carrying several team-prefixed builds
+    // of the same app, the longest match resolves to the wrong one.
+    final qualified =
+        installed
+            .where((id) => ProvisioningIdentifiers.isQualifiedForm(id, base))
+            .toList()
           ..sort(compare((id) => id.length));
     // Several identities' builds of one app are indistinguishable by suffix,
     // and picking the wrong one launches a stale binary whose engine can be
@@ -264,14 +284,15 @@ abstract final class CoreDeviceLauncher {
     // mismatches ("Could not run configuration in engine"). Run/install
     // callers avoid this by passing the exact installed id; anything else
     // (attach-style flows) at least gets told the guess was ambiguous.
-    if (matches.length > 1) {
+    if (qualified.length > 1) {
       Log.logWarn(
         'several installed builds match "$requested": '
-        '${matches.join(', ')} — using ${matches.first}. Delete the stale '
+        '${qualified.join(', ')} — using ${qualified.first}. Delete the stale '
         'ones on the device if this picks wrong.',
       );
     }
-    return matches.isNotEmpty ? matches.first : requested;
+    if (qualified.isNotEmpty) return qualified.first;
+    return requested;
   }
 
   /// Launch the app suspended and return its device PID.

--- a/packages/xcross/lib/src/device/device_backend.dart
+++ b/packages/xcross/lib/src/device/device_backend.dart
@@ -5,6 +5,7 @@ import 'package:cli_kit/cli_kit.dart';
 import 'package:dart_mobile_device/dart_mobile_device.dart';
 import 'package:path/path.dart' as p;
 import 'package:xcross/src/device/internal/embedded_extension.dart';
+import 'package:xcross/src/device/internal/signed_bundle_identity.dart';
 import 'package:xcross/src/device/internal/signing_session.dart';
 import 'package:xcross/src/errors.dart';
 import 'package:xcross/src/flutter/flutter.dart';
@@ -74,17 +75,20 @@ final class NativeBackend implements DeviceBackend {
     final signing = await _resolveSigningSession();
     // xtool-style: qualify with XCR-<identity> so two accounts can share a
     // project bundle id without racing on a globally unique App ID.
-    final signedBundleId = ProvisioningIdentifiers.qualify(
-      bundleId,
-      signing.identityId,
+    final bundleIdentity = SignedBundleIdentity.qualify(
+      requested: bundleId,
+      signingIdentityId: signing.identityId,
     );
     final profilesDir = p.join(p.dirname(signing.identityDir), 'profiles');
-    final outputDir = p.join(profilesDir, signedBundleId);
+    final outputDir = p.join(profilesDir, bundleIdentity.exact);
 
     try {
-      await _rewriteBundleIdentifier(appOrIpaPath, signedBundleId);
-      if (signedBundleId != bundleId) {
-        Log.logInfo('App ID', '$bundleId ${Log.dim('→')} $signedBundleId');
+      await _rewriteBundleIdentifier(appOrIpaPath, bundleIdentity.exact);
+      if (bundleIdentity.exact != bundleIdentity.requested) {
+        Log.logInfo(
+          'App ID',
+          '${bundleIdentity.requested} ${Log.dim('→')} ${bundleIdentity.exact}',
+        );
         // Custom URL schemes are conventionally derived from the bundle id
         // (`ShareMedia-<bundle id>`), and an extension builds the URL it
         // opens from its *own* qualified host id at runtime. Leaving the
@@ -93,16 +97,16 @@ final class NativeBackend implements DeviceBackend {
         // silently does nothing.
         await _rewriteUrlSchemes(
           appOrIpaPath,
-          from: bundleId,
-          to: signedBundleId,
+          from: bundleIdentity.requested,
+          to: bundleIdentity.exact,
         );
       }
       // Embedded extensions must be renamed under the qualified app id and
       // provisioned in their own right before the app can be signed.
       final extensions = await _rewriteExtensionIdentifiers(
         appOrIpaPath,
-        hostBundleId: bundleId,
-        signedHostBundleId: signedBundleId,
+        hostBundleId: bundleIdentity.requested,
+        signedHostBundleId: bundleIdentity.exact,
       );
       // The app and its extensions must share the same App Groups, or the
       // extension has no way to hand data back to the app.
@@ -130,7 +134,7 @@ final class NativeBackend implements DeviceBackend {
       };
       final identity = await AscProvisioning.provisionDevelopmentIdentity(
         client: signing.client,
-        bundleId: signedBundleId,
+        bundleId: bundleIdentity.exact,
         deviceUdids: [udid],
         outputDir: outputDir,
         identityDir: signing.identityDir,
@@ -186,12 +190,20 @@ final class NativeBackend implements DeviceBackend {
           extensionAssets: extensionAssets,
         ).signApp(appOrIpaPath),
       );
+      final signedInfoPlist = File(p.join(appOrIpaPath, 'Info.plist'));
+      bundleIdentity.verifyArtifact(
+        signedInfoPlist.existsSync()
+            ? InfoPlist.readBundleIdentifier(
+                await signedInfoPlist.readAsString(),
+              )
+            : null,
+      );
       await PymdDevices.install(
         appOrIpaPath,
         udid: udid,
         overTunnel: device.source == DeviceSource.tunneld,
       );
-      return signedBundleId;
+      return bundleIdentity.exact;
     } finally {
       signing.client.close();
       signing.anisette?.close();

--- a/packages/xcross/lib/src/device/internal/signed_bundle_identity.dart
+++ b/packages/xcross/lib/src/device/internal/signed_bundle_identity.dart
@@ -1,0 +1,38 @@
+import 'package:apple_developer_kit/apple_developer_kit.dart';
+import 'package:xcross/src/errors.dart';
+
+/// The one bundle identity used from provisioning through device launch.
+///
+/// [exact] is computed once from the requested project id and signing identity.
+/// Every operation must carry this value forward rather than qualifying or
+/// resolving the identifier again.
+final class SignedBundleIdentity {
+  SignedBundleIdentity._({required this.requested, required this.exact});
+
+  factory SignedBundleIdentity.qualify({
+    required String requested,
+    required String signingIdentityId,
+  }) => SignedBundleIdentity._(
+    requested: requested,
+    exact: ProvisioningIdentifiers.qualify(requested, signingIdentityId),
+  );
+
+  final String requested;
+  final String exact;
+
+  /// Proves that the artifact handed to the installer carries [exact].
+  ///
+  /// Installation consumes the `.app` directory rather than a separate bundle
+  /// id argument, so checking its Info.plist immediately before install closes
+  /// the only place the planned identity and installed identity could diverge.
+  void verifyArtifact(String? artifactBundleId) {
+    if (artifactBundleId == exact) return;
+    final actual = artifactBundleId == null
+        ? 'missing CFBundleIdentifier'
+        : '"$artifactBundleId"';
+    throw XcrossError(
+      'Refusing to install an app whose bundle id changed after signing: '
+      'expected "$exact", found $actual.',
+    );
+  }
+}

--- a/packages/xcross/test/device/core_device_launcher_bundle_id_test.dart
+++ b/packages/xcross/test/device/core_device_launcher_bundle_id_test.dart
@@ -1,0 +1,58 @@
+import 'package:test/test.dart';
+import 'package:xcross/src/device/core_device_launcher.dart';
+
+void main() {
+  String pick(List<String> installed, String requested) =>
+      CoreDeviceLauncher.pickInstalledBundleId(
+        installed: installed,
+        requested: requested,
+      );
+
+  test('prefers the XCR-qualified build over the production one', () {
+    expect(
+      pick([
+        'com.production.app',
+        'XCR-ABCD1234.com.production.app',
+      ], 'com.production.app'),
+      'XCR-ABCD1234.com.production.app',
+    );
+  });
+
+  test('falls back to the requested id when no qualified build exists', () {
+    expect(
+      pick(['com.production.app'], 'com.production.app'),
+      'com.production.app',
+    );
+  });
+
+  test('does not match unrelated suffixes', () {
+    expect(
+      pick(['com.other.com.example.App'], 'com.example.App'),
+      'com.example.App',
+    );
+  });
+
+  test('shortest qualified match wins', () {
+    expect(
+      pick([
+        'XCR-LONGERTEAMID.com.example.App',
+        'XCR-ABCD.com.example.App',
+      ], 'com.example.App'),
+      'XCR-ABCD.com.example.App',
+    );
+  });
+
+  test('does not match an extension of the app id', () {
+    expect(
+      pick(['XCR-ABCD.com.example.App.Share-Extension'], 'com.example.App'),
+      'com.example.App',
+    );
+  });
+
+  test('already-qualified request resolves to itself', () {
+    expect(
+      pick(['XCR-ABCD.com.example.App'], 'XCR-ABCD.com.example.App'),
+      'XCR-ABCD.com.example.App',
+    );
+  });
+}

--- a/packages/xcross/test/device/signed_bundle_identity_test.dart
+++ b/packages/xcross/test/device/signed_bundle_identity_test.dart
@@ -1,0 +1,52 @@
+import 'package:test/test.dart';
+import 'package:xcross/src/device/internal/signed_bundle_identity.dart';
+import 'package:xcross/src/errors.dart';
+
+void main() {
+  test('computes the exact signed id once, including qualification', () {
+    final identity = SignedBundleIdentity.qualify(
+      requested: 'com.example.App',
+      signingIdentityId: 'team-id-with-additions',
+    );
+
+    expect(identity.requested, 'com.example.App');
+    expect(identity.exact, 'XCR-TEAM.com.example.App');
+  });
+
+  test('preserves additions already present in the requested id', () {
+    final identity = SignedBundleIdentity.qualify(
+      requested: 'com.example.App.debug.share-host',
+      signingIdentityId: 'ABC123',
+    );
+
+    expect(identity.exact, 'XCR-ABC123.com.example.App.debug.share-host');
+    expect(() => identity.verifyArtifact(identity.exact), returnsNormally);
+  });
+
+  test('rejects a different artifact id before installation', () {
+    final identity = SignedBundleIdentity.qualify(
+      requested: 'com.example.App',
+      signingIdentityId: 'ABC123',
+    );
+
+    expect(
+      () => identity.verifyArtifact('XCR-OTHER.com.example.App'),
+      throwsA(
+        isA<XcrossError>().having(
+          (error) => error.message,
+          'message',
+          contains('expected "XCR-ABC123.com.example.App"'),
+        ),
+      ),
+    );
+  });
+
+  test('rejects a missing artifact id before installation', () {
+    final identity = SignedBundleIdentity.qualify(
+      requested: 'com.example.App',
+      signingIdentityId: 'ABC123',
+    );
+
+    expect(() => identity.verifyArtifact(null), throwsA(isA<XcrossError>()));
+  });
+}

--- a/packages/xcross/test/flutter/build/ios_app_extensions_test.dart
+++ b/packages/xcross/test/flutter/build/ios_app_extensions_test.dart
@@ -290,7 +290,9 @@ $exceptions
 
     setUp(() async {
       synced = Directory(p.join(tmp.path, 'ios', 'Share Extension'));
-      await Directory(p.join(synced.path, 'Base.lproj')).create(recursive: true);
+      await Directory(
+        p.join(synced.path, 'Base.lproj'),
+      ).create(recursive: true);
       await File(
         p.join(synced.path, 'ShareViewController.swift'),
       ).writeAsString('class ShareViewController {}');

--- a/packages/xcross/test/flutter/vm_service_output_live_test.dart
+++ b/packages/xcross/test/flutter/vm_service_output_live_test.dart
@@ -13,13 +13,11 @@ import 'package:xcross/src/flutter/hot_reload/dart_vm_service_client.dart';
 /// silently matched nothing and no app output was ever forwarded. Only a live
 /// VM can catch that class of mistake.
 void main() {
-  test(
-    'surfaces streamId so Stdout and Stderr are distinguishable',
-    () async {
-      final dir = await Directory.systemTemp.createTemp('xcross_vm_out');
-      addTearDown(() => dir.delete(recursive: true));
-      final script = File('${dir.path}/target.dart');
-      await script.writeAsString('''
+  test('surfaces streamId so Stdout and Stderr are distinguishable', () async {
+    final dir = await Directory.systemTemp.createTemp('xcross_vm_out');
+    addTearDown(() => dir.delete(recursive: true));
+    final script = File('${dir.path}/target.dart');
+    await script.writeAsString('''
 import 'dart:async';
 import 'dart:developer';
 import 'dart:io';
@@ -35,49 +33,47 @@ void main() {
 }
 ''');
 
-      final child = await Process.start(Platform.resolvedExecutable, [
-        'run',
-        '--enable-vm-service=0',
-        '--disable-service-auth-codes',
-        script.path,
-      ], environment: _noLoopbackProxy());
-      addTearDown(() => child.kill(ProcessSignal.sigkill));
+    final child = await Process.start(Platform.resolvedExecutable, [
+      'run',
+      '--enable-vm-service=0',
+      '--disable-service-auth-codes',
+      script.path,
+    ], environment: _noLoopbackProxy());
+    addTearDown(() => child.kill(ProcessSignal.sigkill));
 
-      // "The Dart VM service is listening on http://127.0.0.1:<port>/"
-      final banner = await child.stdout
-          .transform(const SystemEncoding().decoder)
-          .transform(const LineSplitter())
-          .firstWhere((l) => l.contains('listening on'))
-          .timeout(const Duration(seconds: 30));
-      final httpUri = Uri.parse(
-        RegExp(r'(http://\S+)').firstMatch(banner)!.group(1)!,
-      );
-      final wsUri = httpUri.replace(scheme: 'ws', path: '${httpUri.path}ws');
+    // "The Dart VM service is listening on http://127.0.0.1:<port>/"
+    final banner = await child.stdout
+        .transform(const SystemEncoding().decoder)
+        .transform(const LineSplitter())
+        .firstWhere((l) => l.contains('listening on'))
+        .timeout(const Duration(seconds: 30));
+    final httpUri = Uri.parse(
+      RegExp(r'(http://\S+)').firstMatch(banner)!.group(1)!,
+    );
+    final wsUri = httpUri.replace(scheme: 'ws', path: '${httpUri.path}ws');
 
-      final vm = DartVmServiceClient();
-      await vm.connect(wsUri);
-      addTearDown(vm.close);
+    final vm = DartVmServiceClient();
+    await vm.connect(wsUri);
+    addTearDown(vm.close);
 
-      final seen = <String>{};
-      final done = Completer<void>();
-      vm.events.listen((event) {
-        if (event['streamId'] case final String id) seen.add(id);
-        if (seen.containsAll(const {'Stdout', 'Stderr', 'Logging'}) &&
-            !done.isCompleted) {
-          done.complete();
-        }
-      });
-      await vm.streamListen('Stdout');
-      await vm.streamListen('Stderr');
-      await vm.streamListen('Logging');
+    final seen = <String>{};
+    final done = Completer<void>();
+    vm.events.listen((event) {
+      if (event['streamId'] case final String id) seen.add(id);
+      if (seen.containsAll(const {'Stdout', 'Stderr', 'Logging'}) &&
+          !done.isCompleted) {
+        done.complete();
+      }
+    });
+    await vm.streamListen('Stdout');
+    await vm.streamListen('Stderr');
+    await vm.streamListen('Logging');
 
-      await done.future.timeout(
-        const Duration(seconds: 20),
-        onTimeout: () => fail('never saw all three streams; saw: $seen'),
-      );
-    },
-    timeout: const Timeout(Duration(seconds: 60)),
-  );
+    await done.future.timeout(
+      const Duration(seconds: 20),
+      onTimeout: () => fail('never saw all three streams; saw: $seen'),
+    );
+  }, timeout: const Timeout(Duration(seconds: 60)));
 }
 
 /// Environment for the child VM with loopback exempted from any proxy.

--- a/packages/xcross/test/update/file_swap_test.dart
+++ b/packages/xcross/test/update/file_swap_test.dart
@@ -86,11 +86,9 @@ void main() {
     );
     await swap.discardBackups();
 
-    expect(
-      installed.listSync().map((e) => p.basename(e.path)),
-      ['xcross'],
-      reason: 'no .new- or .old- leftovers',
-    );
+    expect(installed.listSync().map((e) => p.basename(e.path)), [
+      'xcross',
+    ], reason: 'no .new- or .old- leftovers');
   });
 
   test('rollback removes a file the update newly added', () async {

--- a/packages/xcross/test/update/install_layout_test.dart
+++ b/packages/xcross/test/update/install_layout_test.dart
@@ -32,22 +32,18 @@ void main() {
     expect(File(layout.binaryPath).existsSync(), isTrue);
   });
 
-  test(
-    'resolves a symlink so the real file is the update target',
-    () {
-      final linkDir = Directory(p.join(prefix.path, 'link'))..createSync();
-      final link = Link(p.join(linkDir.path, _exeName()))
-        ..createSync(p.join(prefix.path, 'bin', _exeName()));
+  test('resolves a symlink so the real file is the update target', () {
+    final linkDir = Directory(p.join(prefix.path, 'link'))..createSync();
+    final link = Link(p.join(linkDir.path, _exeName()))
+      ..createSync(p.join(prefix.path, 'bin', _exeName()));
 
-      final layout = InstallLayout.forExecutable(link.path);
-      expect(p.basename(layout.binDir), 'bin');
-      expect(
-        layout.binaryPath,
-        File(p.join(prefix.path, 'bin', _exeName())).resolveSymbolicLinksSync(),
-      );
-    },
-    onPlatform: const {'windows': Skip('symlinks need elevation')},
-  );
+    final layout = InstallLayout.forExecutable(link.path);
+    expect(p.basename(layout.binDir), 'bin');
+    expect(
+      layout.binaryPath,
+      File(p.join(prefix.path, 'bin', _exeName())).resolveSymbolicLinksSync(),
+    );
+  }, onPlatform: const {'windows': Skip('symlinks need elevation')});
 
   test('refuses a dart run checkout', () {
     final dart = File(p.join(prefix.path, 'bin', 'dart'))
@@ -102,10 +98,8 @@ void main() {
       p.join(prefix.path, 'bin', _exeName()),
     );
     expect(layout.isWritable, isTrue);
-    expect(
-      Directory(layout.binDir).listSync().map((e) => p.basename(e.path)),
-      [_exeName()],
-      reason: 'the write probe must not leave anything behind',
-    );
+    expect(Directory(layout.binDir).listSync().map((e) => p.basename(e.path)), [
+      _exeName(),
+    ], reason: 'the write probe must not leave anything behind');
   });
 }


### PR DESCRIPTION
Fixes #26.

## Problem

With a production/TestFlight build of the same app installed, `xcross flutter run` attached to *that* app instead of the one it had just installed:

```
'NSLocalizedDescription': 'Permission to debug com.production.app was denied.'
'NSLocalizedRecoverySuggestion': "The app must be debuggable and signed with 'get-task-allow'."
```

The launcher re-derived the bundle id by scanning the device's installed-app list for a suffix match on `.<bundle id>`. The bare production id matched and, being the shortest, won. It is signed without `get-task-allow`, so the debugger attach fails.

## Fix

Single source of truth for the qualified id:

- `DeviceBackend.install` now returns the `XCR-<identity>.<id>` it actually signed and installed.
- `DeviceRunOperation` hands that exact value to `CoreDeviceLauncher.launch`, which no longer guesses at all.
- The app-list lookup remains only for `terminateIfRunning`, which runs before the signing identity is known, and is now strict: `ProvisioningIdentifiers.isQualifiedForm` requires the `XCR-<identity>.` prefix and an exact base match, so a bare production id or an extension id can never match.

Behaviour is unchanged otherwise: xcross still deliberately installs under its own prefixed App ID rather than taking over the production bundle id.

## Tests

`ProvisioningIdentifiers.isQualifiedForm` and `CoreDeviceLauncher.pickInstalledBundleId` are covered directly (production id, unrelated suffix, extension id, several team prefixes), and the run-operation test asserts launch receives the id install returned. Full suite passes, analyzer clean.