### PR TITLE
fix(device): restart stale wifi tunnel daemon

### DIFF
--- a/packages/dart_mobile_device/lib/src/pymd/pymd_device_resolver.dart
+++ b/packages/dart_mobile_device/lib/src/pymd/pymd_device_resolver.dart
@@ -7,6 +7,7 @@ import 'package:dart_mobile_device/src/pymd/pymd.dart';
 import 'package:dart_mobile_device/src/pymd/pymd_devices.dart';
 import 'package:dart_mobile_device/src/pymd/remote_pairing.dart';
 import 'package:dart_mobile_device/src/tunnel/tunnel_daemon.dart';
+import 'package:dart_mobile_device/src/tunnel/tunnel_discovery.dart';
 import 'package:meta/meta.dart';
 
 /// Resolves a target [Device] via pymobiledevice3-backed listing.
@@ -281,6 +282,15 @@ class PymdDeviceResolver {
       _daemonFailure = e;
       Log.logTrace('wireless bring-up: tunneld unavailable: $e');
       return PymdDevices.devices(mode: mode);
+    }
+
+    if (await TunnelDiscovery.activeTunnels().then(
+          (tunnels) => tunnels.isEmpty,
+        ) &&
+        await daemon.restartStale()) {
+      Log.logTrace(
+        'restarted the xcross-managed tunnel daemon after it lost all tunnels',
+      );
     }
 
     final tail = TunneldLogTail.start();

--- a/packages/dart_mobile_device/lib/src/pymd/pymd_device_resolver.dart
+++ b/packages/dart_mobile_device/lib/src/pymd/pymd_device_resolver.dart
@@ -284,13 +284,14 @@ class PymdDeviceResolver {
       return PymdDevices.devices(mode: mode);
     }
 
-    if (await TunnelDiscovery.activeTunnels().then(
-          (tunnels) => tunnels.isEmpty,
-        ) &&
-        await daemon.restartStale()) {
-      Log.logTrace(
-        'restarted the xcross-managed tunnel daemon after it lost all tunnels',
-      );
+    final activeTunnels = await TunnelDiscovery.activeTunnels();
+    if (activeTunnels.isEmpty) {
+      final restarted = await daemon.restartStale();
+      if (restarted) {
+        Log.logTrace(
+          'restarted the xcross-managed tunnel daemon after it lost all tunnels',
+        );
+      }
     }
 
     final tail = TunneldLogTail.start();

--- a/packages/dart_mobile_device/lib/src/tunnel/tunnel_daemon.dart
+++ b/packages/dart_mobile_device/lib/src/tunnel/tunnel_daemon.dart
@@ -212,7 +212,7 @@ class TunnelDaemon {
   /// Only the pid-file daemon is ever killed — a tunneld the user started
   /// in their own terminal is never touched.
   Future<bool> restartStale() async {
-    if (Platform.isWindows) return false;
+    if (_ownsDaemon || Platform.isWindows) return false;
     final int pid;
     try {
       pid = int.parse(File(pidFilePath).readAsStringSync().trim());


### PR DESCRIPTION
## Summary

- detect a reachable xcross-managed tunneld that has lost all active tunnels after the USB bootstrap is unplugged
- restart that stale daemon before polling wireless discovery so its USB and Wi-Fi monitor tasks are recreated
- avoid restarting a daemon started by the current process or a user-managed tunneld

## Testing

- `dart analyze` in `packages/dart_mobile_device`
- `dart test` in `packages/dart_mobile_device`