### PR TITLE
fix(xcross): attach Flutter window to UIScene

### DIFF
--- a/packages/xcross/lib/src/cli/basic/sdk_install.dart
+++ b/packages/xcross/lib/src/cli/basic/sdk_install.dart
@@ -284,6 +284,11 @@ abstract final class SdkInstall {
     final relativeSdkRoot = p
         .relative(sdkRoot, from: artifactRoot)
         .replaceAll(r'\', '/');
+    final toolchainCxx = p.join(artifactRoot, _toolchain, 'usr/include/c++/v1');
+    final sdkCxx = p.join(sdkRoot, 'usr/include/c++/v1');
+    final cxxInclude = Directory(toolchainCxx).existsSync()
+        ? '$_toolchain/usr/include/c++/v1'
+        : p.relative(sdkCxx, from: artifactRoot).replaceAll(r'\', '/');
 
     await _writeJson(p.join(artifactRoot, 'swift-sdk.json'), {
       'schemaVersion': '4.0',
@@ -292,10 +297,7 @@ abstract final class SdkInstall {
           'sdkRootPath': relativeSdkRoot,
           'swiftResourcesPath': _swiftResources,
           'swiftStaticResourcesPath': _swiftStaticResources,
-          'includeSearchPaths': [
-            '$_platformDeveloper/usr/lib',
-            '$_toolchain/usr/include/c++/v1',
-          ],
+          'includeSearchPaths': ['$_platformDeveloper/usr/lib', cxxInclude],
           'librarySearchPaths': ['$_platformDeveloper/usr/lib'],
           'toolsetPaths': ['toolset.json'],
         },

--- a/packages/xcross/lib/src/flutter/build/flutter_packer.dart
+++ b/packages/xcross/lib/src/flutter/build/flutter_packer.dart
@@ -444,6 +444,7 @@ final class FlutterPacker {
       deploymentTarget: deploymentTarget,
     );
     plistXml = InfoPlist.stripUnsatisfiableStoryboards(plistXml, bundleDir);
+    plistXml = InfoPlist.applySceneLifecycle(plistXml);
     plistXml = InfoPlist.normalizeObjCClassNames(plistXml);
     // Carry the app's own App Groups forward so the sign/install stage can
     // provision them alongside its extensions'.

--- a/packages/xcross/lib/src/flutter/build/info_plist.dart
+++ b/packages/xcross/lib/src/flutter/build/info_plist.dart
@@ -222,6 +222,125 @@ abstract final class InfoPlist {
     return result;
   }
 
+  static String applySceneLifecycle(String xml) {
+    const manifestKey = '<key>UIApplicationSceneManifest</key>';
+    final manifestKeyStart = xml.indexOf(manifestKey);
+    if (manifestKeyStart < 0) return _insertBeforeEnd(xml, _sceneManifest);
+
+    final manifest = _containerAfterKey(
+      xml,
+      manifestKeyStart,
+      manifestKey,
+      'dict',
+    );
+    if (manifest == null) return xml;
+    if (manifest.selfClosing) {
+      return xml.replaceRange(
+        manifestKeyStart,
+        manifest.end,
+        _sceneManifest.trimRight(),
+      );
+    }
+
+    const roleKey = '<key>UIWindowSceneSessionRoleApplication</key>';
+    final roleKeyStart = xml.indexOf(roleKey, manifest.start);
+    if (roleKeyStart >= 0 && roleKeyStart < manifest.end) {
+      final role = _containerAfterKey(xml, roleKeyStart, roleKey, 'array');
+      if (role != null && role.end <= manifest.end) {
+        return xml.replaceRange(
+          roleKeyStart,
+          role.end,
+          _applicationSceneConfiguration.trim(),
+        );
+      }
+    }
+
+    const configurationsKey = '<key>UISceneConfigurations</key>';
+    final configurationsKeyStart = xml.indexOf(
+      configurationsKey,
+      manifest.start,
+    );
+    if (configurationsKeyStart >= 0 && configurationsKeyStart < manifest.end) {
+      final configurations = _containerAfterKey(
+        xml,
+        configurationsKeyStart,
+        configurationsKey,
+        'dict',
+      );
+      if (configurations != null && configurations.end <= manifest.end) {
+        if (configurations.selfClosing) {
+          return xml.replaceRange(
+            configurations.start,
+            configurations.end,
+            '<dict>\n$_applicationSceneConfiguration\t\t</dict>',
+          );
+        }
+        return xml.replaceRange(
+          configurations.end - '</dict>'.length,
+          configurations.end - '</dict>'.length,
+          _applicationSceneConfiguration,
+        );
+      }
+    }
+
+    return xml.replaceRange(
+      manifest.end - '</dict>'.length,
+      manifest.end - '</dict>'.length,
+      '\t\t<key>UISceneConfigurations</key>\n'
+      '\t\t<dict>\n'
+      '$_applicationSceneConfiguration'
+      '\t\t</dict>\n',
+    );
+  }
+
+  static ({int start, int end, bool selfClosing})? _containerAfterKey(
+    String xml,
+    int keyStart,
+    String key,
+    String tag,
+  ) {
+    final valueStart = keyStart + key.length;
+    final value = RegExp('\\s*<$tag(/?)>').matchAsPrefix(xml, valueStart);
+    if (value == null) return null;
+    if (value.group(1) == '/') {
+      return (start: value.start, end: value.end, selfClosing: true);
+    }
+
+    var depth = 0;
+    for (final match in RegExp('</?$tag>').allMatches(xml, value.start)) {
+      if (match.group(0) == '<$tag>') {
+        depth++;
+      } else if (--depth == 0) {
+        return (start: value.start, end: match.end, selfClosing: false);
+      }
+    }
+    return null;
+  }
+
+  static const _applicationSceneConfiguration =
+      '\t\t\t<key>UIWindowSceneSessionRoleApplication</key>\n'
+      '\t\t\t<array>\n'
+      '\t\t\t\t<dict>\n'
+      '\t\t\t\t\t<key>UISceneClassName</key>\n'
+      '\t\t\t\t\t<string>UIWindowScene</string>\n'
+      '\t\t\t\t\t<key>UISceneDelegateClassName</key>\n'
+      '\t\t\t\t\t<string>SceneDelegate</string>\n'
+      '\t\t\t\t\t<key>UISceneConfigurationName</key>\n'
+      '\t\t\t\t\t<string>flutter</string>\n'
+      '\t\t\t\t</dict>\n'
+      '\t\t\t</array>\n';
+
+  static const _sceneManifest =
+      '\t<key>UIApplicationSceneManifest</key>\n'
+      '\t<dict>\n'
+      '\t\t<key>UIApplicationSupportsMultipleScenes</key>\n'
+      '\t\t<false/>\n'
+      '\t\t<key>UISceneConfigurations</key>\n'
+      '\t\t<dict>\n'
+      '$_applicationSceneConfiguration'
+      '\t\t</dict>\n'
+      '\t</dict>\n';
+
   /// Drop Swift module prefix from ObjC class names in the plist.
   /// The Runner shim registers `AppDelegate` / `SceneDelegate` without a module
   /// prefix, so `Runner.SceneDelegate` from the stock template would fail
@@ -260,6 +379,7 @@ abstract final class InfoPlist {
       ' "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n'
       '<plist version="1.0">\n'
       '<dict>\n'
+      '$_sceneManifest'
       '\t<key>UILaunchScreen</key>\n'
       '\t<dict/>\n'
       '\t<key>UISupportedInterfaceOrientations</key>\n'

--- a/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
@@ -1331,16 +1331,32 @@ let package = Package(
 
   @visibleForTesting
   static String removeMissingResources(String manifest, String packageDir) {
-    return manifest.replaceAllMapped(
-      RegExp(r'\.((?:process|copy))\(\s*"([^"]+)"\s*\)\s*,?'),
-      (match) {
-        final resource = p.joinAll([packageDir, ...match.group(2)!.split('/')]);
-        return FileSystemEntity.typeSync(resource) ==
-                FileSystemEntityType.notFound
-            ? ''
-            : match.group(0)!;
-      },
+    final targets = _swiftCalls(manifest, '.target');
+    final resourcePattern = RegExp(
+      r'\.((?:process|copy))\(\s*"([^"]+)"\s*\)\s*,?',
     );
+    var result = manifest;
+    for (final match
+        in resourcePattern.allMatches(manifest).toList().reversed) {
+      var root = packageDir;
+      for (final target in targets) {
+        if (target.start > match.start || target.end < match.end) continue;
+        final explicitPath = _namedString(target.text, 'path');
+        final name = _namedString(target.text, 'name');
+        if (explicitPath != null) {
+          root = p.joinAll([packageDir, ...explicitPath.split('/')]);
+        } else if (name != null) {
+          root = p.join(packageDir, 'Sources', name);
+        }
+        break;
+      }
+      final resource = p.joinAll([root, ...match.group(2)!.split('/')]);
+      if (FileSystemEntity.typeSync(resource) ==
+          FileSystemEntityType.notFound) {
+        result = result.replaceRange(match.start, match.end, '');
+      }
+    }
+    return result;
   }
 
   /// Host-side Package.swift fixes for cross builds.

--- a/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
@@ -198,6 +198,8 @@ abstract final class GeneratedPluginsPackage {
       outputDir: outputDir,
       cCompilerPath: darwinClang ?? await ProcessRunner.locateTool('cc'),
     );
+    final objectiveCCompatibilityHeader =
+        await writeObjectiveCCompatibilityHeader(outputDir);
     final swiftSdksPath = p.dirname(sdk.swiftSdkPath);
     final environment = swiftProcessEnvironment(windows: windows);
     if (windows) {
@@ -222,6 +224,7 @@ abstract final class GeneratedPluginsPackage {
               swiftSdksPath: swiftSdksPath,
               iosSdk: sdk.iPhoneOSSdk(),
               flutterFrameworkSlice: flutterFrameworkSlice,
+              objectiveCCompatibilityHeader: objectiveCCompatibilityHeader,
               toolsetPath: toolsetPath,
               // Windows gets the same override from the toolset's `linker`.
               linkerPath: windows ? null : linker,
@@ -576,6 +579,19 @@ abstract final class GeneratedPluginsPackage {
     return exePath;
   }
 
+  @visibleForTesting
+  static Future<String> writeObjectiveCCompatibilityHeader(
+    String outputDir,
+  ) async {
+    final path = p.join(outputDir, '.xcross', 'objective-c-compatibility.h');
+    await Directory(p.dirname(path)).create(recursive: true);
+    await _writeStable(
+      path,
+      '#ifdef __OBJC__\n#import <Foundation/Foundation.h>\n#endif\n',
+    );
+    return path;
+  }
+
   /// Search-path arguments for the Objective-C interop modules SwiftPM
   /// generates under [targetBuildDir].
   ///
@@ -643,6 +659,7 @@ abstract final class GeneratedPluginsPackage {
     required String swiftSdksPath,
     required String iosSdk,
     required String flutterFrameworkSlice,
+    String? objectiveCCompatibilityHeader,
     String? toolsetPath,
     String? linkerPath,
     bool? windows,
@@ -709,6 +726,12 @@ abstract final class GeneratedPluginsPackage {
     '-isysroot',
     '-Xcc',
     iosSdk,
+    if (objectiveCCompatibilityHeader != null) ...[
+      '-Xcc',
+      '-include',
+      '-Xcc',
+      objectiveCCompatibilityHeader,
+    ],
     '-Xswiftc',
     '-F',
     '-Xswiftc',

--- a/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
@@ -1012,7 +1012,10 @@ abstract final class GeneratedPluginsPackage {
     }
 
     final manifest = await File(p.join(target, 'Package.swift')).readAsString();
-    var normalizedManifest = normalizeHostManifest(manifest);
+    var normalizedManifest = removeMissingResources(
+      normalizeHostManifest(manifest),
+      target,
+    );
     final fallbackSwiftModules = <String, List<String>>{};
     if (vendorDir != null) {
       normalizedManifest = await vendorUrlPackagesAsPathDeps(
@@ -1302,6 +1305,20 @@ let package = Package(
           for (final argument in arguments) ...['"-Xlinker"', '"$argument"'],
         ].join(', ');
       });
+
+  @visibleForTesting
+  static String removeMissingResources(String manifest, String packageDir) {
+    return manifest.replaceAllMapped(
+      RegExp(r'\.((?:process|copy))\(\s*"([^"]+)"\s*\)\s*,?'),
+      (match) {
+        final resource = p.joinAll([packageDir, ...match.group(2)!.split('/')]);
+        return FileSystemEntity.typeSync(resource) ==
+                FileSystemEntityType.notFound
+            ? ''
+            : match.group(0)!;
+      },
+    );
+  }
 
   /// Host-side Package.swift fixes for cross builds.
   ///

--- a/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
@@ -731,6 +731,14 @@ abstract final class GeneratedPluginsPackage {
     '-Xclang-linker',
     '-Xswiftc',
     iosSdk,
+    '-Xswiftc',
+    '-Xlinker',
+    '-Xswiftc',
+    '-ObjC',
+    '-Xswiftc',
+    '-Xlinker',
+    '-Xswiftc',
+    '-no_objc_category_merging',
     // The link runs through the toolchain's own clang, which resolves
     // `-use-ld=lld` to the `ld64.lld` sitting next to itself — swiftly's, the
     // one that refuses iOS (see [resolveLd64Lld]). `--ld-path` overrides that

--- a/packages/xcross/lib/src/flutter/build/runner_shim.dart
+++ b/packages/xcross/lib/src/flutter/build/runner_shim.dart
@@ -282,14 +282,6 @@ ${hasPlugins ? _pluginsExternDeclaration : _emptyPluginRegistrantStub}
 @implementation AppDelegate
 - (BOOL)application:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
   ${verbose ? 'NSLog(@"[xcross] application launch started");' : ''}
-  FlutterViewController* flutterViewController = [[FlutterViewController alloc] initWithProject:nil nibName:nil bundle:nil];
-  [flutterViewController setFlutterViewDidRenderCallback:^{
-    NSLog(@"[xcross] first Flutter frame rendered");
-  }];
-  UIWindow* window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
-  window.rootViewController = flutterViewController;
-  [window makeKeyAndVisible];
-  self.window = window;
   BOOL launched = [super application:application didFinishLaunchingWithOptions:launchOptions];
   ${verbose ? 'NSLog(@"[xcross] FlutterAppDelegate didFinishLaunching returned: %@", launched ? @"YES" : @"NO");' : ''}
   return launched;
@@ -305,6 +297,19 @@ ${hasPlugins ? _pluginsExternDeclaration : _emptyPluginRegistrantStub}
 @interface SceneDelegate : FlutterSceneDelegate
 @end
 @implementation SceneDelegate
+- (void)scene:(UIScene*)scene willConnectToSession:(UISceneSession*)session options:(UISceneConnectionOptions*)connectionOptions {
+  if (![scene isKindOfClass:[UIWindowScene class]]) return;
+  UIWindowScene* windowScene = (UIWindowScene*)scene;
+  FlutterViewController* flutterViewController = [[FlutterViewController alloc] initWithProject:nil nibName:nil bundle:nil];
+  [flutterViewController setFlutterViewDidRenderCallback:^{
+    NSLog(@"[xcross] first Flutter frame rendered");
+  }];
+  UIWindow* window = [[UIWindow alloc] initWithWindowScene:windowScene];
+  window.rootViewController = flutterViewController;
+  self.window = window;
+  [window makeKeyAndVisible];
+  [super scene:scene willConnectToSession:session options:connectionOptions];
+}
 @end
 
 int main(int argc, char * argv[]) {

--- a/packages/xcross/test/cli/sdk_command_test.dart
+++ b/packages/xcross/test/cli/sdk_command_test.dart
@@ -408,6 +408,9 @@ void main() {
     await Directory(
       p.join(sdkRoot, 'System', 'Library', 'Frameworks'),
     ).create(recursive: true);
+    await Directory(
+      p.join(sdkRoot, 'usr', 'include', 'c++', 'v1'),
+    ).create(recursive: true);
     final layout = File(
       p.join(
         bundle.path,
@@ -469,7 +472,7 @@ void main() {
     );
     expect(target['includeSearchPaths'], [
       'Developer/Platforms/iPhoneOS.platform/Developer/usr/lib',
-      'Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1',
+      'Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.2.sdk/usr/include/c++/v1',
     ]);
     expect(target['librarySearchPaths'], [
       'Developer/Platforms/iPhoneOS.platform/Developer/usr/lib',

--- a/packages/xcross/test/flutter/build/info_plist_test.dart
+++ b/packages/xcross/test/flutter/build/info_plist_test.dart
@@ -139,6 +139,143 @@ BAZ = a=b
     });
   });
 
+  group('applySceneLifecycle', () {
+    test('adds a programmatic SceneDelegate manifest', () {
+      final result = InfoPlist.applySceneLifecycle(_minimalPlist);
+
+      expect(result, contains('<key>UIApplicationSceneManifest</key>'));
+      expect(result, contains('<string>UIWindowScene</string>'));
+      expect(
+        result,
+        contains(
+          '<key>UISceneDelegateClassName</key>\n'
+          '\t\t\t\t\t<string>SceneDelegate</string>',
+        ),
+      );
+      expect(result, isNot(contains('UISceneStoryboardFile')));
+    });
+
+    test('completes an existing empty manifest', () {
+      const xml =
+          '<?xml version="1.0"?>\n'
+          '<plist version="1.0">\n'
+          '<dict>\n'
+          '\t<key>UIApplicationSceneManifest</key>\n'
+          '\t<dict/>\n'
+          '</dict>\n'
+          '</plist>\n';
+
+      final result = InfoPlist.applySceneLifecycle(xml);
+
+      expect('UIApplicationSceneManifest'.allMatches(result).length, 1);
+      expect(result, contains('<string>SceneDelegate</string>'));
+    });
+
+    test('replaces only the application scene role', () {
+      const xml =
+          '<?xml version="1.0"?>\n'
+          '<plist version="1.0">\n'
+          '<dict>\n'
+          '\t<key>UIApplicationSceneManifest</key>\n'
+          '\t<dict>\n'
+          '\t\t<key>UISceneConfigurations</key>\n'
+          '\t\t<dict>\n'
+          '\t\t\t<key>UIWindowSceneSessionRoleApplication</key>\n'
+          '\t\t\t<array><dict>\n'
+          '\t\t\t\t<key>UISceneDelegateClassName</key>\n'
+          '\t\t\t\t<string>Runner.CustomSceneDelegate</string>\n'
+          '\t\t\t</dict></array>\n'
+          '\t\t\t<key>UIWindowSceneSessionRoleExternalDisplay</key>\n'
+          '\t\t\t<array><dict>\n'
+          '\t\t\t\t<key>UISceneDelegateClassName</key>\n'
+          '\t\t\t\t<string>Runner.ExternalSceneDelegate</string>\n'
+          '\t\t\t</dict></array>\n'
+          '\t\t</dict>\n'
+          '\t</dict>\n'
+          '</dict>\n'
+          '</plist>\n';
+
+      final result = InfoPlist.applySceneLifecycle(xml);
+
+      expect(result, contains('<string>SceneDelegate</string>'));
+      expect(result, isNot(contains('CustomSceneDelegate')));
+      expect(result, contains('UIWindowSceneSessionRoleExternalDisplay'));
+      expect(result, contains('Runner.ExternalSceneDelegate'));
+    });
+
+    test(
+      'replaces a self-closing application role without touching others',
+      () {
+        const xml =
+            '<?xml version="1.0"?>\n'
+            '<plist version="1.0">\n'
+            '<dict>\n'
+            '\t<key>UIApplicationSceneManifest</key>\n'
+            '\t<dict>\n'
+            '\t\t<key>UISceneConfigurations</key>\n'
+            '\t\t<dict>\n'
+            '\t\t\t<key>UIWindowSceneSessionRoleApplication</key>\n'
+            '\t\t\t<array/>\n'
+            '\t\t\t<key>UIWindowSceneSessionRoleExternalDisplay</key>\n'
+            '\t\t\t<array><dict>\n'
+            '\t\t\t\t<key>UISceneDelegateClassName</key>\n'
+            '\t\t\t\t<string>Runner.ExternalSceneDelegate</string>\n'
+            '\t\t\t</dict></array>\n'
+            '\t\t</dict>\n'
+            '\t</dict>\n'
+            '</dict>\n'
+            '</plist>\n';
+
+        final result = InfoPlist.applySceneLifecycle(xml);
+
+        expect(result, contains('<string>SceneDelegate</string>'));
+        expect(result, contains('UIWindowSceneSessionRoleExternalDisplay'));
+        expect(result, contains('Runner.ExternalSceneDelegate'));
+      },
+    );
+
+    test('leaves a malformed manifest untouched', () {
+      const xml =
+          '<?xml version="1.0"?>\n'
+          '<plist version="1.0">\n'
+          '<dict>\n'
+          '\t<key>UIApplicationSceneManifest</key>\n'
+          '\t<string>invalid</string>\n'
+          '\t<key>UILaunchScreen</key>\n'
+          '\t<dict/>\n'
+          '</dict>\n'
+          '</plist>\n';
+
+      expect(InfoPlist.applySceneLifecycle(xml), xml);
+    });
+
+    test('adds the application role to a partial manifest', () {
+      const xml =
+          '<?xml version="1.0"?>\n'
+          '<plist version="1.0">\n'
+          '<dict>\n'
+          '\t<key>UIApplicationSceneManifest</key>\n'
+          '\t<dict>\n'
+          '\t\t<key>UISceneConfigurations</key>\n'
+          '\t\t<dict/>\n'
+          '\t</dict>\n'
+          '</dict>\n'
+          '</plist>\n';
+
+      final result = InfoPlist.applySceneLifecycle(xml);
+
+      expect(result, contains('UIWindowSceneSessionRoleApplication'));
+      expect(result, contains('<string>SceneDelegate</string>'));
+    });
+
+    test('is idempotent', () {
+      final once = InfoPlist.applySceneLifecycle(_minimalPlist);
+      final twice = InfoPlist.applySceneLifecycle(once);
+
+      expect(twice, once);
+    });
+  });
+
   group('normalizeObjCClassNames', () {
     test('strips the Swift module prefix from NSPrincipalClass', () {
       const xml =

--- a/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
+++ b/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
@@ -1777,6 +1777,7 @@ let package = Package(
         swiftSdksPath: 'xcross-swift-sdks',
         iosSdk: 'iPhoneOS.sdk',
         flutterFrameworkSlice: 'Flutter.xcframework/ios-arm64',
+        objectiveCCompatibilityHeader: 'objective-c-compatibility.h',
         toolsetPath: 'toolset.json',
         linkerPath: '/usr/bin/ld64.lld',
         windows: true,
@@ -1842,6 +1843,15 @@ let package = Package(
       expect(
         arguments,
         containsAllInOrder(['-Xcc', '-isysroot', '-Xcc', 'iPhoneOS.sdk']),
+      );
+      expect(
+        arguments,
+        containsAllInOrder([
+          '-Xcc',
+          '-include',
+          '-Xcc',
+          'objective-c-compatibility.h',
+        ]),
       );
       expect(
         arguments,
@@ -2197,6 +2207,19 @@ module FirebaseFirestore {
         'GIT_CONFIG_VALUE_0': 'false',
         'EXPERIMENTAL_SPM_BUILDS': '1',
       });
+    });
+  });
+
+  group('Objective-C compatibility header', () {
+    test('imports Foundation only for Objective-C compilations', () async {
+      final path =
+          await GeneratedPluginsPackage.writeObjectiveCCompatibilityHeader(
+            tmp.path,
+          );
+      expect(
+        File(path).readAsStringSync(),
+        '#ifdef __OBJC__\n#import <Foundation/Foundation.h>\n#endif\n',
+      );
     });
   });
 

--- a/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
+++ b/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
@@ -864,6 +864,57 @@ resources: [
       expect(normalized, contains('.process("PrivacyInfo.xcprivacy")'));
       expect(normalized, isNot(contains('Missing.bundle')));
     });
+
+    test('resolves resources relative to their target path', () {
+      final package = Directory(p.join(tmp.path, 'target-resources'))
+        ..createSync(recursive: true);
+      File(
+          p.join(
+            package.path,
+            'Sources',
+            'flutter_inappwebview_ios',
+            'Resources',
+            'WebView.storyboard',
+          ),
+        )
+        ..createSync(recursive: true)
+        ..writeAsStringSync('<storyboard/>');
+      const manifest = '''
+let package = Package(targets: [
+    .target(
+        name: "flutter_inappwebview_ios",
+        path: "Sources/flutter_inappwebview_ios",
+        resources: [
+            .process("Resources/WebView.storyboard"),
+            .process("Resources/Missing.xcprivacy"),
+        ]
+    )
+])
+''';
+
+      final normalized = GeneratedPluginsPackage.removeMissingResources(
+        manifest,
+        package.path,
+      );
+      expect(normalized, contains('.process("Resources/WebView.storyboard")'));
+      expect(normalized, isNot(contains('Missing.xcprivacy')));
+    });
+
+    test('uses the conventional Sources target directory', () {
+      final package = Directory(p.join(tmp.path, 'default-target-resources'))
+        ..createSync(recursive: true);
+      File(p.join(package.path, 'Sources', 'Plugin', 'Resources', 'Data.json'))
+        ..createSync(recursive: true)
+        ..writeAsStringSync('{}');
+      const manifest = '''
+.target(name: "Plugin", resources: [.copy("Resources/Data.json")])
+''';
+
+      expect(
+        GeneratedPluginsPackage.removeMissingResources(manifest, package.path),
+        manifest,
+      );
+    });
   });
 
   group('registrantSource', () {

--- a/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
+++ b/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
@@ -1780,11 +1780,25 @@ let package = Package(
         arguments,
         containsAllInOrder([
           '-Xswiftc',
+          '-Xlinker',
+          '-Xswiftc',
+          '-ObjC',
+          '-Xswiftc',
+          '-Xlinker',
+          '-Xswiftc',
+          '-no_objc_category_merging',
+        ]),
+      );
+      expect(
+        arguments,
+        containsAllInOrder([
+          '-Xswiftc',
           '-Xclang-linker',
           '-Xswiftc',
           '--ld-path=/usr/bin/ld64.lld',
         ]),
       );
+
       expect(
         arguments,
         containsAllInOrder([

--- a/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
+++ b/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
@@ -843,6 +843,29 @@ let package = Package(name: "Sentry", products: [], targets: [])
     });
   });
 
+  group('removeMissingResources', () {
+    test('drops missing resources and preserves existing resources', () {
+      final package = Directory(p.join(tmp.path, 'resources'))
+        ..createSync(recursive: true);
+      File(p.join(package.path, 'PrivacyInfo.xcprivacy'))
+        ..createSync()
+        ..writeAsStringSync('{}');
+      const manifest = '''
+resources: [
+    .process("PrivacyInfo.xcprivacy"),
+    .copy("Resources/Missing.bundle"),
+]
+''';
+
+      final normalized = GeneratedPluginsPackage.removeMissingResources(
+        manifest,
+        package.path,
+      );
+      expect(normalized, contains('.process("PrivacyInfo.xcprivacy")'));
+      expect(normalized, isNot(contains('Missing.bundle')));
+    });
+  });
+
   group('registrantSource', () {
     test('imports and registers only the plugin with a pluginClass', () {
       final pluginA = makePlugin('plugin_a', pluginClass: 'PluginA');

--- a/packages/xcross/test/flutter/build/runner_shim_source_test.dart
+++ b/packages/xcross/test/flutter/build/runner_shim_source_test.dart
@@ -9,8 +9,36 @@ void main() {
     );
 
     expect(source, contains('[xcross] first Flutter frame rendered'));
+    expect(
+      source,
+      contains('[[UIWindow alloc] initWithWindowScene:windowScene]'),
+    );
+    expect(source, contains('self.window = window'));
+    expect(source, isNot(contains('[[UIScreen mainScreen] bounds]')));
     expect(source, isNot(contains('application launch started')));
     expect(source, isNot(contains('Flutter engine initialized')));
+  });
+
+  test('creates Flutter UI from the scene lifecycle', () {
+    final source = RunnerShim.runnerObjcSource(
+      hasPlugins: true,
+      verbose: false,
+    );
+    final appDelegate = source.substring(
+      source.indexOf('@implementation AppDelegate'),
+      source.indexOf('@interface SceneDelegate'),
+    );
+    final sceneDelegate = source.substring(
+      source.indexOf('@implementation SceneDelegate'),
+      source.indexOf('int main'),
+    );
+
+    expect(appDelegate, isNot(contains('FlutterViewController')));
+    expect(appDelegate, isNot(contains('UIWindow')));
+    expect(sceneDelegate, contains('willConnectToSession'));
+    expect(sceneDelegate, contains('initWithWindowScene:windowScene'));
+    expect(sceneDelegate, contains('self.window = window'));
+    expect(sceneDelegate, contains('[super scene:scene'));
   });
 
   test('verbose source records native launch and engine phases', () {


### PR DESCRIPTION
## Summary

- create the Flutter view controller and window from `SceneDelegate`
- attach the window to the active `UIWindowScene`
- ensure packed apps contain a programmatic application scene configuration
- preserve non-application scene roles

## Why

Flutter 3.47.1 can launch and expose the VM service while showing a black screen because the generated Runner creates its window from `AppDelegate` even when the app uses the UIScene lifecycle.


## Tests

- `dart test test/flutter/build`
- `dart analyze` (one pre-existing `unnecessary_async` info in `test/update/build_xcross_test.dart`)
