### PR TITLE
fix(xcross): Flutter launch diagnostics

### DIFF
--- a/packages/xcross/lib/src/device/core_device_launcher.dart
+++ b/packages/xcross/lib/src/device/core_device_launcher.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:apple_developer_kit/apple_developer_kit.dart';
@@ -122,40 +123,46 @@ abstract final class CoreDeviceLauncher {
       bundleId: bundleId,
       appArgs: arguments,
     );
-
-    final gdb = await _attachDebugger(endpoint: debugproxy, pid: pid);
-
-    ({HotReloadController? controller, String? unavailable}) hotReloadSetup = (
-      controller: null,
-      unavailable: null,
+    final deviceLog = await _DeviceLog.start(
+      deviceArgs: transport.pymdDeviceArgs,
+      pid: pid,
     );
-    HotReloadController? hotReloadController;
-    PortForwarder? vmService;
-    // Hot-reload setup is inside the same cleanup boundary as the session. A
-    // failed VM connection must not leak the attached debugger or leave a DAP
-    // launch paused forever.
+
     try {
-      hotReloadSetup = await _trySpinUpHotReload(
-        hotReload: hotReload,
-        transport: transport,
-      );
-      hotReloadController = hotReloadSetup.controller;
-      if (hotReloadController != null) {
-        vmService = await _publishVmService(transport: transport);
+      final gdb = await _attachDebugger(endpoint: debugproxy, pid: pid);
+
+      ({HotReloadController? controller, String? unavailable}) hotReloadSetup =
+          (controller: null, unavailable: null);
+      HotReloadController? hotReloadController;
+      PortForwarder? vmService;
+      // Hot-reload setup is inside the same cleanup boundary as the session. A
+      // failed VM connection must not leak the attached debugger or leave a DAP
+      // launch paused forever.
+      try {
+        hotReloadSetup = await _trySpinUpHotReload(
+          hotReload: hotReload,
+          transport: transport,
+        );
+        hotReloadController = hotReloadSetup.controller;
+        if (hotReloadController != null) {
+          vmService = await _publishVmService(transport: transport);
+        }
+        await SessionConsole(
+          gdb: gdb,
+          hotReload: hotReloadController,
+          hotReloadUnavailable: hotReloadSetup.unavailable,
+          onRestartRequested: onRestartRequested,
+        ).run();
+      } finally {
+        // Every step is timed out: a single hung flush/close on Windows left
+        // `q` in a silent stuck state (no further input or output).
+        await _cleanupStep('vm-service', () => vmService?.close());
+        await _cleanupStep('hot-reload', () => hotReloadController?.close());
+        await _cleanupStep('gdb-kill', gdb.kill);
+        await _cleanupStep('gdb-close', gdb.close);
       }
-      await SessionConsole(
-        gdb: gdb,
-        hotReload: hotReloadController,
-        hotReloadUnavailable: hotReloadSetup.unavailable,
-        onRestartRequested: onRestartRequested,
-      ).run();
     } finally {
-      // Every step is timed out: a single hung flush/close on Windows left `q`
-      // in a silent stuck state (no further input or output).
-      await _cleanupStep('vm-service', () => vmService?.close());
-      await _cleanupStep('hot-reload', () => hotReloadController?.close());
-      await _cleanupStep('gdb-kill', gdb.kill);
-      await _cleanupStep('gdb-close', gdb.close);
+      await deviceLog?.close();
     }
   }
 
@@ -412,5 +419,66 @@ abstract final class CoreDeviceLauncher {
     // ignore: only_throw_errors
     if (lastError case final Object error?) throw error;
     throw XcrossError('VM Service did not become available');
+  }
+}
+
+final class _DeviceLog {
+  _DeviceLog(this._process);
+
+  final Process _process;
+  late final StreamSubscription<String> _stdout;
+  late final StreamSubscription<String> _stderr;
+
+  static Future<_DeviceLog?> start({
+    required List<String> deviceArgs,
+    required int pid,
+  }) async {
+    try {
+      final invocation = await Pymd.resolve();
+      final process = await Process.start(invocation.executable, [
+        ...invocation.prefixArgs,
+        'developer',
+        'dvt',
+        'oslog',
+        ...deviceArgs,
+        '--pid',
+        '$pid',
+      ], environment: Pymd.usbmuxEnvironment());
+      final log = _DeviceLog(process).._listen();
+      unawaited(
+        process.exitCode.then((code) {
+          if (code != 0) {
+            Log.logTrace('device log stream exited with code $code');
+          }
+        }),
+      );
+      Log.logInfo('Device logs', 'streaming for pid $pid');
+      return log;
+    } on Object catch (e) {
+      Log.logWarn('could not stream device logs: $e');
+      return null;
+    }
+  }
+
+  void _listen() {
+    _stdout = _process.stdout
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .listen((line) => stdout.writeln('[device] $line'));
+    _stderr = _process.stderr
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .listen((line) => stderr.writeln('[device] $line'));
+  }
+
+  Future<void> close() async {
+    _process.kill();
+    await _stdout.cancel();
+    await _stderr.cancel();
+    try {
+      await _process.exitCode.timeout(_cleanupTimeout);
+    } on TimeoutException {
+      Log.logTrace('cleanup device-log timed out');
+    }
   }
 }

--- a/packages/xcross/lib/src/device/core_device_launcher.dart
+++ b/packages/xcross/lib/src/device/core_device_launcher.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:apple_developer_kit/apple_developer_kit.dart';
@@ -9,6 +8,7 @@ import 'package:meta/meta.dart';
 import 'package:pure/pure.dart';
 import 'package:xcross/src/constants.dart';
 import 'package:xcross/src/device/core_device_launch_profile.dart';
+import 'package:xcross/src/device/device_log.dart';
 import 'package:xcross/src/device/session_console.dart';
 import 'package:xcross/src/errors.dart';
 import 'package:xcross/src/flutter/flutter.dart';
@@ -123,7 +123,7 @@ abstract final class CoreDeviceLauncher {
       bundleId: bundleId,
       appArgs: arguments,
     );
-    final deviceLog = await _DeviceLog.start(
+    final deviceLog = await DeviceLog.start(
       deviceArgs: transport.pymdDeviceArgs,
       pid: pid,
     );
@@ -419,66 +419,5 @@ abstract final class CoreDeviceLauncher {
     // ignore: only_throw_errors
     if (lastError case final Object error?) throw error;
     throw XcrossError('VM Service did not become available');
-  }
-}
-
-final class _DeviceLog {
-  _DeviceLog(this._process);
-
-  final Process _process;
-  late final StreamSubscription<String> _stdout;
-  late final StreamSubscription<String> _stderr;
-
-  static Future<_DeviceLog?> start({
-    required List<String> deviceArgs,
-    required int pid,
-  }) async {
-    try {
-      final invocation = await Pymd.resolve();
-      final process = await Process.start(invocation.executable, [
-        ...invocation.prefixArgs,
-        'developer',
-        'dvt',
-        'oslog',
-        ...deviceArgs,
-        '--pid',
-        '$pid',
-      ], environment: Pymd.usbmuxEnvironment());
-      final log = _DeviceLog(process).._listen();
-      unawaited(
-        process.exitCode.then((code) {
-          if (code != 0) {
-            Log.logTrace('device log stream exited with code $code');
-          }
-        }),
-      );
-      Log.logInfo('Device logs', 'streaming for pid $pid');
-      return log;
-    } on Object catch (e) {
-      Log.logWarn('could not stream device logs: $e');
-      return null;
-    }
-  }
-
-  void _listen() {
-    _stdout = _process.stdout
-        .transform(utf8.decoder)
-        .transform(const LineSplitter())
-        .listen((line) => stdout.writeln('[device] $line'));
-    _stderr = _process.stderr
-        .transform(utf8.decoder)
-        .transform(const LineSplitter())
-        .listen((line) => stderr.writeln('[device] $line'));
-  }
-
-  Future<void> close() async {
-    _process.kill();
-    await _stdout.cancel();
-    await _stderr.cancel();
-    try {
-      await _process.exitCode.timeout(_cleanupTimeout);
-    } on TimeoutException {
-      Log.logTrace('cleanup device-log timed out');
-    }
   }
 }

--- a/packages/xcross/lib/src/device/device_log.dart
+++ b/packages/xcross/lib/src/device/device_log.dart
@@ -1,0 +1,71 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:cli_kit/cli_kit.dart';
+import 'package:dart_mobile_device/dart_mobile_device.dart';
+import 'package:meta/meta.dart';
+
+@internal
+final class DeviceLog {
+  DeviceLog._(this._process);
+
+  static const _cleanupTimeout = Duration(seconds: 2);
+
+  final Process _process;
+  late final StreamSubscription<String> _stdout;
+  late final StreamSubscription<String> _stderr;
+
+  static Future<DeviceLog?> start({
+    required List<String> deviceArgs,
+    required int pid,
+  }) async {
+    try {
+      final invocation = await Pymd.resolve();
+      final process = await Process.start(invocation.executable, [
+        ...invocation.prefixArgs,
+        'developer',
+        'dvt',
+        'oslog',
+        ...deviceArgs,
+        '--pid',
+        '$pid',
+      ], environment: Pymd.usbmuxEnvironment());
+      final log = DeviceLog._(process).._listen();
+      unawaited(
+        process.exitCode.then((code) {
+          if (code != 0) {
+            Log.logTrace('device log stream exited with code $code');
+          }
+        }),
+      );
+      Log.logInfo('Device logs', 'streaming for pid $pid');
+      return log;
+    } on Object catch (e) {
+      Log.logWarn('could not stream device logs: $e');
+      return null;
+    }
+  }
+
+  void _listen() {
+    _stdout = _process.stdout
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .listen((line) => stdout.writeln('[device] $line'));
+    _stderr = _process.stderr
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .listen((line) => stderr.writeln('[device] $line'));
+  }
+
+  Future<void> close() async {
+    _process.kill();
+    await _stdout.cancel();
+    await _stderr.cancel();
+    try {
+      await _process.exitCode.timeout(_cleanupTimeout);
+    } on TimeoutException {
+      Log.logTrace('cleanup device-log timed out');
+    }
+  }
+}

--- a/packages/xcross/lib/src/flutter/build/flutter_packer.dart
+++ b/packages/xcross/lib/src/flutter/build/flutter_packer.dart
@@ -81,11 +81,13 @@ final class FlutterPacker {
     final pluginsBuild = await _buildPlugins(
       flutterRoot,
       deploymentTarget: deploymentTarget,
+      verbose: Log.isVerbose,
     );
     final runnerResult = await _buildRunnerBinary(
       flutterRoot,
       deploymentTarget: deploymentTarget,
       pluginsLibrary: pluginsBuild?.libraryPath,
+      verbose: Log.isVerbose,
     );
 
     final extensions = await _buildAppExtensions(
@@ -194,6 +196,7 @@ final class FlutterPacker {
   Future<GeneratedPluginsBuildResult?> _buildPlugins(
     String flutterRoot, {
     required IosDeploymentTarget deploymentTarget,
+    required bool verbose,
   }) async {
     final plugins = await PluginDiscovery.discover(projectRoot);
     final spmPlugins = <IosPlugin>[];
@@ -234,6 +237,7 @@ final class FlutterPacker {
       flutterXcframework: xcframework,
       outputDir: p.join(projectRoot, 'build', 'xcross-flutter-plugins'),
       deploymentTarget: deploymentTarget,
+      verbose: verbose,
     );
   }
 
@@ -279,6 +283,7 @@ final class FlutterPacker {
   Future<RunnerBinary> _buildRunnerBinary(
     String flutterRoot, {
     required IosDeploymentTarget deploymentTarget,
+    required bool verbose,
     String? pluginsLibrary,
   }) async {
     final xcframework = IosEngineCache(
@@ -300,6 +305,7 @@ final class FlutterPacker {
       outputDir: p.join(projectRoot, 'build', 'xcross-flutter-runner-bin'),
       deploymentTarget: deploymentTarget,
       pluginsLibrary: pluginsLibrary,
+      verbose: verbose,
     );
 
     return RunnerBinary(xcframework: xcframework, runnerBinary: runnerBinary);

--- a/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
@@ -76,6 +76,7 @@ abstract final class GeneratedPluginsPackage {
     required String flutterXcframework,
     required String outputDir,
     required IosDeploymentTarget deploymentTarget,
+    bool verbose = false,
   }) =>
       Log.logStep('Building Flutter plugins (Swift Package Manager)', () async {
         final spmPlugins = plugins
@@ -93,6 +94,7 @@ abstract final class GeneratedPluginsPackage {
           plugins: spmPlugins,
           flutterXcframework: flutterXcframework,
           deploymentTarget: deploymentTarget,
+          verbose: verbose,
         );
 
         final pluginsDir = p.join(outputDir, 'Plugins');
@@ -704,6 +706,7 @@ abstract final class GeneratedPluginsPackage {
     required List<IosPlugin> plugins,
     required String flutterXcframework,
     required IosDeploymentTarget deploymentTarget,
+    bool verbose = false,
     bool? copyFlutterXcframework,
     bool? vendorRemotePackages,
   }) async {
@@ -737,6 +740,7 @@ abstract final class GeneratedPluginsPackage {
       plugins: plugins,
       pluginPackageDirs: pluginPackageDirs,
       deploymentTarget: deploymentTarget,
+      verbose: verbose,
     );
   }
 
@@ -1009,6 +1013,7 @@ abstract final class GeneratedPluginsPackage {
     required List<IosPlugin> plugins,
     required Map<String, String> pluginPackageDirs,
     required IosDeploymentTarget deploymentTarget,
+    required bool verbose,
   }) async {
     final sourcesDir = p.join(pluginsDir, 'Sources', _pluginsProductName);
     await Directory(sourcesDir).create(recursive: true);
@@ -1025,7 +1030,7 @@ abstract final class GeneratedPluginsPackage {
 
     await _writeStable(
       p.join(sourcesDir, 'GeneratedPluginRegistrant.swift'),
-      registrantSource(plugins),
+      registrantSource(plugins, verbose: verbose),
     );
   }
 
@@ -2364,18 +2369,50 @@ $targetDependencies            ]
   /// (facade/pure-Dart/FFI-only packages) remain SwiftPM target dependencies,
   /// but need no module import or registration call.
   @visibleForTesting
-  static String registrantSource(List<IosPlugin> plugins) {
+  static String registrantSource(
+    List<IosPlugin> plugins, {
+    bool verbose = false,
+  }) {
     final imports = StringBuffer();
     final registrations = StringBuffer();
+    var pluginCount = 0;
     for (final plugin in plugins) {
       final pluginClass = plugin.pluginClassIos;
       if (pluginClass == null) continue;
+      pluginCount++;
       imports.writeln('import ${plugin.name}');
-      registrations.writeln('''
+      if (verbose) {
+        registrations.writeln('''
+    NSLog("[xcross] registering plugin ${plugin.name} ($pluginClass)")
+    if let registrar = registry.registrar(forPlugin: "$pluginClass") {
+        $pluginClass.register(with: registrar)
+        registered += 1
+        NSLog("[xcross] registered plugin ${plugin.name} ($pluginClass)")
+    } else {
+        failures.append("${plugin.name} ($pluginClass): registrar unavailable")
+        NSLog("[xcross] failed plugin ${plugin.name} ($pluginClass): registrar unavailable")
+    }''');
+      } else {
+        registrations.writeln('''
     if let registrar = registry.registrar(forPlugin: "$pluginClass") {
         $pluginClass.register(with: registrar)
     }''');
+      }
     }
+
+    final diagnosticsStart = verbose
+        ? '    var registered = 0\n'
+              '    var failures: [String] = []\n'
+        : '';
+    final diagnosticsEnd = verbose
+        ? '    NSLog("[xcross] plugin registration summary: '
+              '$pluginCount attempted, \\(registered) registered, '
+              '\\(failures.count) failed")\n'
+              '    for failure in failures {\n'
+              '        NSLog("[xcross] plugin registration failure: '
+              '\\(failure)")\n'
+              '    }\n'
+        : '';
 
     return '''
 //
@@ -2386,7 +2423,7 @@ import UIKit
 $imports
 @_cdecl("${GeneratedPluginsConstants.registrantSymbol}")
 public func xcrossRegisterGeneratedPlugins(_ registry: FlutterPluginRegistry) {
-$registrations}
+$diagnosticsStart$registrations$diagnosticsEnd}
 ''';
   }
 

--- a/packages/xcross/lib/src/flutter/build/runner_shim.dart
+++ b/packages/xcross/lib/src/flutter/build/runner_shim.dart
@@ -276,15 +276,23 @@ ${hasPlugins ? _pluginsExternDeclaration : _emptyPluginRegistrantStub}
 @end
 @implementation AppDelegate
 - (BOOL)application:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
+  NSLog(@"[xcross] application launch started");
   FlutterViewController* flutterViewController = [[FlutterViewController alloc] initWithProject:nil nibName:nil bundle:nil];
+  [flutterViewController setFlutterViewDidRenderCallback:^{
+    NSLog(@"[xcross] first Flutter frame rendered");
+  }];
   UIWindow* window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
   window.rootViewController = flutterViewController;
   [window makeKeyAndVisible];
   self.window = window;
-  return [super application:application didFinishLaunchingWithOptions:launchOptions];
+  BOOL launched = [super application:application didFinishLaunchingWithOptions:launchOptions];
+  NSLog(@"[xcross] application launch completed: %@", launched ? @"YES" : @"NO");
+  return launched;
 }
 - (void)didInitializeImplicitFlutterEngine:(NSObject<FlutterImplicitEngineBridge>*)engineBridge {
+  NSLog(@"[xcross] Flutter engine initialized; registering plugins");
   ${hasPlugins ? '${GeneratedPluginsConstants.registrantSymbol}(engineBridge.pluginRegistry);' : '[GeneratedPluginRegistrant registerWithRegistry:engineBridge.pluginRegistry];'}
+  NSLog(@"[xcross] plugin registration completed");
 }
 @end
 

--- a/packages/xcross/lib/src/flutter/build/runner_shim.dart
+++ b/packages/xcross/lib/src/flutter/build/runner_shim.dart
@@ -35,6 +35,7 @@ final class RunnerShim {
     required String outputDir,
     required IosDeploymentTarget deploymentTarget,
     String? pluginsLibrary,
+    bool verbose = false,
   }) => Log.logStep('Compiling Runner', () async {
     final clang = await DarwinSdk.resolveDarwinClang(sdk);
     final iosSdk = _resolveIPhoneOsSDK(sdk);
@@ -46,9 +47,9 @@ final class RunnerShim {
     final objectPath = p.join(outputDir, 'Runner.o');
     final outputPath = p.join(outputDir, 'Runner');
 
-    await File(
-      sourcePath,
-    ).writeAsString(_runnerObjcSource(hasPlugins: pluginsLibrary != null));
+    await File(sourcePath).writeAsString(
+      runnerObjcSource(hasPlugins: pluginsLibrary != null, verbose: verbose),
+    );
 
     await _compileObject(
       clang: clang,
@@ -266,7 +267,11 @@ final class RunnerShim {
   /// `GeneratedPluginsPackage` in ios_plugin_package.dart) — no
   /// generated-header or clang-modules setup needed, just a normal C symbol
   /// resolved at link time by [_linkBinary].
-  static String _runnerObjcSource({required bool hasPlugins}) =>
+  @visibleForTesting
+  static String runnerObjcSource({
+    required bool hasPlugins,
+    required bool verbose,
+  }) =>
       '''
 #import <UIKit/UIKit.h>
 #import <Flutter/Flutter.h>
@@ -276,7 +281,7 @@ ${hasPlugins ? _pluginsExternDeclaration : _emptyPluginRegistrantStub}
 @end
 @implementation AppDelegate
 - (BOOL)application:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
-  NSLog(@"[xcross] application launch started");
+  ${verbose ? 'NSLog(@"[xcross] application launch started");' : ''}
   FlutterViewController* flutterViewController = [[FlutterViewController alloc] initWithProject:nil nibName:nil bundle:nil];
   [flutterViewController setFlutterViewDidRenderCallback:^{
     NSLog(@"[xcross] first Flutter frame rendered");
@@ -286,13 +291,14 @@ ${hasPlugins ? _pluginsExternDeclaration : _emptyPluginRegistrantStub}
   [window makeKeyAndVisible];
   self.window = window;
   BOOL launched = [super application:application didFinishLaunchingWithOptions:launchOptions];
-  NSLog(@"[xcross] application launch completed: %@", launched ? @"YES" : @"NO");
+  ${verbose ? 'NSLog(@"[xcross] FlutterAppDelegate didFinishLaunching returned: %@", launched ? @"YES" : @"NO");' : ''}
   return launched;
 }
 - (void)didInitializeImplicitFlutterEngine:(NSObject<FlutterImplicitEngineBridge>*)engineBridge {
-  NSLog(@"[xcross] Flutter engine initialized; registering plugins");
+  ${verbose ? 'NSLog(@"[xcross] Flutter engine initialized; registering plugins");' : ''}
   ${hasPlugins ? '${GeneratedPluginsConstants.registrantSymbol}(engineBridge.pluginRegistry);' : '[GeneratedPluginRegistrant registerWithRegistry:engineBridge.pluginRegistry];'}
-  NSLog(@"[xcross] plugin registration completed");
+  ${verbose && !hasPlugins ? 'NSLog(@"[xcross] plugin registration summary: 0 attempted, 0 registered, 0 failed");' : ''}
+  ${verbose ? 'NSLog(@"[xcross] plugin registration completed");' : ''}
 }
 @end
 

--- a/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
+++ b/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
@@ -853,6 +853,28 @@ let package = Package(name: "Sentry", products: [], targets: [])
       // Exactly one registration block: only plugin_a has a pluginClass.
       expect('if let registrar'.allMatches(source).length, 1);
       expect(source, contains('@_cdecl("XcrossRegisterGeneratedPlugins")'));
+      expect(source, isNot(contains('[xcross] registering plugin')));
+    });
+
+    test('verbose source tracks each plugin and prints a summary', () {
+      final source = GeneratedPluginsPackage.registrantSource([
+        makePlugin('plugin_a', pluginClass: 'PluginA'),
+      ], verbose: true);
+
+      expect(
+        source,
+        contains('[xcross] registering plugin plugin_a (PluginA)'),
+      );
+      expect(source, contains('[xcross] registered plugin plugin_a (PluginA)'));
+      expect(
+        source,
+        contains(
+          '[xcross] failed plugin plugin_a (PluginA): registrar unavailable',
+        ),
+      );
+      expect(source, contains(r'1 attempted, \(registered) registered'));
+      expect(source, contains(r'\(failures.count) failed'));
+      expect(source, contains(r'plugin registration failure: \(failure)'));
     });
 
     test(

--- a/packages/xcross/test/flutter/build/runner_shim_source_test.dart
+++ b/packages/xcross/test/flutter/build/runner_shim_source_test.dart
@@ -1,0 +1,45 @@
+import 'package:test/test.dart';
+import 'package:xcross/src/flutter/build/runner_shim.dart';
+
+void main() {
+  test('always records the first rendered Flutter frame', () {
+    final source = RunnerShim.runnerObjcSource(
+      hasPlugins: true,
+      verbose: false,
+    );
+
+    expect(source, contains('[xcross] first Flutter frame rendered'));
+    expect(source, isNot(contains('application launch started')));
+    expect(source, isNot(contains('Flutter engine initialized')));
+  });
+
+  test('verbose source records native launch and engine phases', () {
+    final source = RunnerShim.runnerObjcSource(hasPlugins: true, verbose: true);
+
+    expect(source, contains('[xcross] application launch started'));
+    expect(
+      source,
+      contains('[xcross] FlutterAppDelegate didFinishLaunching returned: %@'),
+    );
+    expect(
+      source,
+      contains('[xcross] Flutter engine initialized; registering plugins'),
+    );
+    expect(source, contains('[xcross] plugin registration completed'));
+  });
+
+  test('verbose source summarizes an app without native plugins', () {
+    final source = RunnerShim.runnerObjcSource(
+      hasPlugins: false,
+      verbose: true,
+    );
+
+    expect(
+      source,
+      contains(
+        '[xcross] plugin registration summary: '
+        '0 attempted, 0 registered, 0 failed',
+      ),
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- stream process-scoped iOS unified logs during attached runs
- emit native launch, engine, plugin registration, and first-frame markers
- clean up logging subprocesses without making logging failures fatal
