### PR TITLE
fix(dap): support read-only Flutter SDKs on NixOS

### DIFF
--- a/packages/xcross/lib/src/flutter/build/ios_engine_cache.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_engine_cache.dart
@@ -11,27 +11,28 @@ import 'package:xcross/src/flutter/errors.dart';
 ///
 /// On macOS, `flutter precache --ios` downloads these into
 /// `bin/cache/artifacts/engine/ios/`. On Linux, Flutter skips iOS artifacts,
-/// so we fetch them ourselves from `storage.googleapis.com`.
+/// so we fetch them ourselves from `storage.googleapis.com`. Missing artifacts
+/// are stored outside the Flutter SDK so read-only installations work.
 final class IosEngineCache {
-  final String flutterRoot;
-  final String cacheRoot;
-
   IosEngineCache({required this.flutterRoot, String? cacheRoot})
     : cacheRoot = cacheRoot ?? _defaultCacheRoot;
 
-  String get _sdkEngineRoot =>
+  final String flutterRoot;
+  final String cacheRoot;
+
+  String get _flutterSdkEngineRoot =>
       p.join(flutterRoot, 'bin', 'cache', 'artifacts', 'engine');
 
-  String get _cachedEngineRoot =>
-      p.join(cacheRoot, _engineHash(), 'artifacts', 'engine');
+  String get _userEngineRoot =>
+      p.join(cacheRoot, _readEngineHash(), 'artifacts', 'engine');
 
-  /// `bin/cache/artifacts/engine/ios/` — debug/JIT artifacts only.
+  /// Directory containing the debug/JIT iOS engine artifacts.
   String get _engineDir {
-    final sdkDir = p.join(_sdkEngineRoot, 'ios');
-    if (Directory(p.join(sdkDir, 'Flutter.xcframework')).existsSync()) {
-      return sdkDir;
-    }
-    return p.join(_cachedEngineRoot, 'ios');
+    final flutterSdkDirectory = p.join(_flutterSdkEngineRoot, 'ios');
+    final flutterFramework = p.join(flutterSdkDirectory, 'Flutter.xcframework');
+    if (Directory(flutterFramework).existsSync()) return flutterSdkDirectory;
+
+    return p.join(_userEngineRoot, 'ios');
   }
 
   /// Flutter.xcframework inside [_engineDir].
@@ -45,14 +46,20 @@ final class IosEngineCache {
   String get isolateSnapshotData =>
       p.join(_hostEngineDir, 'isolate_snapshot.bin');
 
-  /// Host engine cache dir — where Flutter caches the host Dart engine.
+  /// Directory containing snapshot data for the host Dart engine.
   String get _hostEngineDir {
-    final sdkDir = p.join(_sdkEngineRoot, _hostEngineCacheDir);
-    if (File(p.join(sdkDir, 'vm_isolate_snapshot.bin')).existsSync() &&
-        File(p.join(sdkDir, 'isolate_snapshot.bin')).existsSync()) {
-      return sdkDir;
-    }
-    return p.join(_cachedEngineRoot, _hostEngineCacheDir);
+    final flutterSdkDirectory = p.join(
+      _flutterSdkEngineRoot,
+      _hostEngineCacheDir,
+    );
+    final hasSnapshotData =
+        File(
+          p.join(flutterSdkDirectory, 'vm_isolate_snapshot.bin'),
+        ).existsSync() &&
+        File(p.join(flutterSdkDirectory, 'isolate_snapshot.bin')).existsSync();
+    if (hasSnapshotData) return flutterSdkDirectory;
+
+    return p.join(_userEngineRoot, _hostEngineCacheDir);
   }
 
   /// Path to the Dart frontend_server snapshot. Prefers the AOT variant
@@ -78,15 +85,20 @@ final class IosEngineCache {
 
   /// Patched SDK platform .dill — debug uses `flutter_patched_sdk/`.
   String get patchedSdkRoot {
-    final sdkDir = p.join(_sdkEngineRoot, 'common', 'flutter_patched_sdk');
-    if (Directory(sdkDir).existsSync()) return sdkDir;
-    return p.join(_cachedEngineRoot, 'common', 'flutter_patched_sdk');
+    final flutterSdkDirectory = p.join(
+      _flutterSdkEngineRoot,
+      'common',
+      'flutter_patched_sdk',
+    );
+    if (Directory(flutterSdkDirectory).existsSync()) {
+      return flutterSdkDirectory;
+    }
+
+    return p.join(_userEngineRoot, 'common', 'flutter_patched_sdk');
   }
 
-  /// Engine hash that pins the artifact set. Read from
-  /// `bin/internal/engine.version` (stable/beta) or `bin/cache/engine.stamp`
-  /// (written by flutter_tools at runtime).
-  String _engineHash() {
+  /// Reads the engine hash that pins the artifact set.
+  String _readEngineHash() {
     for (final rel in [
       p.join('bin', 'internal', 'engine.version'),
       p.join('bin', 'cache', 'engine.stamp'),
@@ -121,7 +133,7 @@ final class IosEngineCache {
   }
 
   Future<void> _downloadHostArtifacts() async {
-    final hash = _engineHash();
+    final hash = _readEngineHash();
     final url =
         '$flutterArtifactBaseUrl/$hash/$_hostEngineCacheDir/artifacts.zip';
     Log.logTrace('downloading Flutter host engine artifacts from $url');
@@ -134,7 +146,7 @@ final class IosEngineCache {
   }
 
   Future<void> _downloadIosArtifacts() async {
-    final hash = _engineHash();
+    final hash = _readEngineHash();
     final url = '$flutterArtifactBaseUrl/$hash/ios/artifacts.zip';
     Log.logTrace('downloading Flutter iOS engine artifacts from $url');
     await _fetchAndExtract(
@@ -146,7 +158,7 @@ final class IosEngineCache {
   }
 
   Future<void> _downloadPatchedSdk() async {
-    final hash = _engineHash();
+    final hash = _readEngineHash();
     final leaf = p.basename(patchedSdkRoot);
     final url = '$flutterArtifactBaseUrl/$hash/$leaf.zip';
     Log.logTrace('downloading Flutter patched SDK from $url');
@@ -187,6 +199,7 @@ final class IosEngineCache {
     await tmp.delete(recursive: true);
   }
 
+  /// Per-user directory for artifacts missing from the Flutter SDK.
   static String get _defaultCacheRoot {
     if (Platform.isWindows) {
       final localAppData = Platform.environment['LOCALAPPDATA'];

--- a/packages/xcross/lib/src/flutter/build/ios_engine_cache.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_engine_cache.dart
@@ -14,12 +14,25 @@ import 'package:xcross/src/flutter/errors.dart';
 /// so we fetch them ourselves from `storage.googleapis.com`.
 final class IosEngineCache {
   final String flutterRoot;
+  final String cacheRoot;
 
-  IosEngineCache({required this.flutterRoot});
+  IosEngineCache({required this.flutterRoot, String? cacheRoot})
+    : cacheRoot = cacheRoot ?? _defaultCacheRoot;
+
+  String get _sdkEngineRoot =>
+      p.join(flutterRoot, 'bin', 'cache', 'artifacts', 'engine');
+
+  String get _cachedEngineRoot =>
+      p.join(cacheRoot, _engineHash(), 'artifacts', 'engine');
 
   /// `bin/cache/artifacts/engine/ios/` — debug/JIT artifacts only.
-  String get _engineDir =>
-      p.join(flutterRoot, 'bin', 'cache', 'artifacts', 'engine', 'ios');
+  String get _engineDir {
+    final sdkDir = p.join(_sdkEngineRoot, 'ios');
+    if (Directory(p.join(sdkDir, 'Flutter.xcframework')).existsSync()) {
+      return sdkDir;
+    }
+    return p.join(_cachedEngineRoot, 'ios');
+  }
 
   /// Flutter.xcframework inside [_engineDir].
   String get flutterXcframework => p.join(_engineDir, 'Flutter.xcframework');
@@ -33,14 +46,14 @@ final class IosEngineCache {
       p.join(_hostEngineDir, 'isolate_snapshot.bin');
 
   /// Host engine cache dir — where Flutter caches the host Dart engine.
-  String get _hostEngineDir => p.join(
-    flutterRoot,
-    'bin',
-    'cache',
-    'artifacts',
-    'engine',
-    _hostEngineCacheDir,
-  );
+  String get _hostEngineDir {
+    final sdkDir = p.join(_sdkEngineRoot, _hostEngineCacheDir);
+    if (File(p.join(sdkDir, 'vm_isolate_snapshot.bin')).existsSync() &&
+        File(p.join(sdkDir, 'isolate_snapshot.bin')).existsSync()) {
+      return sdkDir;
+    }
+    return p.join(_cachedEngineRoot, _hostEngineCacheDir);
+  }
 
   /// Path to the Dart frontend_server snapshot. Prefers the AOT variant
   /// (`frontend_server_aot.dart.snapshot`) for speed; falls back to the JIT
@@ -64,27 +77,23 @@ final class IosEngineCache {
   }
 
   /// Patched SDK platform .dill — debug uses `flutter_patched_sdk/`.
-  String get patchedSdkRoot => p.join(
-    flutterRoot,
-    'bin',
-    'cache',
-    'artifacts',
-    'engine',
-    'common',
-    'flutter_patched_sdk',
-  );
+  String get patchedSdkRoot {
+    final sdkDir = p.join(_sdkEngineRoot, 'common', 'flutter_patched_sdk');
+    if (Directory(sdkDir).existsSync()) return sdkDir;
+    return p.join(_cachedEngineRoot, 'common', 'flutter_patched_sdk');
+  }
 
   /// Engine hash that pins the artifact set. Read from
   /// `bin/internal/engine.version` (stable/beta) or `bin/cache/engine.stamp`
   /// (written by flutter_tools at runtime).
-  Future<String> _engineHash() async {
+  String _engineHash() {
     for (final rel in [
       p.join('bin', 'internal', 'engine.version'),
       p.join('bin', 'cache', 'engine.stamp'),
     ]) {
       final file = File(p.join(flutterRoot, rel));
       if (file.existsSync()) {
-        final text = (await file.readAsString()).trim();
+        final text = file.readAsStringSync().trim();
         if (text.isNotEmpty) return text;
       }
     }
@@ -112,7 +121,7 @@ final class IosEngineCache {
   }
 
   Future<void> _downloadHostArtifacts() async {
-    final hash = await _engineHash();
+    final hash = _engineHash();
     final url =
         '$flutterArtifactBaseUrl/$hash/$_hostEngineCacheDir/artifacts.zip';
     Log.logTrace('downloading Flutter host engine artifacts from $url');
@@ -125,7 +134,7 @@ final class IosEngineCache {
   }
 
   Future<void> _downloadIosArtifacts() async {
-    final hash = await _engineHash();
+    final hash = _engineHash();
     final url = '$flutterArtifactBaseUrl/$hash/ios/artifacts.zip';
     Log.logTrace('downloading Flutter iOS engine artifacts from $url');
     await _fetchAndExtract(
@@ -137,7 +146,7 @@ final class IosEngineCache {
   }
 
   Future<void> _downloadPatchedSdk() async {
-    final hash = await _engineHash();
+    final hash = _engineHash();
     final leaf = p.basename(patchedSdkRoot);
     final url = '$flutterArtifactBaseUrl/$hash/$leaf.zip';
     Log.logTrace('downloading Flutter patched SDK from $url');
@@ -176,6 +185,24 @@ final class IosEngineCache {
       () => extractFileToDisk(zipPath, destDir),
     );
     await tmp.delete(recursive: true);
+  }
+
+  static String get _defaultCacheRoot {
+    if (Platform.isWindows) {
+      final localAppData = Platform.environment['LOCALAPPDATA'];
+      if (localAppData != null && localAppData.isNotEmpty) {
+        return p.join(localAppData, 'xcross', 'flutter-engine');
+      }
+    }
+    final xdg = Platform.environment['XDG_CACHE_HOME'];
+    if (xdg != null && xdg.isNotEmpty) {
+      return p.join(xdg, 'xcross', 'flutter-engine');
+    }
+    final home =
+        Platform.environment['HOME'] ??
+        Platform.environment['USERPROFILE'] ??
+        '.';
+    return p.join(home, '.cache', 'xcross', 'flutter-engine');
   }
 
   /// Platform-specific engine cache directory name.

--- a/packages/xcross/test/flutter/build/ios_engine_cache_test.dart
+++ b/packages/xcross/test/flutter/build/ios_engine_cache_test.dart
@@ -1,0 +1,73 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:xcross/src/flutter/build/ios_engine_cache.dart';
+
+void main() {
+  late Directory tmp;
+  late String flutterRoot;
+  late String cacheRoot;
+
+  setUp(() async {
+    tmp = await Directory.systemTemp.createTemp('xcross_ios_engine_cache-');
+    flutterRoot = p.join(tmp.path, 'flutter');
+    cacheRoot = p.join(tmp.path, 'cache');
+    final internal = Directory(p.join(flutterRoot, 'bin', 'internal'));
+    await internal.create(recursive: true);
+    await File(
+      p.join(internal.path, 'engine.version'),
+    ).writeAsString('engine-hash\n');
+  });
+
+  tearDown(() => tmp.delete(recursive: true));
+
+  test('uses per-user cache when SDK artifacts are absent', () {
+    final cache = IosEngineCache(
+      flutterRoot: flutterRoot,
+      cacheRoot: cacheRoot,
+    );
+    final engineRoot = p.join(cacheRoot, 'engine-hash', 'artifacts', 'engine');
+
+    expect(
+      cache.flutterXcframework,
+      p.join(engineRoot, 'ios', 'Flutter.xcframework'),
+    );
+    expect(
+      cache.patchedSdkRoot,
+      p.join(engineRoot, 'common', 'flutter_patched_sdk'),
+    );
+    expect(cache.vmSnapshotData, contains(engineRoot));
+    expect(cache.isolateSnapshotData, contains(engineRoot));
+  });
+
+  test('prefers artifacts already present in Flutter SDK', () {
+    final sdkEngine = p.join(
+      flutterRoot,
+      'bin',
+      'cache',
+      'artifacts',
+      'engine',
+    );
+    Directory(
+      p.join(sdkEngine, 'ios', 'Flutter.xcframework'),
+    ).createSync(recursive: true);
+    Directory(
+      p.join(sdkEngine, 'common', 'flutter_patched_sdk'),
+    ).createSync(recursive: true);
+
+    final cache = IosEngineCache(
+      flutterRoot: flutterRoot,
+      cacheRoot: cacheRoot,
+    );
+
+    expect(
+      cache.flutterXcframework,
+      p.join(sdkEngine, 'ios', 'Flutter.xcframework'),
+    );
+    expect(
+      cache.patchedSdkRoot,
+      p.join(sdkEngine, 'common', 'flutter_patched_sdk'),
+    );
+  });
+}

--- a/packages/xcross/test/flutter/build/ios_engine_cache_test.dart
+++ b/packages/xcross/test/flutter/build/ios_engine_cache_test.dart
@@ -5,14 +5,16 @@ import 'package:test/test.dart';
 import 'package:xcross/src/flutter/build/ios_engine_cache.dart';
 
 void main() {
-  late Directory tmp;
+  late Directory temporaryDirectory;
   late String flutterRoot;
   late String cacheRoot;
 
   setUp(() async {
-    tmp = await Directory.systemTemp.createTemp('xcross_ios_engine_cache-');
-    flutterRoot = p.join(tmp.path, 'flutter');
-    cacheRoot = p.join(tmp.path, 'cache');
+    temporaryDirectory = await Directory.systemTemp.createTemp(
+      'xcross_ios_engine_cache-',
+    );
+    flutterRoot = p.join(temporaryDirectory.path, 'flutter');
+    cacheRoot = p.join(temporaryDirectory.path, 'cache');
     final internal = Directory(p.join(flutterRoot, 'bin', 'internal'));
     await internal.create(recursive: true);
     await File(
@@ -20,29 +22,34 @@ void main() {
     ).writeAsString('engine-hash\n');
   });
 
-  tearDown(() => tmp.delete(recursive: true));
+  tearDown(() => temporaryDirectory.delete(recursive: true));
 
   test('uses per-user cache when SDK artifacts are absent', () {
     final cache = IosEngineCache(
       flutterRoot: flutterRoot,
       cacheRoot: cacheRoot,
     );
-    final engineRoot = p.join(cacheRoot, 'engine-hash', 'artifacts', 'engine');
+    final userEngineRoot = p.join(
+      cacheRoot,
+      'engine-hash',
+      'artifacts',
+      'engine',
+    );
 
     expect(
       cache.flutterXcframework,
-      p.join(engineRoot, 'ios', 'Flutter.xcframework'),
+      p.join(userEngineRoot, 'ios', 'Flutter.xcframework'),
     );
     expect(
       cache.patchedSdkRoot,
-      p.join(engineRoot, 'common', 'flutter_patched_sdk'),
+      p.join(userEngineRoot, 'common', 'flutter_patched_sdk'),
     );
-    expect(cache.vmSnapshotData, contains(engineRoot));
-    expect(cache.isolateSnapshotData, contains(engineRoot));
+    expect(cache.vmSnapshotData, contains(userEngineRoot));
+    expect(cache.isolateSnapshotData, contains(userEngineRoot));
   });
 
   test('prefers artifacts already present in Flutter SDK', () {
-    final sdkEngine = p.join(
+    final flutterSdkEngineRoot = p.join(
       flutterRoot,
       'bin',
       'cache',
@@ -50,10 +57,10 @@ void main() {
       'engine',
     );
     Directory(
-      p.join(sdkEngine, 'ios', 'Flutter.xcframework'),
+      p.join(flutterSdkEngineRoot, 'ios', 'Flutter.xcframework'),
     ).createSync(recursive: true);
     Directory(
-      p.join(sdkEngine, 'common', 'flutter_patched_sdk'),
+      p.join(flutterSdkEngineRoot, 'common', 'flutter_patched_sdk'),
     ).createSync(recursive: true);
 
     final cache = IosEngineCache(
@@ -63,11 +70,11 @@ void main() {
 
     expect(
       cache.flutterXcframework,
-      p.join(sdkEngine, 'ios', 'Flutter.xcframework'),
+      p.join(flutterSdkEngineRoot, 'ios', 'Flutter.xcframework'),
     );
     expect(
       cache.patchedSdkRoot,
-      p.join(sdkEngine, 'common', 'flutter_patched_sdk'),
+      p.join(flutterSdkEngineRoot, 'common', 'flutter_patched_sdk'),
     );
   });
 }


### PR DESCRIPTION
## Summary
- fix DAP launches failing when Flutter is installed in the read-only Nix store
- download missing Flutter engine artifacts into a writable per-user cache
- key cached artifacts by Flutter engine hash
- continue preferring artifacts already present in the Flutter SDK
- add regression coverage for SDK and user-cache path selection

## DAP path
`XcrossDap._startRun` starts `xcross flutter run`, which reaches `IosEngineCache.ensureArtifactsAvailable`; this is the path shown in the reported DAP stack trace. The adapter itself does not download artifacts.

## Validation
- `dart analyze lib/src/flutter/build/ios_engine_cache.dart test/flutter/build/ios_engine_cache_test.dart`
- `dart test test/flutter/build/ios_engine_cache_test.dart`