### PR TITLE
fix(flutter): sanitize cross-build inputs

### DIFF
--- a/packages/xcross/lib/src/cli/basic/sdk_install.dart
+++ b/packages/xcross/lib/src/cli/basic/sdk_install.dart
@@ -284,6 +284,11 @@ abstract final class SdkInstall {
     final relativeSdkRoot = p
         .relative(sdkRoot, from: artifactRoot)
         .replaceAll(r'\', '/');
+    final toolchainCxx = p.join(artifactRoot, _toolchain, 'usr/include/c++/v1');
+    final sdkCxx = p.join(sdkRoot, 'usr/include/c++/v1');
+    final cxxInclude = Directory(toolchainCxx).existsSync()
+        ? '$_toolchain/usr/include/c++/v1'
+        : p.relative(sdkCxx, from: artifactRoot).replaceAll(r'\', '/');
 
     await _writeJson(p.join(artifactRoot, 'swift-sdk.json'), {
       'schemaVersion': '4.0',
@@ -292,10 +297,7 @@ abstract final class SdkInstall {
           'sdkRootPath': relativeSdkRoot,
           'swiftResourcesPath': _swiftResources,
           'swiftStaticResourcesPath': _swiftStaticResources,
-          'includeSearchPaths': [
-            '$_platformDeveloper/usr/lib',
-            '$_toolchain/usr/include/c++/v1',
-          ],
+          'includeSearchPaths': ['$_platformDeveloper/usr/lib', cxxInclude],
           'librarySearchPaths': ['$_platformDeveloper/usr/lib'],
           'toolsetPaths': ['toolset.json'],
         },

--- a/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
@@ -784,7 +784,10 @@ abstract final class GeneratedPluginsPackage {
     }
 
     final manifest = await File(p.join(target, 'Package.swift')).readAsString();
-    var normalizedManifest = normalizeHostManifest(manifest);
+    var normalizedManifest = removeMissingResources(
+      normalizeHostManifest(manifest),
+      target,
+    );
     final fallbackSwiftModules = <String, List<String>>{};
     if (vendorDir != null) {
       normalizedManifest = await vendorUrlPackagesAsPathDeps(
@@ -1074,6 +1077,20 @@ let package = Package(
           for (final argument in arguments) ...['"-Xlinker"', '"$argument"'],
         ].join(', ');
       });
+
+  @visibleForTesting
+  static String removeMissingResources(String manifest, String packageDir) {
+    return manifest.replaceAllMapped(
+      RegExp(r'\.((?:process|copy))\(\s*"([^"]+)"\s*\)\s*,?'),
+      (match) {
+        final resource = p.joinAll([packageDir, ...match.group(2)!.split('/')]);
+        return FileSystemEntity.typeSync(resource) ==
+                FileSystemEntityType.notFound
+            ? ''
+            : match.group(0)!;
+      },
+    );
+  }
 
   /// Host-side Package.swift fixes for cross builds.
   ///

--- a/packages/xcross/test/cli/sdk_command_test.dart
+++ b/packages/xcross/test/cli/sdk_command_test.dart
@@ -408,6 +408,9 @@ void main() {
     await Directory(
       p.join(sdkRoot, 'System', 'Library', 'Frameworks'),
     ).create(recursive: true);
+    await Directory(
+      p.join(sdkRoot, 'usr', 'include', 'c++', 'v1'),
+    ).create(recursive: true);
     final layout = File(
       p.join(
         bundle.path,
@@ -469,7 +472,7 @@ void main() {
     );
     expect(target['includeSearchPaths'], [
       'Developer/Platforms/iPhoneOS.platform/Developer/usr/lib',
-      'Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1',
+      'Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.2.sdk/usr/include/c++/v1',
     ]);
     expect(target['librarySearchPaths'], [
       'Developer/Platforms/iPhoneOS.platform/Developer/usr/lib',

--- a/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
+++ b/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
@@ -833,6 +833,29 @@ let package = Package(name: "Sentry", products: [], targets: [])
     });
   });
 
+  group('removeMissingResources', () {
+    test('drops missing resources and preserves existing resources', () {
+      final package = Directory(p.join(tmp.path, 'resources'))
+        ..createSync(recursive: true);
+      File(p.join(package.path, 'PrivacyInfo.xcprivacy'))
+        ..createSync()
+        ..writeAsStringSync('{}');
+      const manifest = '''
+resources: [
+    .process("PrivacyInfo.xcprivacy"),
+    .copy("Resources/Missing.bundle"),
+]
+''';
+
+      final normalized = GeneratedPluginsPackage.removeMissingResources(
+        manifest,
+        package.path,
+      );
+      expect(normalized, contains('.process("PrivacyInfo.xcprivacy")'));
+      expect(normalized, isNot(contains('Missing.bundle')));
+    });
+  });
+
   group('registrantSource', () {
     test('imports and registers only the plugin with a pluginClass', () {
       final pluginA = makePlugin('plugin_a', pluginClass: 'PluginA');


### PR DESCRIPTION
## Summary

- point Swift SDK metadata at the libc++ headers that actually exist in the iPhoneOS SDK
- remove missing resource declarations from staged plugin manifests
- retain existing resource declarations and prefer toolchain libc++ when present

## Why

This removes the xcross-owned build warnings in the supplied Flutter 3.47.1 log:

- `directory not found ... XcodeDefault.xctoolchain/usr/include/c++/v1`
- `Invalid Resource Resources/PrivacyInfo.xcprivacy: File not found`

The runtime Objective-C exception is fixed by #37, already merged into the base branch. Other lines in the log are dependency deprecations, an LLVM app-extension safety warning, an expected initial tunneld probe, or consequences of the app crash rather than independent exceptions.

## Tests

- `dart test test/cli/sdk_command_test.dart test/flutter/build/ios_plugin_package_test.dart`
- `dart analyze` (one pre-existing `unnecessary_async` info in `test/update/build_xcross_test.dart`)
