### PR TITLE
fix(xcross): validate Flutter engine artifacts

### DIFF
--- a/packages/xcross/lib/src/flutter/build/ios_engine_cache.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_engine_cache.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:archive/archive_io.dart';
 import 'package:cli_kit/cli_kit.dart';
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:xcross/src/flutter/constants.dart';
 import 'package:xcross/src/flutter/errors.dart';
@@ -74,13 +75,14 @@ final class IosEngineCache {
     'flutter_patched_sdk',
   );
 
-  /// Engine hash that pins the artifact set. Read from
-  /// `bin/internal/engine.version` (stable/beta) or `bin/cache/engine.stamp`
-  /// (written by flutter_tools at runtime).
+  static const _revisionStampName = '.xcross-engine-revision';
+
+  /// Engine hash that pins the artifact set. Prefer the materialized cache
+  /// stamp used by flutter_tools, falling back to the SDK's tracked revision.
   Future<String> _engineHash() async {
     for (final rel in [
-      p.join('bin', 'internal', 'engine.version'),
       p.join('bin', 'cache', 'engine.stamp'),
+      p.join('bin', 'internal', 'engine.version'),
     ]) {
       final file = File(p.join(flutterRoot, rel));
       if (file.existsSync()) {
@@ -96,86 +98,258 @@ final class IosEngineCache {
     );
   }
 
-  /// Verify required iOS engine artifacts are present, downloading each set
-  /// from `storage.googleapis.com` if missing. Safe to call repeatedly.
+  /// Verify required iOS engine artifacts are present and belong to the
+  /// selected engine revision. Safe to call repeatedly.
   Future<void> ensureArtifactsAvailable() async {
-    if (!Directory(flutterXcframework).existsSync()) {
-      await _downloadIosArtifacts();
-    }
-    if (!File(vmSnapshotData).existsSync() ||
-        !File(isolateSnapshotData).existsSync()) {
-      await _downloadHostArtifacts();
-    }
-    if (!Directory(patchedSdkRoot).existsSync()) {
-      await _downloadPatchedSdk();
+    final lock = await File(
+      p.join(flutterRoot, 'bin', 'cache', 'lockfile'),
+    ).open(mode: FileMode.append);
+    try {
+      await lock.lock();
+      final hash = await _engineHash();
+      if (!artifactIsCurrent(
+        directory: _engineDir,
+        revision: hash,
+        officialStamp: Platform.isMacOS
+            ? p.join(flutterRoot, 'bin', 'cache', 'ios-sdk.stamp')
+            : null,
+        requiredFiles: const [
+          'Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
+          'Flutter.xcframework/ios-arm64/Flutter.framework/Info.plist',
+        ],
+      )) {
+        await _downloadIosArtifacts(hash);
+      }
+      final flutterSdkStamp = p.join(
+        flutterRoot,
+        'bin',
+        'cache',
+        'flutter_sdk.stamp',
+      );
+      if (!artifactIsCurrent(
+        directory: _hostEngineDir,
+        revision: hash,
+        officialStamp: flutterSdkStamp,
+        requiredFiles: const [
+          'vm_isolate_snapshot.bin',
+          'isolate_snapshot.bin',
+        ],
+      )) {
+        await _downloadHostArtifacts(hash);
+      }
+      if (!artifactIsCurrent(
+        directory: patchedSdkRoot,
+        revision: hash,
+        officialStamp: flutterSdkStamp,
+        requiredFiles: const ['platform_strong.dill', 'vm_outline_strong.dill'],
+      )) {
+        await _downloadPatchedSdk(hash);
+      }
+      _validateDartSdk(hash);
+    } finally {
+      try {
+        await lock.unlock();
+      } on FileSystemException {
+        // Lock acquisition failed, so there is nothing to release.
+      }
+      await lock.close();
     }
   }
 
-  Future<void> _downloadHostArtifacts() async {
-    final hash = await _engineHash();
+  @visibleForTesting
+  static bool artifactIsCurrent({
+    required String directory,
+    required String revision,
+    String? officialStamp,
+    List<String> requiredFiles = const [],
+    List<String> requiredDirectories = const [],
+  }) {
+    final privateStamp = File(p.join(directory, _revisionStampName));
+    final stamp = privateStamp.existsSync()
+        ? privateStamp
+        : officialStamp == null
+        ? null
+        : File(officialStamp);
+    if (stamp == null || !stamp.existsSync()) return false;
+    final revisionMatches = () {
+      try {
+        return stamp.readAsStringSync().trim() == revision;
+      } on FileSystemException {
+        return false;
+      }
+    }();
+    if (!revisionMatches) return false;
+    return requiredFiles.every((relative) {
+          final file = File(p.join(directory, relative));
+          try {
+            return file.existsSync() && file.lengthSync() > 0;
+          } on FileSystemException {
+            return false;
+          }
+        }) &&
+        requiredDirectories.every(
+          (relative) => Directory(p.join(directory, relative)).existsSync(),
+        );
+  }
+
+  void _validateDartSdk(String revision) {
+    final stamp = File(
+      p.join(flutterRoot, 'bin', 'cache', 'engine-dart-sdk.stamp'),
+    );
+    final runtime = File(
+      p.join(
+        flutterRoot,
+        'bin',
+        'cache',
+        'dart-sdk',
+        'bin',
+        ProcessRunner.hostExecutableName('dart'),
+      ),
+    );
+    final server = File(frontendServer);
+    final current =
+        stamp.existsSync() &&
+        stamp.readAsStringSync().trim() == revision &&
+        runtime.existsSync() &&
+        runtime.lengthSync() > 0 &&
+        server.existsSync() &&
+        server.lengthSync() > 0;
+    if (!current) {
+      throw FlutterBuildError(
+        'Flutter Dart SDK artifacts do not match engine $revision.\n'
+        'Run `<FLUTTER_ROOT>/bin/flutter precache --force` and retry.',
+      );
+    }
+  }
+
+  Future<void> _downloadHostArtifacts(String hash) async {
     final url =
         '$flutterArtifactBaseUrl/$hash/$_hostEngineCacheDir/artifacts.zip';
     Log.logTrace('downloading Flutter host engine artifacts from $url');
-    await _fetchAndExtract(
+    await _fetchAndInstall(
       url,
       _hostEngineDir,
       'host-artifacts-',
+      revision: hash,
+      requiredFiles: const ['vm_isolate_snapshot.bin', 'isolate_snapshot.bin'],
       label: 'Flutter host engine',
     );
   }
 
-  Future<void> _downloadIosArtifacts() async {
-    final hash = await _engineHash();
+  Future<void> _downloadIosArtifacts(String hash) async {
     final url = '$flutterArtifactBaseUrl/$hash/ios/artifacts.zip';
     Log.logTrace('downloading Flutter iOS engine artifacts from $url');
-    await _fetchAndExtract(
+    await _fetchAndInstall(
       url,
       _engineDir,
       'ios-artifacts-',
+      revision: hash,
+      requiredFiles: const [
+        'Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
+        'Flutter.xcframework/ios-arm64/Flutter.framework/Info.plist',
+      ],
       label: 'Flutter iOS engine',
     );
   }
 
-  Future<void> _downloadPatchedSdk() async {
-    final hash = await _engineHash();
+  Future<void> _downloadPatchedSdk(String hash) async {
     final leaf = p.basename(patchedSdkRoot);
     final url = '$flutterArtifactBaseUrl/$hash/$leaf.zip';
     Log.logTrace('downloading Flutter patched SDK from $url');
-    await _fetchAndExtract(
+    await _fetchAndInstall(
       url,
-      p.dirname(patchedSdkRoot),
+      patchedSdkRoot,
       'patched-sdk-',
+      revision: hash,
+      extractedSubdirectory: leaf,
+      requiredFiles: const ['platform_strong.dill', 'vm_outline_strong.dill'],
       label: 'Flutter patched SDK',
     );
   }
 
-  /// Download [url] into a temp directory, extract into [destDir], then
-  /// delete the temp directory.
+  /// Download [url] into a staging directory, validate it, then atomically
+  /// replace [destDir].
   ///
   /// Pure Dart — no `curl`/`unzip` subprocess. The download follows redirects
   /// and retries transient failures; the archive package's posix-aware
   /// extractor restores unix permissions (exec bits) and symlinks.
-  static Future<void> _fetchAndExtract(
+  static Future<void> _fetchAndInstall(
     String url,
     String destDir,
     String tmpPrefix, {
+    required String revision,
     required String label,
+    String? extractedSubdirectory,
+    List<String> requiredFiles = const [],
+    List<String> requiredDirectories = const [],
   }) async {
-    await Directory(destDir).create(recursive: true);
-    final tmp = await Directory.systemTemp.createTemp(tmpPrefix);
-    final zipPath = p.join(tmp.path, 'artifacts.zip');
-    await Downloader.downloadToFile(
-      url,
-      File(zipPath),
-      maxAttempts: 5,
-      label: label,
+    final parent = Directory(p.dirname(destDir));
+    await parent.create(recursive: true);
+    final staging = await parent.createTemp('.$tmpPrefix');
+    final download = File('${staging.path}.zip');
+    final backup = Directory(
+      p.join(parent.path, '.${p.basename(destDir)}.xcross-backup'),
     );
-    // Unzipping hundreds of MB is slow enough to look like a hang on its own.
-    await Log.logStep(
-      'Extracting $label',
-      () => extractFileToDisk(zipPath, destDir),
-    );
-    await tmp.delete(recursive: true);
+    try {
+      await _restoreBackupIfNeeded(destDir, backup);
+      await Downloader.downloadToFile(
+        url,
+        download,
+        maxAttempts: 5,
+        label: label,
+      );
+      await Log.logStep(
+        'Extracting $label',
+        () => extractFileToDisk(download.path, staging.path),
+      );
+      final extracted = Directory(
+        extractedSubdirectory == null
+            ? staging.path
+            : p.join(staging.path, extractedSubdirectory),
+      );
+      if (!requiredFiles.every((relative) {
+            final file = File(p.join(extracted.path, relative));
+            return file.existsSync() && file.lengthSync() > 0;
+          }) ||
+          !requiredDirectories.every(
+            (relative) =>
+                Directory(p.join(extracted.path, relative)).existsSync(),
+          )) {
+        throw FlutterBuildError(
+          '$label archive for engine $revision is incomplete.',
+        );
+      }
+      await File(
+        p.join(extracted.path, _revisionStampName),
+      ).writeAsString('$revision\n', flush: true);
+
+      final destination = Directory(destDir);
+      if (destination.existsSync()) await destination.rename(backup.path);
+      try {
+        await extracted.rename(destDir);
+      } on Object {
+        if (backup.existsSync() && !Directory(destDir).existsSync()) {
+          await backup.rename(destDir);
+        }
+        rethrow;
+      }
+      if (backup.existsSync()) await backup.delete(recursive: true);
+    } finally {
+      if (download.existsSync()) await download.delete();
+      if (staging.existsSync()) await staging.delete(recursive: true);
+    }
+  }
+
+  static Future<void> _restoreBackupIfNeeded(
+    String destination,
+    Directory backup,
+  ) async {
+    if (!backup.existsSync()) return;
+    if (Directory(destination).existsSync()) {
+      await backup.delete(recursive: true);
+      return;
+    }
+    await backup.rename(destination);
   }
 
   /// Platform-specific engine cache directory name.

--- a/packages/xcross/test/flutter/build/ios_engine_cache_test.dart
+++ b/packages/xcross/test/flutter/build/ios_engine_cache_test.dart
@@ -1,0 +1,117 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:xcross/src/flutter/build/ios_engine_cache.dart';
+
+void main() {
+  late Directory tmp;
+
+  setUp(() => tmp = Directory.systemTemp.createTempSync('xcross_engine_'));
+  tearDown(() => tmp.deleteSync(recursive: true));
+
+  test('accepts only complete artifacts stamped for the engine revision', () {
+    File(
+      p.join(tmp.path, '.xcross-engine-revision'),
+    ).writeAsStringSync('abc\n');
+    File(p.join(tmp.path, 'snapshot.bin')).writeAsStringSync('snapshot');
+    Directory(p.join(tmp.path, 'Flutter.xcframework')).createSync();
+
+    expect(
+      IosEngineCache.artifactIsCurrent(
+        directory: tmp.path,
+        revision: 'abc',
+        requiredFiles: const ['snapshot.bin'],
+        requiredDirectories: const ['Flutter.xcframework'],
+      ),
+      isTrue,
+    );
+  });
+
+  test('accepts complete Flutter-managed artifacts with an official stamp', () {
+    final stamp = File(p.join(tmp.path, 'flutter_sdk.stamp'))
+      ..writeAsStringSync('abc\n');
+    File(p.join(tmp.path, 'snapshot.bin')).writeAsStringSync('snapshot');
+
+    expect(
+      IosEngineCache.artifactIsCurrent(
+        directory: tmp.path,
+        revision: 'abc',
+        officialStamp: stamp.path,
+        requiredFiles: const ['snapshot.bin'],
+      ),
+      isTrue,
+    );
+  });
+
+  test('rejects artifacts without a revision stamp', () {
+    File(p.join(tmp.path, 'snapshot.bin')).writeAsStringSync('snapshot');
+
+    expect(
+      IosEngineCache.artifactIsCurrent(
+        directory: tmp.path,
+        revision: 'abc',
+        requiredFiles: const ['snapshot.bin'],
+      ),
+      isFalse,
+    );
+  });
+
+  test('private stamp takes precedence over a newer official stamp', () {
+    final official = File(p.join(tmp.path, 'flutter_sdk.stamp'))
+      ..writeAsStringSync('new');
+    File(p.join(tmp.path, '.xcross-engine-revision')).writeAsStringSync('old');
+    File(p.join(tmp.path, 'snapshot.bin')).writeAsStringSync('snapshot');
+
+    expect(
+      IosEngineCache.artifactIsCurrent(
+        directory: tmp.path,
+        revision: 'new',
+        officialStamp: official.path,
+        requiredFiles: const ['snapshot.bin'],
+      ),
+      isFalse,
+    );
+  });
+
+  test('rejects artifacts stamped for another engine revision', () {
+    File(p.join(tmp.path, '.xcross-engine-revision')).writeAsStringSync('old');
+    File(p.join(tmp.path, 'snapshot.bin')).writeAsStringSync('snapshot');
+
+    expect(
+      IosEngineCache.artifactIsCurrent(
+        directory: tmp.path,
+        revision: 'new',
+        requiredFiles: const ['snapshot.bin'],
+      ),
+      isFalse,
+    );
+  });
+
+  test('rejects empty required files', () {
+    File(p.join(tmp.path, '.xcross-engine-revision')).writeAsStringSync('abc');
+    File(p.join(tmp.path, 'snapshot.bin')).createSync();
+
+    expect(
+      IosEngineCache.artifactIsCurrent(
+        directory: tmp.path,
+        revision: 'abc',
+        requiredFiles: const ['snapshot.bin'],
+      ),
+      isFalse,
+    );
+  });
+
+  test('rejects stamped artifacts with missing payload', () {
+    File(p.join(tmp.path, '.xcross-engine-revision')).writeAsStringSync('abc');
+
+    expect(
+      IosEngineCache.artifactIsCurrent(
+        directory: tmp.path,
+        revision: 'abc',
+        requiredFiles: const ['snapshot.bin'],
+      ),
+      isFalse,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- validate Flutter iOS, host, patched SDK, Dart SDK, and frontend-server artifacts against the selected engine revision
- redownload stale xcross-managed artifacts into validated staging directories
- serialize cache updates with Flutter's cache lock and recover interrupted replacements
- add focused tests for stale, conflicting, incomplete, and Flutter-managed artifact stamps

## Why

A mixed Flutter SDK cache can compile `kernel_blob.bin` with a newer Dart kernel format while embedding an older iOS Flutter engine. The app then launches to a black screen because the root isolate fails with `Invalid kernel binary format version`.

## Tests

- `dart test test/flutter/build`
- `dart analyze` (one pre-existing `unnecessary_async` info in `test/update/build_xcross_test.dart`)
