### PR TITLE
chore(release): v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 1.2.2
 
 - Phase release and update identity work so source-ref installs report injected normalized refs, tagged release archives report the release tag, and unreleased builds stay clearly marked until the next official update.
 - Build Linux and Windows release artifacts through the shared compile-time identity wrapper, remove the hardcoded dev version fallback from stamped release automation, and keep unreleased installs returning to the latest official release.

--- a/packages/xcross/CHANGELOG.md
+++ b/packages/xcross/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 1.2.2
 
 - Phase release and update identity work so source-ref installs report injected normalized refs, tagged release archives report the release tag, and unreleased builds stay clearly marked until the next official update.
 - Build Linux and Windows release artifacts through the shared compile-time identity wrapper, remove the hardcoded dev version fallback from stamped release automation, and keep unreleased installs returning to the latest official release.

--- a/packages/xcross/pubspec.yaml
+++ b/packages/xcross/pubspec.yaml
@@ -2,7 +2,7 @@ name: xcross
 description: >-
   Build, run, and hot-reload Flutter iOS apps natively from Linux and Windows
   with official Swift and LLVM toolchains and no xtool runtime.
-version: 1.2.1
+version: 1.2.2
 repository: https://github.com/arxdeus/xcross
 homepage: https://github.com/arxdeus/xcross
 topics:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: xcross_workspace
 description: >-
   Workspace root for xcross — the CLI lives in packages/xcross.
-version: 1.2.1
+version: 1.2.2
 publish_to: none
 
 environment:


### PR DESCRIPTION
## Summary

- bump the workspace and `xcross` package versions to 1.2.2
- finalize the 1.2.2 changelog entries

## Verification

- Dart analyzer: no errors or warnings
- `dart test` for all six workspace packages
- `dart pub publish --dry-run` in `packages/xcross`
- `git diff --check`