### PR TITLE
fix(flutter): preserve Objective-C plugin categories

### DIFF
--- a/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
@@ -534,6 +534,14 @@ abstract final class GeneratedPluginsPackage {
     '-Xclang-linker',
     '-Xswiftc',
     iosSdk,
+    '-Xswiftc',
+    '-Xlinker',
+    '-Xswiftc',
+    '-ObjC',
+    '-Xswiftc',
+    '-Xlinker',
+    '-Xswiftc',
+    '-no_objc_category_merging',
     // The link runs through the toolchain's own clang, which resolves
     // `-use-ld=lld` to the `ld64.lld` sitting next to itself — swiftly's, the
     // one that refuses iOS (see [resolveLd64Lld]). `--ld-path` overrides that

--- a/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
+++ b/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
@@ -1700,11 +1700,25 @@ let package = Package(
         arguments,
         containsAllInOrder([
           '-Xswiftc',
+          '-Xlinker',
+          '-Xswiftc',
+          '-ObjC',
+          '-Xswiftc',
+          '-Xlinker',
+          '-Xswiftc',
+          '-no_objc_category_merging',
+        ]),
+      );
+      expect(
+        arguments,
+        containsAllInOrder([
+          '-Xswiftc',
           '-Xclang-linker',
           '-Xswiftc',
           '--ld-path=/usr/bin/ld64.lld',
         ]),
       );
+
       expect(
         arguments,
         containsAllInOrder([


### PR DESCRIPTION
## Summary

- force SwiftPM to load Objective-C classes and categories from plugin static archives
- disable ld64.lld Objective-C category merging for the aggregate plugin dylib
- cover both linker flags in the SwiftPM argument regression test

## Why

The reported Flutter 3.47.1 launch still crashes on the UIScene fix branch with `+[NSNotificationCenter ]: unrecognized selector sent to class`. The receiver is the Foundation class and the selector text is empty, which points to malformed or discarded Objective-C runtime category metadata rather than the UIScene window attachment. The app links many Objective-C plugin and binary targets into one SwiftPM dylib through `ld64.lld`. `-ObjC` preserves category-only archive members, while disabling category merging avoids rewriting mixed Apple SDK/plugin metadata.

This PR targets the existing UIScene branch because that branch is required to reproduce the remaining crash.

## Tests

- `dart test test/flutter/build/ios_plugin_package_test.dart`
- `dart analyze` (one pre-existing `unnecessary_async` info in `test/update/build_xcross_test.dart`)
