### PR TITLE
fix(flutter): recover missing Swift interop targets

### DIFF
--- a/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
@@ -89,10 +89,25 @@ abstract final class GeneratedPluginsPackage {
           'spmPlugins=${[for (final plugin in spmPlugins) plugin.name]}',
         );
 
+        final interopProductsByPlugin = <String, Set<String>>{};
+        for (final plugin in spmPlugins) {
+          final manifest = await File(
+            p.join(plugin.swiftPackageDir, 'Package.swift'),
+          ).readAsString();
+          final products = dependencyProductNames(manifest);
+          if (products.isNotEmpty) {
+            interopProductsByPlugin[plugin.name] = products;
+          }
+        }
+        final interopTargetCandidates = {
+          for (final products in interopProductsByPlugin.values) ...products,
+        };
+
         await writeGeneratedPackages(
           outputDir: outputDir,
           plugins: spmPlugins,
           flutterXcframework: flutterXcframework,
+          copyPluginPackages: interopProductsByPlugin.keys.toSet(),
           deploymentTarget: deploymentTarget,
           verbose: verbose,
         );
@@ -104,6 +119,18 @@ abstract final class GeneratedPluginsPackage {
           pluginsDir: pluginsDir,
           scratchPath: scratchPath,
           flutterXcframework: flutterXcframework,
+          interopTargetCandidates: interopTargetCandidates,
+          interopConsumers: {
+            for (final plugin in spmPlugins)
+              if (interopProductsByPlugin[plugin.name] case final products?)
+                p.join(
+                  outputDir,
+                  'Packages',
+                  plugin.name,
+                  plugin.platformDirectoryName,
+                  p.basename(plugin.swiftPackageDir),
+                ): products,
+          },
         );
 
         return discoverAndRewriteDylibs(
@@ -118,6 +145,8 @@ abstract final class GeneratedPluginsPackage {
     required String pluginsDir,
     required String scratchPath,
     required String flutterXcframework,
+    required Set<String> interopTargetCandidates,
+    required Map<String, Set<String>> interopConsumers,
   }) async {
     final sdk = DarwinSdk.current();
     if (sdk == null) {
@@ -183,32 +212,40 @@ abstract final class GeneratedPluginsPackage {
       );
     }
     final targetBuildDir = p.join(scratchPath, 'arm64-apple-ios', 'debug');
-    Future<void> build() => ProcessRunner.runChecked(
-      swift,
-      swiftBuildArguments(
-        pluginsDir: pluginsDir,
-        scratchPath: scratchPath,
-        swiftSdksPath: swiftSdksPath,
-        iosSdk: sdk.iPhoneOSSdk(),
-        flutterFrameworkSlice: flutterFrameworkSlice,
-        toolsetPath: toolsetPath,
-        // Windows gets the same override from the toolset's `linker`.
-        linkerPath: windows ? null : linker,
-        windows: windows,
-        interopSearchPaths: windows
-            ? swiftInteropSearchPaths(targetBuildDir)
-            : const [],
-        previewMacroStubPath: previewMacroStub,
-      ),
-      environment: environment,
-      inheritStdio: Log.isVerbose,
-      label: 'swift build',
-    );
+    Future<void> runBuild([List<String> selection = const []]) =>
+        ProcessRunner.runChecked(
+          swift,
+          [
+            ...swiftBuildArguments(
+              pluginsDir: pluginsDir,
+              scratchPath: scratchPath,
+              swiftSdksPath: swiftSdksPath,
+              iosSdk: sdk.iPhoneOSSdk(),
+              flutterFrameworkSlice: flutterFrameworkSlice,
+              toolsetPath: toolsetPath,
+              // Windows gets the same override from the toolset's `linker`.
+              linkerPath: windows ? null : linker,
+              windows: windows,
+              interopSearchPaths: swiftInteropSearchPaths(targetBuildDir),
+              previewMacroStubPath: previewMacroStub,
+            ),
+            ...selection,
+          ],
+          environment: environment,
+          inheritStdio: windows && Log.isVerbose,
+          label: 'swift build',
+        );
 
     await buildTranslatingSdkMismatch(
-      () => buildWithInteropRetry(
-        build: build,
+      () => buildWithInteropRecovery(
+        build: runBuild,
+        buildTarget: (target) => runBuild(['--target', target]),
         targetBuildDir: targetBuildDir,
+        interopTargetCandidates: interopTargetCandidates,
+        repairConsumers: () => repairSwiftInteropConsumers(
+          targetBuildDir: targetBuildDir,
+          consumerProducts: interopConsumers,
+        ),
         windows: windows,
       ),
     );
@@ -270,50 +307,191 @@ abstract final class GeneratedPluginsPackage {
     }
   }
 
-  /// Retries a [build] once when it looks like it lost the race against
-  /// SwiftPM's own interop-header generation.
+  /// Repairs and retries a [build] whose generated Swift interop header is
+  /// missing.
   ///
-  /// A target that reaches a package's Objective-C headers through a
-  /// generated compatibility module needs the interop headers Swift emits
-  /// for that package, and SwiftPM does not put them on its search path.
-  /// Those headers only exist once their own target has been built, so the
-  /// first run can fail at the target that needs them while emitting them
-  /// for a retry to consume. POSIX hosts additionally require the failure to
-  /// name a missing `-Swift.h`; Windows retains the broader header-emission
-  /// check because its compatibility-module failures do not always name it.
-  /// Builds are incremental, so the retry only builds what the first run
-  /// could not.
+  /// SwiftPM can schedule an Objective-C consumer after writing a Swift
+  /// target's module map but before compiling the target that emits the
+  /// referenced `-Swift.h`. Prebuilding each affected target establishes the
+  /// missing output before the aggregate build resumes. Windows retains its
+  /// existing one-retry fallback for compatibility modules whose failure does
+  /// not leave a missing generated-header reference behind.
   @visibleForTesting
-  static Future<void> buildWithInteropRetry({
+  static Future<void> buildWithInteropRecovery({
     required Future<void> Function() build,
+    required Future<void> Function(String target) buildTarget,
     required String targetBuildDir,
+    required Set<String> interopTargetCandidates,
+    Future<void> Function()? repairConsumers,
     bool? windows,
   }) async {
+    final repair = repairConsumers ?? () async {};
+
+    Future<bool> recoverMissingTargets([Object? failure]) async {
+      final targets = missingSwiftInteropTargets(
+        targetBuildDir,
+        candidates: interopTargetCandidates,
+      );
+      if (failure != null &&
+          !(windows ?? Platform.isWindows) &&
+          !isMissingSwiftInteropHeaderFailure(failure, targets)) {
+        return false;
+      }
+      for (final target in targets) {
+        await buildTarget(target);
+      }
+      if (targets.isNotEmpty) await repair();
+      return targets.isNotEmpty;
+    }
+
+    await repair();
+    if (await recoverMissingTargets()) {
+      await build();
+      return;
+    }
+
     final before = swiftInteropSearchPaths(targetBuildDir).toSet();
     try {
       await build();
     } on Object catch (error) {
-      if (!(windows ?? Platform.isWindows) &&
-          !_isMissingSwiftInteropHeaderError(error)) {
-        rethrow;
+      if (await recoverMissingTargets(error)) {
+        await build();
+        return;
       }
       final emitted = swiftInteropSearchPaths(
         targetBuildDir,
       ).toSet().difference(before);
-      if (emitted.isEmpty) {
+      if (!(windows ?? Platform.isWindows) || emitted.isEmpty) {
         rethrow;
       }
+      await repair();
       await build();
     }
   }
 
-  static bool _isMissingSwiftInteropHeaderError(Object error) {
+  @visibleForTesting
+  static bool isMissingSwiftInteropHeaderFailure(
+    Object error,
+    Iterable<String> targets,
+  ) {
     final message = '$error';
-    return message.contains('-Swift.h') &&
-        RegExp(
-          r'\b(?:file )?not found\b',
-          caseSensitive: false,
-        ).hasMatch(message);
+    return targets.any(
+      (target) =>
+          message.contains('$target-Swift.h') && message.contains('not found'),
+    );
+  }
+
+  @visibleForTesting
+  static List<String> missingSwiftInteropTargets(
+    String targetBuildDir, {
+    required Set<String> candidates,
+  }) {
+    final directory = Directory(targetBuildDir);
+    if (!directory.existsSync()) return const [];
+    final targets = <String>{};
+    final headerPattern = RegExp(r'\bheader\s+"([^"]+-Swift\.h)"');
+    for (final entity in directory.listSync(followLinks: false)) {
+      if (entity is! Directory || !p.basename(entity.path).endsWith('.build')) {
+        continue;
+      }
+      final include = p.join(entity.path, 'include');
+      final moduleMap = File(p.join(include, 'module.modulemap'));
+      if (!moduleMap.existsSync()) continue;
+      for (final match in headerPattern.allMatches(
+        moduleMap.readAsStringSync(),
+      )) {
+        final reference = match.group(1)!;
+        final header = p.isAbsolute(reference)
+            ? reference
+            : p.join(include, reference);
+        if (File(header).existsSync()) continue;
+        final basename = p.basename(reference);
+        final target = basename.substring(
+          0,
+          basename.length - '-Swift.h'.length,
+        );
+        if (candidates.contains(target)) targets.add(target);
+      }
+    }
+    final sorted = targets.toList()..sort();
+    return sorted;
+  }
+
+  @visibleForTesting
+  static Set<String> dependencyProductNames(String manifest) => {
+    for (final call in _swiftCalls(manifest, '.product'))
+      if (_namedString(call.text, 'name') case final String name) name,
+  };
+
+  @visibleForTesting
+  static Future<void> repairSwiftInteropConsumers({
+    required String targetBuildDir,
+    required Map<String, Set<String>> consumerProducts,
+  }) async {
+    final importsByProduct = <String, List<String>>{};
+    final importPattern = RegExp(
+      r'^\s*@import\s+([A-Za-z_][A-Za-z0-9_]*)\s*;',
+      multiLine: true,
+    );
+    for (final product in {
+      for (final products in consumerProducts.values) ...products,
+    }) {
+      final header = File(
+        p.join(targetBuildDir, '$product.build', 'include', '$product-Swift.h'),
+      );
+      if (!header.existsSync()) continue;
+      final imports = {
+        for (final match in importPattern.allMatches(header.readAsStringSync()))
+          if (match.group(1)! != product) match.group(1)!,
+      }.toList()..sort();
+      if (imports.isNotEmpty) importsByProduct[product] = imports;
+    }
+
+    for (final MapEntry(key: consumer, value: products)
+        in consumerProducts.entries) {
+      final directory = Directory(consumer);
+      if (!directory.existsSync()) continue;
+      await for (final entity in directory.list(
+        recursive: true,
+        followLinks: false,
+      )) {
+        if (entity is! File ||
+            !const {'.h', '.m', '.mm'}.contains(p.extension(entity.path))) {
+          continue;
+        }
+        var source = await entity.readAsString();
+        final newline = source.contains('\r\n') ? '\r\n' : '\n';
+        final original = source;
+        for (final product in products) {
+          final imports = importsByProduct[product];
+          if (imports == null) continue;
+          final marker = '@import $product;';
+          final markerStart = source.indexOf(marker);
+          if (markerStart == -1) continue;
+          final missing = [
+            for (final imported in imports)
+              if (!source.contains('@import $imported;')) '@import $imported;',
+          ];
+          if (missing.isEmpty) continue;
+          var insertAt = markerStart + marker.length;
+          if (source.startsWith('\r\n', insertAt)) {
+            insertAt += 2;
+          } else if (source.startsWith('\n', insertAt) ||
+              source.startsWith('\r', insertAt)) {
+            insertAt++;
+          } else {
+            source = source.replaceRange(insertAt, insertAt, newline);
+            insertAt += newline.length;
+          }
+          source = source.replaceRange(
+            insertAt,
+            insertAt,
+            '${missing.join(newline)}$newline',
+          );
+        }
+        if (source != original) await _writeStable(entity.path, source);
+      }
+    }
   }
 
   /// Process-local settings for Windows SwiftPM dependency checkout and
@@ -509,8 +687,8 @@ abstract final class GeneratedPluginsPackage {
       // implicit Clang modules through its own frontend, so it needs the
       // flag as well as the C/Objective-C targets.
       ...noImplicitModuleLockArguments,
-      ...interopSearchPaths,
     ],
+    ...interopSearchPaths,
     // Apple's `PreviewsMacros` plugin ships only inside Xcode, so `#Preview`
     // needs the stub on every cross host, not just Windows.
     if (previewMacroStubPath != null) ...[
@@ -728,6 +906,7 @@ abstract final class GeneratedPluginsPackage {
     bool verbose = false,
     bool? copyFlutterXcframework,
     bool? vendorRemotePackages,
+    Set<String> copyPluginPackages = const {},
   }) async {
     final windows = Platform.isWindows;
     final packagesDir = p.join(outputDir, 'Packages');
@@ -751,7 +930,35 @@ abstract final class GeneratedPluginsPackage {
         target: plugin.swiftPackageDir,
         platformDir: plugin.platformDirectoryName,
         vendorDir: shouldVendor ? vendorDir : null,
+        copySources: copyPluginPackages.contains(plugin.name),
       );
+    }
+    final packagesByDirectoryName = {
+      for (final package in pluginPackageDirs.values)
+        p.basename(package): package,
+    };
+    for (final plugin in plugins) {
+      if (!copyPluginPackages.contains(plugin.name)) continue;
+      final stagedPackage = pluginPackageDirs[plugin.name]!;
+      final manifestFile = File(p.join(stagedPackage, 'Package.swift'));
+      var manifest = await manifestFile.readAsString();
+      final original = manifest;
+      for (final call in _swiftCalls(manifest, '.package').reversed) {
+        final relativePath = _namedString(call.text, 'path');
+        if (relativePath == null || p.isAbsolute(relativePath)) continue;
+        final dependencyPath = p.normalize(p.join(stagedPackage, relativePath));
+        final sharedPackage =
+            packagesByDirectoryName[p.basename(dependencyPath)];
+        if (sharedPackage == null || p.equals(dependencyPath, sharedPackage)) {
+          continue;
+        }
+        final rewritten = call.text.replaceFirst(
+          RegExp(r'path\s*:\s*"[^"]+"'),
+          'path: "${_swiftPath(sharedPackage)}"',
+        );
+        manifest = manifest.replaceRange(call.start, call.end, rewritten);
+      }
+      if (manifest != original) await _writeStable(manifestFile.path, manifest);
     }
     await _writePluginsPackage(
       pluginsDir: pluginsDir,
@@ -776,9 +983,11 @@ abstract final class GeneratedPluginsPackage {
     required String target,
     String platformDir = 'ios',
     String? vendorDir,
+    bool copySources = false,
   }) async {
     var stagedPackage = alias;
-    if (vendorDir != null) {
+    final shouldCopySources = vendorDir != null || copySources;
+    if (shouldCopySources) {
       await _deleteUnless(alias, FileSystemEntityType.directory);
       final packageRoot = p.dirname(p.dirname(target));
       await _stageAncestorOverlay(
@@ -805,7 +1014,7 @@ abstract final class GeneratedPluginsPackage {
       );
     }
 
-    if (vendorDir != null) {
+    if (shouldCopySources) {
       // Normalizing during the mirror keeps re-runs byte-stable: copying
       // first and normalizing after would rewrite (and re-timestamp) every
       // normalized source on every build.

--- a/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
@@ -205,13 +205,12 @@ abstract final class GeneratedPluginsPackage {
       label: 'swift build',
     );
 
-    if (!windows) {
-      await buildTranslatingSdkMismatch(build);
-      return;
-    }
     await buildTranslatingSdkMismatch(
-      () =>
-          _buildWithInteropRetry(build: build, targetBuildDir: targetBuildDir),
+      () => buildWithInteropRetry(
+        build: build,
+        targetBuildDir: targetBuildDir,
+        windows: windows,
+      ),
     );
   }
 
@@ -271,30 +270,50 @@ abstract final class GeneratedPluginsPackage {
     }
   }
 
-  /// Retries a Windows [build] once when it looks like it lost the race
-  /// against SwiftPM's own interop-header generation.
+  /// Retries a [build] once when it looks like it lost the race against
+  /// SwiftPM's own interop-header generation.
   ///
   /// A target that reaches a package's Objective-C headers through a
   /// generated compatibility module needs the interop headers Swift emits
   /// for that package, and SwiftPM does not put them on its search path.
   /// Those headers only exist once their own target has been built, so the
   /// first run can fail at the target that needs them while emitting them
-  /// for a retry to consume. Builds are incremental, so the retry only
-  /// builds what the first run could not — and a genuine compile error,
-  /// which emits no new headers, still fails once.
-  static Future<void> _buildWithInteropRetry({
+  /// for a retry to consume. POSIX hosts additionally require the failure to
+  /// name a missing `-Swift.h`; Windows retains the broader header-emission
+  /// check because its compatibility-module failures do not always name it.
+  /// Builds are incremental, so the retry only builds what the first run
+  /// could not.
+  @visibleForTesting
+  static Future<void> buildWithInteropRetry({
     required Future<void> Function() build,
     required String targetBuildDir,
+    bool? windows,
   }) async {
-    final before = swiftInteropSearchPaths(targetBuildDir);
+    final before = swiftInteropSearchPaths(targetBuildDir).toSet();
     try {
       await build();
-    } on Object {
-      if (swiftInteropSearchPaths(targetBuildDir).length == before.length) {
+    } on Object catch (error) {
+      if (!(windows ?? Platform.isWindows) &&
+          !_isMissingSwiftInteropHeaderError(error)) {
+        rethrow;
+      }
+      final emitted = swiftInteropSearchPaths(
+        targetBuildDir,
+      ).toSet().difference(before);
+      if (emitted.isEmpty) {
         rethrow;
       }
       await build();
     }
+  }
+
+  static bool _isMissingSwiftInteropHeaderError(Object error) {
+    final message = '$error';
+    return message.contains('-Swift.h') &&
+        RegExp(
+          r'\b(?:file )?not found\b',
+          caseSensitive: false,
+        ).hasMatch(message);
   }
 
   /// Process-local settings for Windows SwiftPM dependency checkout and

--- a/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
+++ b/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
@@ -1801,6 +1801,81 @@ let package = Package(
       );
     });
 
+    test('retries when a failed build emits a Swift interop header', () async {
+      final buildDir = p.join(tmp.path, 'arm64-apple-ios', 'debug');
+      var attempts = 0;
+
+      await GeneratedPluginsPackage.buildWithInteropRetry(
+        targetBuildDir: buildDir,
+        windows: false,
+        build: () async {
+          attempts++;
+          if (attempts != 1) return;
+          final include = p.join(
+            buildDir,
+            'FirebaseFirestore.build',
+            'include',
+          );
+          Directory(include).createSync(recursive: true);
+          File(
+            p.join(include, 'FirebaseFirestore-Swift.h'),
+          ).writeAsStringSync('// generated');
+          throw StateError(
+            "header '$include/FirebaseFirestore-Swift.h' not found",
+          );
+        },
+      );
+
+      expect(attempts, 2);
+    });
+
+    test('does not retry a failure that emits no interop header', () async {
+      var attempts = 0;
+
+      await expectLater(
+        GeneratedPluginsPackage.buildWithInteropRetry(
+          targetBuildDir: p.join(tmp.path, 'arm64-apple-ios', 'debug'),
+          windows: false,
+          build: () {
+            attempts++;
+            return Future<void>.error(StateError('real compile failure'));
+          },
+        ),
+        throwsStateError,
+      );
+
+      expect(attempts, 1);
+    });
+
+    test(
+      'does not retry an unrelated POSIX failure as headers build',
+      () async {
+        final buildDir = p.join(tmp.path, 'arm64-apple-ios', 'debug');
+        var attempts = 0;
+
+        await expectLater(
+          GeneratedPluginsPackage.buildWithInteropRetry(
+            targetBuildDir: buildDir,
+            windows: false,
+            build: () {
+              attempts++;
+              final include = p.join(buildDir, 'OtherSwift.build', 'include');
+              Directory(include).createSync(recursive: true);
+              File(
+                p.join(include, 'OtherSwift-Swift.h'),
+              ).writeAsStringSync('// generated');
+              return Future<void>.error(
+                StateError('unrelated compile failure'),
+              );
+            },
+          ),
+          throwsStateError,
+        );
+
+        expect(attempts, 1);
+      },
+    );
+
     test('drops Clang implicit module locks only on Windows', () {
       List<String> argumentsFor({required bool windows}) =>
           GeneratedPluginsPackage.swiftBuildArguments(

--- a/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
+++ b/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
@@ -170,6 +170,16 @@ let package = Package(
   });
 
   group('normalizeHostManifest', () {
+    test('finds dependency products that may emit Swift headers', () {
+      expect(
+        GeneratedPluginsPackage.dependencyProductNames('''
+.product(name: "FirebaseFirestore", package: "firebase-ios-sdk"),
+.product(name: "firebase-core", package: "firebase_core"),
+'''),
+        {'FirebaseFirestore', 'firebase-core'},
+      );
+    });
+
     test('inserts CRT and ucrt before MSVCRT', () {
       const input = '''
 #if canImport(Darwin)
@@ -1419,6 +1429,76 @@ let package = Package(
       },
     );
 
+    test('copies plugin packages that need interop source repair', () async {
+      final plugin = makePlugin(
+        'cloud_firestore',
+        packageManifest: '''
+// swift-tools-version: 5.9
+import PackageDescription
+let package = Package(
+    name: "cloud_firestore",
+    dependencies: [
+        .package(url: "https://example.com/firebase.git", from: "1.0.0"),
+        .package(name: "firebase_core", path: "../firebase_core")
+    ],
+    targets: [
+        .target(
+            name: "cloud_firestore",
+            dependencies: [.product(name: "FirebaseFirestore", package: "firebase")]
+        )
+    ]
+)
+''',
+      );
+      final source = File(p.join(plugin.swiftPackageDir, 'Sources', 'Plugin.m'))
+        ..createSync(recursive: true);
+      source.writeAsStringSync('@import FirebaseFirestore;\n');
+      final firebaseCore = makePlugin('firebase_core');
+      final flutterXcframework = p.join(tmp.path, 'Flutter.xcframework');
+      Directory(flutterXcframework).createSync(recursive: true);
+      final outputDir = p.join(tmp.path, 'out');
+
+      await GeneratedPluginsPackage.writeGeneratedPackages(
+        outputDir: outputDir,
+        plugins: [plugin, firebaseCore],
+        flutterXcframework: flutterXcframework,
+        copyFlutterXcframework: true,
+        vendorRemotePackages: false,
+        copyPluginPackages: const {'cloud_firestore'},
+        deploymentTarget: const IosDeploymentTarget('15.6'),
+      );
+
+      final staged = File(
+        p.join(
+          outputDir,
+          'Packages',
+          'cloud_firestore',
+          'ios',
+          'cloud_firestore',
+          'Sources',
+          'Plugin.m',
+        ),
+      );
+      expect(staged.readAsStringSync(), '@import FirebaseFirestore;\n');
+      staged.writeAsStringSync('// repaired\n');
+      expect(source.readAsStringSync(), '@import FirebaseFirestore;\n');
+      expect(
+        File(
+          p.join(
+            outputDir,
+            'Packages',
+            'cloud_firestore',
+            'ios',
+            'cloud_firestore',
+            'Package.swift',
+          ),
+        ).readAsStringSync(),
+        contains(
+          'path: "${swiftPath(p.join(outputDir, 'Packages', 'firebase_core'))}"',
+        ),
+      );
+    });
+
     test(
       'writes shared packages and the Flutter xcframework symlink',
       () async {
@@ -1762,7 +1842,7 @@ let package = Package(
       expect(arguments, isNot(contains('-install_name')));
     });
 
-    test('passes interop include dirs of built Swift targets', () {
+    test('passes interop include dirs on POSIX hosts', () {
       final buildDir = p.join(tmp.path, 'arm64-apple-ios', 'debug');
       // A Swift target that has been built: interop header emitted.
       final built = p.join(buildDir, 'Impl.build', 'include');
@@ -1794,52 +1874,154 @@ let package = Package(
           swiftSdksPath: 'xcross-swift-sdks',
           iosSdk: 'iPhoneOS.sdk',
           flutterFrameworkSlice: 'Flutter.xcframework/ios-arm64',
-          windows: true,
+          windows: false,
           interopSearchPaths: ['-Xcc', '-I', '-Xcc', built],
         ),
         containsAllInOrder(['-Xcc', '-I', '-Xcc', built]),
       );
     });
 
-    test('retries when a failed build emits a Swift interop header', () async {
-      final buildDir = p.join(tmp.path, 'arm64-apple-ios', 'debug');
-      var attempts = 0;
+    test(
+      'repairs transitive imports exposed by generated Swift headers',
+      () async {
+        final buildDir = p.join(tmp.path, 'arm64-apple-ios', 'debug');
+        final include = p.join(buildDir, 'FirebaseFirestore.build', 'include');
+        Directory(include).createSync(recursive: true);
+        File(p.join(include, 'FirebaseFirestore-Swift.h')).writeAsStringSync('''
+@import FirebaseFirestoreInternal;
+''');
+        final consumer = p.join(tmp.path, 'cloud_firestore');
+        final source = File(p.join(consumer, 'Sources', 'Plugin.m'))
+          ..createSync(recursive: true)
+          ..writeAsStringSync('''
+@import FirebaseFirestore;
+void registerPlugin(void) {}
+''');
+        final unrelated = File(p.join(consumer, 'Sources', 'Other.m'))
+          ..writeAsStringSync('@import FirebaseCore;\n');
 
-      await GeneratedPluginsPackage.buildWithInteropRetry(
-        targetBuildDir: buildDir,
-        windows: false,
-        build: () async {
-          attempts++;
-          if (attempts != 1) return;
-          final include = p.join(
-            buildDir,
-            'FirebaseFirestore.build',
-            'include',
-          );
-          Directory(include).createSync(recursive: true);
-          File(
-            p.join(include, 'FirebaseFirestore-Swift.h'),
-          ).writeAsStringSync('// generated');
-          throw StateError(
-            "header '$include/FirebaseFirestore-Swift.h' not found",
-          );
-        },
-      );
+        await GeneratedPluginsPackage.repairSwiftInteropConsumers(
+          targetBuildDir: buildDir,
+          consumerProducts: {
+            consumer: const {'FirebaseFirestore'},
+          },
+        );
+        await GeneratedPluginsPackage.repairSwiftInteropConsumers(
+          targetBuildDir: buildDir,
+          consumerProducts: {
+            consumer: const {'FirebaseFirestore'},
+          },
+        );
 
-      expect(attempts, 2);
-    });
+        expect(source.readAsStringSync(), '''
+@import FirebaseFirestore;
+@import FirebaseFirestoreInternal;
+void registerPlugin(void) {}
+''');
+        expect(unrelated.readAsStringSync(), '@import FirebaseCore;\n');
+      },
+    );
+
+    test(
+      'prebuilds a Swift target whose generated header is missing',
+      () async {
+        final buildDir = p.join(tmp.path, 'arm64-apple-ios', 'debug');
+        final include = p.join(buildDir, 'FirebaseFirestore.build', 'include');
+        Directory(include).createSync(recursive: true);
+        File(p.join(include, 'module.modulemap')).writeAsStringSync('''
+module FirebaseFirestore {
+  header "FirebaseFirestore-Swift.h"
+}
+''');
+        final unrelated = p.join(buildDir, 'FirebaseAI.build', 'include');
+        Directory(unrelated).createSync(recursive: true);
+        File(p.join(unrelated, 'module.modulemap')).writeAsStringSync('''
+module FirebaseAI {
+  header "FirebaseAI-Swift.h"
+}
+''');
+        var attempts = 0;
+        final prebuilt = <String>[];
+        final events = <String>[];
+
+        await GeneratedPluginsPackage.buildWithInteropRecovery(
+          targetBuildDir: buildDir,
+          interopTargetCandidates: const {'FirebaseFirestore'},
+          windows: false,
+          build: () async {
+            events.add('build');
+            attempts++;
+          },
+          buildTarget: (target) async {
+            events.add('target');
+            prebuilt.add(target);
+            File(
+              p.join(include, 'FirebaseFirestore-Swift.h'),
+            ).writeAsStringSync('// generated');
+          },
+          repairConsumers: () async => events.add('repair'),
+        );
+
+        expect(prebuilt, ['FirebaseFirestore']);
+        expect(attempts, 1);
+        expect(events, ['repair', 'target', 'repair', 'build']);
+      },
+    );
+
+    test(
+      'prebuilds and retries when a build exposes a missing header',
+      () async {
+        final buildDir = p.join(tmp.path, 'arm64-apple-ios', 'debug');
+        final include = p.join(buildDir, 'FirebaseFirestore.build', 'include');
+        var attempts = 0;
+        final events = <String>[];
+
+        await GeneratedPluginsPackage.buildWithInteropRecovery(
+          targetBuildDir: buildDir,
+          interopTargetCandidates: const {'FirebaseFirestore'},
+          windows: false,
+          build: () async {
+            attempts++;
+            events.add('build$attempts');
+            if (attempts != 1) return;
+            Directory(include).createSync(recursive: true);
+            File(p.join(include, 'module.modulemap')).writeAsStringSync('''
+module FirebaseFirestore {
+  header "$include/FirebaseFirestore-Swift.h"
+}
+''');
+            throw StateError(
+              "header '$include/FirebaseFirestore-Swift.h' not found",
+            );
+          },
+          buildTarget: (target) async {
+            events.add('target');
+            expect(target, 'FirebaseFirestore');
+            File(
+              p.join(include, 'FirebaseFirestore-Swift.h'),
+            ).writeAsStringSync('// generated');
+          },
+          repairConsumers: () async => events.add('repair'),
+        );
+
+        expect(attempts, 2);
+        expect(events, ['repair', 'build1', 'target', 'repair', 'build2']);
+      },
+    );
 
     test('does not retry a failure that emits no interop header', () async {
       var attempts = 0;
 
       await expectLater(
-        GeneratedPluginsPackage.buildWithInteropRetry(
+        GeneratedPluginsPackage.buildWithInteropRecovery(
           targetBuildDir: p.join(tmp.path, 'arm64-apple-ios', 'debug'),
+          interopTargetCandidates: const {'FirebaseFirestore'},
           windows: false,
           build: () {
             attempts++;
             return Future<void>.error(StateError('real compile failure'));
           },
+          buildTarget: (_) async => fail('no target should be prebuilt'),
         ),
         throwsStateError,
       );
@@ -1848,14 +2030,48 @@ let package = Package(
     });
 
     test(
+      'does not retry an unrelated failure that exposes a missing header',
+      () async {
+        final buildDir = p.join(tmp.path, 'arm64-apple-ios', 'debug');
+        final include = p.join(buildDir, 'FirebaseFirestore.build', 'include');
+        var attempts = 0;
+
+        await expectLater(
+          GeneratedPluginsPackage.buildWithInteropRecovery(
+            targetBuildDir: buildDir,
+            interopTargetCandidates: const {'FirebaseFirestore'},
+            windows: false,
+            build: () {
+              attempts++;
+              Directory(include).createSync(recursive: true);
+              File(p.join(include, 'module.modulemap')).writeAsStringSync('''
+module FirebaseFirestore {
+  header "FirebaseFirestore-Swift.h"
+}
+''');
+              return Future<void>.error(
+                StateError('unrelated compile failure'),
+              );
+            },
+            buildTarget: (_) async => fail('no target should be prebuilt'),
+          ),
+          throwsStateError,
+        );
+
+        expect(attempts, 1);
+      },
+    );
+
+    test(
       'does not retry an unrelated POSIX failure as headers build',
       () async {
         final buildDir = p.join(tmp.path, 'arm64-apple-ios', 'debug');
         var attempts = 0;
 
         await expectLater(
-          GeneratedPluginsPackage.buildWithInteropRetry(
+          GeneratedPluginsPackage.buildWithInteropRecovery(
             targetBuildDir: buildDir,
+            interopTargetCandidates: const {'FirebaseFirestore'},
             windows: false,
             build: () {
               attempts++;
@@ -1868,6 +2084,7 @@ let package = Package(
                 StateError('unrelated compile failure'),
               );
             },
+            buildTarget: (_) async => fail('no target should be prebuilt'),
           ),
           throwsStateError,
         );


### PR DESCRIPTION
## Summary

- detect missing generated Swift interop headers and prebuild only the affected SwiftPM targets
- repair transitive Objective-C imports and generated interop search paths for FlutterFire consumers
- qualify POSIX retries to the exact missing-header diagnostic and preserve unrelated failures

## Validation

- `cd packages/xcross && dart test`
- Dart MCP analysis reported no errors
- clean public `xcross flutter build -v` with Flutter 3.47.1, cloud_firestore 6.8.0, and firebase_core 4.13.0 recovered via `--target FirebaseFirestore` and produced the app
- subsequent public recompilation succeeded without another recovery or Firestore module error