### PR TITLE
fix(flutter): stabilize Windows native assets and SwiftPM builds

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,7 +24,7 @@ jobs:
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    name: Flutter and Compose SwiftPM build (${{ matrix.os }})
+    name: Flutter SwiftPM build (${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:
@@ -314,72 +314,13 @@ jobs:
             throw "SwiftPM artifact junction gate did not execute:`n$output"
           }
 
-      - name: Restore cached Compose toolchains
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        with:
-          path: ~/.konan
-          key: >-
-            xcross-compose-v1-${{ runner.os }}-${{ runner.arch }}-${{
-            hashFiles(
-              'packages/xcross/lib/src/compose/toolchain/**',
-              'examples/**/gradle/libs.versions.toml',
-              'examples/**/gradle.properties'
-            ) }}
-
-      - name: Build examples on Linux
+      - name: Build Flutter example on Linux
         if: runner.os == 'Linux'
         shell: bash
+        working-directory: examples/flutter_example
         run: |
           set -euo pipefail
-          xcross="$RUNNER_TEMP/xcross-bundle/bin/xcross"
-          "$xcross" compose setup
-          for example in "$GITHUB_WORKSPACE"/examples/*; do
-            if [[ -f "$example/pubspec.yaml" ]]; then
-              (cd "$example" && "$xcross" flutter build)
-            elif [[ -f "$example/settings.gradle.kts" ]]; then
-              (cd "$example" && "$xcross" compose build)
-            fi
-          done
-          test -f examples/compose_app/build/xcross-ios/ComposeApp.app/Runner
-          test -f examples/kmp_swift_app/build/xcross-ios/KmpSwiftApp.app/Runner
-
-      - name: Inspect Compose smoke examples on Linux
-        if: runner.os == 'Linux'
-        shell: bash
-        run: |
-          set -euo pipefail
-          # The build pipeline itself gates on Mach-O validity
-          # (MachOValidator.validate64BitExecutable) and Info.plist/framework
-          # presence (ComposeAppAssembler._validateStagedApp) before ever
-          # writing an .app, and both are unit-tested. This step is the
-          # independent, external half of that acceptance criterion: verify
-          # the actual bundles CI just produced, the same way the Flutter
-          # plugin sample below is inspected, rather than trusting the
-          # internal gate alone.
-          declare -A apps=(
-            [examples/compose_app/build/xcross-ios/ComposeApp.app]=ComposeApp
-            [examples/kmp_swift_app/build/xcross-ios/KmpSwiftApp.app]=Shared
-          )
-          for app in "${!apps[@]}"; do
-            base=${apps[$app]}
-            runner="$app/Runner"
-            plist="$app/Info.plist"
-            framework="$app/Frameworks/$base.framework/$base"
-            test -f "$runner"
-            test -f "$plist"
-            test -f "$framework"
-            llvm-readobj --file-headers "$runner" | tee "$(basename "$app")-runner-headers.txt"
-            grep -Eq 'Format: Mach-O arm64|Arch: aarch64' "$(basename "$app")-runner-headers.txt"
-            flatplist=$(tr '\n\t' '  ' < "$plist")
-            echo "$flatplist" | grep -Eq '<key>CFBundleExecutable</key>[[:space:]]*<string>Runner</string>' || {
-              echo "Info.plist missing CFBundleExecutable=Runner: $plist" >&2
-              exit 1
-            }
-            echo "$flatplist" | grep -Eq '<key>CFBundleIdentifier</key>' || {
-              echo "Info.plist missing CFBundleIdentifier: $plist" >&2
-              exit 1
-            }
-          done
+          "$RUNNER_TEMP/xcross-bundle/bin/xcross" flutter build
 
       - name: Prove deterministic SwiftPM binary warm reuse on Windows
         if: runner.os == 'Windows'
@@ -460,90 +401,14 @@ jobs:
             Set-Location $env:GITHUB_WORKSPACE
           }
 
-      - name: Build examples on Windows
+      - name: Build Flutter example on Windows
         if: runner.os == 'Windows'
         shell: pwsh
+        working-directory: examples/flutter_example
         run: |
           $ErrorActionPreference = 'Stop'
-          $xcross = "$env:RUNNER_TEMP\xcross-bundle\bin\xcross.exe"
-          & $xcross compose setup
-          if ($LASTEXITCODE -ne 0) { throw 'xcross compose setup failed' }
-          $firebase = "$env:GITHUB_WORKSPACE\examples\firebase_example"
-          if (-not (Test-Path (Join-Path $firebase 'pubspec.yaml') -PathType Leaf)) {
-            throw 'Pinned examples revision lacks required firebase_example'
-          }
-          Set-Location $firebase
-          & $xcross flutter build
-          if ($LASTEXITCODE -ne 0) { throw 'firebase_example build failed' }
-          Get-ChildItem "$env:GITHUB_WORKSPACE\examples" -Directory |
-            Where-Object Name -ne 'firebase_example' |
-            ForEach-Object {
-              $command = if (Test-Path (Join-Path $_ 'pubspec.yaml')) {
-                'flutter'
-              } elseif (Test-Path (Join-Path $_ 'settings.gradle.kts')) {
-                'compose'
-              } else {
-                return
-              }
-              Set-Location $_.FullName
-              & $xcross $command build
-              if ($LASTEXITCODE -ne 0) {
-                throw "xcross $command build failed: $($_.Name)"
-              }
-            }
-          Set-Location $env:GITHUB_WORKSPACE
-          $outputs = @(
-            'examples/compose_app/build/xcross-ios/ComposeApp.app/Runner',
-            'examples/kmp_swift_app/build/xcross-ios/KmpSwiftApp.app/Runner'
-          )
-          foreach ($output in $outputs) {
-            if (-not (Test-Path $output -PathType Leaf)) {
-              throw "Missing $output"
-            }
-          }
-
-      - name: Inspect Compose smoke examples on Windows
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          # See the matching Linux step's comment: the build pipeline
-          # already gates Mach-O validity and Info.plist/framework presence
-          # internally (and both are unit-tested); this is the independent,
-          # external verification of the bundles this job just produced.
-          $apps = @{
-            'examples/compose_app/build/xcross-ios/ComposeApp.app' = 'ComposeApp'
-            'examples/kmp_swift_app/build/xcross-ios/KmpSwiftApp.app' = 'Shared'
-          }
-          foreach ($app in $apps.Keys) {
-            $base = $apps[$app]
-            $runner = Join-Path $app 'Runner'
-            $plist = Join-Path $app 'Info.plist'
-            $framework = Join-Path $app "Frameworks/$base.framework/$base"
-            if (-not (Test-Path $runner -PathType Leaf)) {
-              throw "Missing $runner"
-            }
-            if (-not (Test-Path $plist -PathType Leaf)) {
-              throw "Missing $plist"
-            }
-            if (-not (Test-Path $framework -PathType Leaf)) {
-              throw "Missing $framework"
-            }
-            $headers = (& llvm-readobj --file-headers $runner | Out-String)
-            if ($LASTEXITCODE -ne 0) { throw 'llvm-readobj failed' }
-            $isMachO = $headers -match 'Format:\s+Mach-O arm64'
-            $isArm64 = $headers -match 'Arch:\s+aarch64'
-            if (-not $isMachO -and -not $isArm64) {
-              throw "Runner is not ARM64 Mach-O:`n$headers"
-            }
-            $plistText = Get-Content $plist -Raw
-            if ($plistText -notmatch '<key>CFBundleExecutable</key>\s*<string>Runner</string>') {
-              throw "Info.plist missing CFBundleExecutable=Runner:`n$plistText"
-            }
-            if ($plistText -notmatch '<key>CFBundleIdentifier</key>') {
-              throw "Info.plist missing CFBundleIdentifier:`n$plistText"
-            }
-          }
+          & "$env:RUNNER_TEMP\xcross-bundle\bin\xcross.exe" flutter build
+          if ($LASTEXITCODE -ne 0) { throw 'flutter_example build failed' }
 
       - name: Create and build plugin sample on Linux
         if: runner.os == 'Linux'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -296,8 +296,6 @@ jobs:
           if ($output -match '(?im)\bskip(?:ped)?\b' -or $output -notmatch [regex]::Escape($name)) {
             throw "package-local junction gate did not execute:`n$output"
           }
-          dart run packages/xcross/tool/swiftpm_gate_evidence.dart `
-            record packageLocalArtifact
 
       - name: Gate SwiftPM artifact junctions on Windows
         if: runner.os == 'Windows'
@@ -315,8 +313,6 @@ jobs:
           if ($output -match '(?im)\bskip(?:ped)?\b' -or $output -notmatch [regex]::Escape($name)) {
             throw "SwiftPM artifact junction gate did not execute:`n$output"
           }
-          dart run packages/xcross/tool/swiftpm_gate_evidence.dart `
-            record swiftPmArtifact
 
       - name: Restore cached Compose toolchains
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Update example submodule
         shell: bash
-        run: git submodule update --init --remote
+        run: git submodule update --init --checkout examples
 
       - name: Use JDK 21 on Linux
         if: runner.os == 'Linux'
@@ -249,6 +249,71 @@ jobs:
       - name: Restore cached Darwin SDK
         uses: ./.github/actions/setup-darwin-sdk
 
+      - name: Preflight Windows SwiftPM junction gates
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $env:XCROSS_CACHE_DIR = "$env:RUNNER_TEMP\xcross-cache"
+          "XCROSS_CACHE_DIR=$env:XCROSS_CACHE_DIR" |
+            Out-File $env:GITHUB_ENV -Encoding utf8 -Append
+          if ([string]::IsNullOrWhiteSpace($env:XCROSS_SWIFT_SDKS_PATH) -or
+              -not (Test-Path $env:XCROSS_SWIFT_SDKS_PATH -PathType Container)) {
+            throw 'XCROSS_SWIFT_SDKS_PATH is missing or is not a directory'
+          }
+          foreach ($tool in @(
+            'swift',
+            'swift-package',
+            'swift-build',
+            'swiftc',
+            'clang',
+            'clang++',
+            'ld64.lld'
+          )) {
+            if (-not (Get-Command $tool -ErrorAction SilentlyContinue)) {
+              throw "Required junction gate tool is unavailable: $tool"
+            }
+          }
+          $sdks = (& swift sdk list --swift-sdks-path $env:XCROSS_SWIFT_SDKS_PATH |
+            Out-String)
+          if ($LASTEXITCODE -ne 0 -or $sdks -notmatch 'xcross-darwin') {
+            throw "Required xcross-darwin Swift SDK is unavailable:`n$sdks"
+          }
+
+      - name: Gate package-local SwiftPM junctions on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $name = 'package-local junction survives repeated resolve and cross-build'
+          $output = (dart test `
+            packages/xcross/test/flutter/build/swiftpm_binary_artifact_preparer_test.dart `
+            --name $name --reporter expanded 2>&1 | Tee-Object -Variable lines |
+            Out-String)
+          if ($LASTEXITCODE -ne 0) { throw 'package-local junction gate failed' }
+          if ($output -match '(?im)\bskip(?:ped)?\b' -or $output -notmatch [regex]::Escape($name)) {
+            throw "package-local junction gate did not execute:`n$output"
+          }
+          dart run packages/xcross/tool/swiftpm_gate_evidence.dart `
+            record packageLocalArtifact
+
+      - name: Gate SwiftPM artifact junctions on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $name = 'SwiftPM artifact junction survives repeated resolve and cross-build'
+          $output = (dart test `
+            packages/xcross/test/flutter/build/swiftpm_binary_artifact_preparer_test.dart `
+            --name $name --reporter expanded 2>&1 | Tee-Object -Variable lines |
+            Out-String)
+          if ($LASTEXITCODE -ne 0) { throw 'SwiftPM artifact junction gate failed' }
+          if ($output -match '(?im)\bskip(?:ped)?\b' -or $output -notmatch [regex]::Escape($name)) {
+            throw "SwiftPM artifact junction gate did not execute:`n$output"
+          }
+          dart run packages/xcross/tool/swiftpm_gate_evidence.dart `
+            record swiftPmArtifact
+
       - name: Restore cached Compose toolchains
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
@@ -316,6 +381,85 @@ jobs:
             }
           done
 
+      - name: Prove deterministic SwiftPM binary warm reuse on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $fixtureRoot = "$env:RUNNER_TEMP\swiftpm-binary-fixture"
+          $sample = "$env:RUNNER_TEMP\swiftpm-binary-sample"
+          dart run packages/xcross/tool/swiftpm_binary_fixture.dart `
+            $fixtureRoot http://127.0.0.1:8123/BinaryFixture.zip
+          $serve = Start-Process python -ArgumentList @(
+            '-m', 'http.server', '8123', '--bind', '127.0.0.1',
+            '--directory', $fixtureRoot
+          ) -PassThru -WindowStyle Hidden
+          try {
+            flutter create --platforms=ios --org com.example.xcrossci `
+              --project-name swiftpm_binary_sample $sample
+            Set-Location $sample
+            $plugin = (Resolve-Path `
+              "$fixtureRoot\binary_fixture_plugin").Path.Replace('\', '/')
+            flutter pub add -- ('binary_fixture_plugin@{path: ' + $plugin + '}')
+            $xcross = "$env:RUNNER_TEMP\xcross-bundle\bin\xcross.exe"
+
+            $firstWatch = [Diagnostics.Stopwatch]::StartNew()
+            & $xcross flutter build --verbose *>&1 |
+              Tee-Object "$env:RUNNER_TEMP\first-build.log"
+            $firstWatch.Stop()
+            if ($LASTEXITCODE -ne 0) { throw 'cold binary fixture build failed' }
+
+            $fingerprints = @(Get-ChildItem `
+              "$env:XCROSS_CACHE_DIR\swiftpm" -Recurse -File `
+              -Filter '.xcross-build-fingerprint')
+            if ($fingerprints.Count -ne 1) {
+              throw "Expected one generated SwiftPM aggregate fingerprint, found $($fingerprints.Count)"
+            }
+            Remove-Item $fingerprints[0].FullName -Force
+
+            $secondWatch = [Diagnostics.Stopwatch]::StartNew()
+            & $xcross flutter build --verbose *>&1 |
+              Tee-Object "$env:RUNNER_TEMP\second-build.log"
+            $secondWatch.Stop()
+            if ($LASTEXITCODE -ne 0) { throw 'warm binary fixture build failed' }
+
+            $first = Get-Content "$env:RUNNER_TEMP\first-build.log" -Raw
+            if ($first -notmatch 'binary target=BinaryFixture operation=download ') {
+              throw 'cold build did not download the deterministic binary artifact'
+            }
+            if ($first -match 'binary target=BinaryFixture operation=(reuse|copy) ') {
+              throw 'cold build reused or copied the deterministic binary artifact'
+            }
+            $second = Get-Content "$env:RUNNER_TEMP\second-build.log" -Raw
+            if ($second -notmatch 'binary target=BinaryFixture operation=reuse ') {
+              throw 'missing binary artifact reuse trace after forced preparation'
+            }
+            if ($second -match 'binary target=BinaryFixture operation=(download|extract|copy) ') {
+              throw 'warm build repeated binary artifact work'
+            }
+            $store = Join-Path $env:XCROSS_CACHE_DIR `
+              'swiftpm\binary-artifacts-v1'
+            $storeBytes = (Get-ChildItem $store -File -Recurse |
+              Measure-Object Length -Sum).Sum
+            function BinaryPhaseMilliseconds([string] $log) {
+              $sum = 0
+              [regex]::Matches($log, 'binary target=BinaryFixture .*?elapsed_ms=(\d+)') |
+                ForEach-Object { $sum += [int64]$_.Groups[1].Value }
+              return $sum
+            }
+            Write-Host "binary fixture cold_phase_ms=$(BinaryPhaseMilliseconds $first)"
+            Write-Host "binary fixture warm_phase_ms=$(BinaryPhaseMilliseconds $second)"
+            Write-Host "binary fixture cold_build_ms=$($firstWatch.ElapsedMilliseconds)"
+            Write-Host "binary fixture warm_build_ms=$($secondWatch.ElapsedMilliseconds)"
+            Write-Host "binary fixture store_bytes=$storeBytes"
+          } finally {
+            if ($serve -and -not $serve.HasExited) {
+              Stop-Process -Id $serve.Id -Force
+              Wait-Process -Id $serve.Id -ErrorAction SilentlyContinue
+            }
+            Set-Location $env:GITHUB_WORKSPACE
+          }
+
       - name: Build examples on Windows
         if: runner.os == 'Windows'
         shell: pwsh
@@ -324,7 +468,15 @@ jobs:
           $xcross = "$env:RUNNER_TEMP\xcross-bundle\bin\xcross.exe"
           & $xcross compose setup
           if ($LASTEXITCODE -ne 0) { throw 'xcross compose setup failed' }
+          $firebase = "$env:GITHUB_WORKSPACE\examples\firebase_example"
+          if (-not (Test-Path (Join-Path $firebase 'pubspec.yaml') -PathType Leaf)) {
+            throw 'Pinned examples revision lacks required firebase_example'
+          }
+          Set-Location $firebase
+          & $xcross flutter build
+          if ($LASTEXITCODE -ne 0) { throw 'firebase_example build failed' }
           Get-ChildItem "$env:GITHUB_WORKSPACE\examples" -Directory |
+            Where-Object Name -ne 'firebase_example' |
             ForEach-Object {
               $command = if (Test-Path (Join-Path $_ 'pubspec.yaml')) {
                 'flutter'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -290,7 +290,9 @@ jobs:
             packages/xcross/test/flutter/build/swiftpm_binary_artifact_preparer_test.dart `
             --name $name --reporter expanded 2>&1 | Tee-Object -Variable lines |
             Out-String)
-          if ($LASTEXITCODE -ne 0) { throw 'package-local junction gate failed' }
+          if ($LASTEXITCODE -ne 0) {
+            throw "package-local junction gate failed:`n$output"
+          }
           if ($output -match '(?im)\bskip(?:ped)?\b' -or $output -notmatch [regex]::Escape($name)) {
             throw "package-local junction gate did not execute:`n$output"
           }
@@ -307,7 +309,9 @@ jobs:
             packages/xcross/test/flutter/build/swiftpm_binary_artifact_preparer_test.dart `
             --name $name --reporter expanded 2>&1 | Tee-Object -Variable lines |
             Out-String)
-          if ($LASTEXITCODE -ne 0) { throw 'SwiftPM artifact junction gate failed' }
+          if ($LASTEXITCODE -ne 0) {
+            throw "SwiftPM artifact junction gate failed:`n$output"
+          }
           if ($output -match '(?im)\bskip(?:ped)?\b' -or $output -notmatch [regex]::Escape($name)) {
             throw "SwiftPM artifact junction gate did not execute:`n$output"
           }

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,6 +13,9 @@ env:
   SWIFT_VERSION: 6.3.3
   SWIFT_WINDOWS_SHA256: >-
     235626548F249CD516D3D4D90EEE980DCCAD46F3822DAC1F8E3119B0FEDE94B7
+  LLVM_VERSION: 22.1.8
+  LLVM_WINDOWS_SHA256: >-
+    16E5709785FEF73C854646241C4A92C5CD574318D1B33C63330DD7721903E55C
 
 concurrency:
   group: integration-${{ github.ref }}
@@ -135,9 +138,26 @@ jobs:
             throw "Swift installer failed: $($process.ExitCode)"
           }
 
-          $llvmBin = "${env:ProgramFiles}\LLVM\bin"
+          $llvmInstaller = "$env:RUNNER_TEMP\llvm-installer.exe"
+          $llvmRoot = "$env:RUNNER_TEMP\llvm-$env:LLVM_VERSION"
+          $llvmUrl = "https://github.com/llvm/llvm-project/releases/download/" +
+            "llvmorg-$env:LLVM_VERSION/LLVM-$env:LLVM_VERSION-win64.exe"
+          Invoke-WebRequest $llvmUrl -OutFile $llvmInstaller
+          $llvmHash = (Get-FileHash $llvmInstaller -Algorithm SHA256).Hash
+          if ($llvmHash -ne $env:LLVM_WINDOWS_SHA256) {
+            throw "LLVM installer checksum mismatch: $llvmHash"
+          }
+          $llvmProcess = Start-Process `
+            $llvmInstaller `
+            -ArgumentList '/S', "/D=$llvmRoot" `
+            -PassThru `
+            -Wait
+          if ($llvmProcess.ExitCode -ne 0) {
+            throw "LLVM installer failed: $($llvmProcess.ExitCode)"
+          }
+          $llvmBin = "$llvmRoot\bin"
           if (-not (Test-Path "$llvmBin\ld64.lld.exe")) {
-            throw "Hosted-runner LLVM missing ld64.lld.exe at $llvmBin"
+            throw "Pinned LLVM missing ld64.lld.exe at $llvmBin"
           }
           $swiftRoot = "$env:LOCALAPPDATA\Programs\Swift"
           # The installer registers its Runtimes, Toolchains, and Tools

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -94,9 +94,10 @@ jobs:
           flutter config --no-analytics
           flutter precache --ios
           dart pub get
-          (cd packages/xcross && dart build cli -t bin/xcross.dart)
+          (cd packages/xcross && dart run tool/build_xcross.dart)
           cp -r packages/xcross/build/cli/*/bundle "$RUNNER_TEMP/xcross-bundle"
           chmod +x "$RUNNER_TEMP/xcross-bundle/bin/xcross"
+          chmod +x "$RUNNER_TEMP/xcross-bundle/bin/xcrun"
           "$RUNNER_TEMP/xcross-bundle/bin/xcross" setup
           sudo apt-get install -y llvm
           tools=(
@@ -234,7 +235,7 @@ jobs:
           flutter precache --ios
           dart pub get
           Push-Location packages/xcross
-          dart build cli -t bin/xcross.dart
+          dart run tool/build_xcross.dart
           Pop-Location
           Copy-Item -Recurse `
             packages/xcross/build/cli/windows_x64/bundle `
@@ -244,18 +245,20 @@ jobs:
       - name: Restore cached Darwin SDK
         uses: ./.github/actions/setup-darwin-sdk
 
-      - name: Build Compose smoke examples on Linux
+      - name: Build examples on Linux
         if: runner.os == 'Linux'
         shell: bash
         run: |
           set -euo pipefail
           xcross="$RUNNER_TEMP/xcross-bundle/bin/xcross"
-          cd "$GITHUB_WORKSPACE/examples/compose_app"
           "$xcross" compose setup
-          "$xcross" compose build
-          cd "$GITHUB_WORKSPACE/examples/kmp_swift_app"
-          "$xcross" compose build
-          cd "$GITHUB_WORKSPACE"
+          for example in "$GITHUB_WORKSPACE"/examples/*; do
+            if [[ -f "$example/pubspec.yaml" ]]; then
+              (cd "$example" && "$xcross" flutter build)
+            elif [[ -f "$example/settings.gradle.kts" ]]; then
+              (cd "$example" && "$xcross" compose build)
+            fi
+          done
           test -f examples/compose_app/build/xcross-ios/ComposeApp.app/Runner
           test -f examples/kmp_swift_app/build/xcross-ios/KmpSwiftApp.app/Runner
 
@@ -297,20 +300,29 @@ jobs:
             }
           done
 
-      - name: Build Compose smoke examples on Windows
+      - name: Build examples on Windows
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
           $xcross = "$env:RUNNER_TEMP\xcross-bundle\bin\xcross.exe"
-          Set-Location "$env:GITHUB_WORKSPACE\examples\compose_app"
           & $xcross compose setup
           if ($LASTEXITCODE -ne 0) { throw 'xcross compose setup failed' }
-          & $xcross compose build
-          if ($LASTEXITCODE -ne 0) { throw 'xcross compose build compose_app failed' }
-          Set-Location "$env:GITHUB_WORKSPACE\examples\kmp_swift_app"
-          & $xcross compose build
-          if ($LASTEXITCODE -ne 0) { throw 'xcross compose build kmp_swift_app failed' }
+          Get-ChildItem "$env:GITHUB_WORKSPACE\examples" -Directory |
+            ForEach-Object {
+              $command = if (Test-Path (Join-Path $_ 'pubspec.yaml')) {
+                'flutter'
+              } elseif (Test-Path (Join-Path $_ 'settings.gradle.kts')) {
+                'compose'
+              } else {
+                return
+              }
+              Set-Location $_.FullName
+              & $xcross $command build
+              if ($LASTEXITCODE -ne 0) {
+                throw "xcross $command build failed: $($_.Name)"
+              }
+            }
           Set-Location $env:GITHUB_WORKSPACE
           $outputs = @(
             'examples/compose_app/build/xcross-ios/ComposeApp.app/Runner',

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -249,6 +249,18 @@ jobs:
       - name: Restore cached Darwin SDK
         uses: ./.github/actions/setup-darwin-sdk
 
+      - name: Restore cached Compose toolchains
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.konan
+          key: >-
+            xcross-compose-v1-${{ runner.os }}-${{ runner.arch }}-${{
+            hashFiles(
+              'packages/xcross/lib/src/compose/toolchain/**',
+              'examples/**/gradle/libs.versions.toml',
+              'examples/**/gradle.properties'
+            ) }}
+
       - name: Build examples on Linux
         if: runner.os == 'Linux'
         shell: bash

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
         with:
           persist-credentials: false
+          submodules: recursive
 
       - name: Use JDK 21 on Linux
         if: runner.os == 'Linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,6 +171,7 @@ jobs:
             'LICENSE'
             'THIRD_PARTY_LICENSES/provision-dart.txt'
             'bin/xcross.exe'
+            'bin/xcrun.exe'
             'lib/sysv_abi_bridge.dll'
           ) | Sort-Object
           $root = Resolve-Path smoke

--- a/install.ps1
+++ b/install.ps1
@@ -143,6 +143,9 @@ try {
   if (-not (Test-Path (Join-Path $staged 'bin\xcross.exe'))) {
     Fail 'archive missing bin\xcross.exe'
   }
+  if (-not (Test-Path (Join-Path $staged 'bin\xcrun.exe'))) {
+    Fail 'archive missing bin\xcrun.exe'
+  }
   if (-not (Test-Path (Join-Path $staged 'lib\sysv_abi_bridge.dll'))) {
     Fail 'archive missing lib\sysv_abi_bridge.dll'
   }

--- a/install.sh
+++ b/install.sh
@@ -172,6 +172,7 @@ tar -C "$staging_dir" -xzf "$staging_dir/$archive_name" ||
 # Verify the bundle really has both halves before touching the system, so a
 # malformed release cannot leave a binary installed without its libraries.
 [ -x "$staging_dir/bin/$BINARY_NAME" ] || err "archive missing bin/$BINARY_NAME"
+[ -x "$staging_dir/bin/xcrun" ] || err "archive missing bin/xcrun"
 [ -d "$staging_dir/lib" ] || err "archive missing lib/"
 
 # ---------------------------------------------------------------------------
@@ -199,6 +200,7 @@ run_privileged mkdir -p "$INSTALL_DIR" "$NATIVE_LIB_DIR" "$LICENSE_DIR"
 
 # 0755: everyone may read and execute, only the owner may write.
 run_privileged install -m 0755 "$staging_dir/bin/$BINARY_NAME" "$installed_binary"
+run_privileged install -m 0755 "$staging_dir/bin/xcrun" "$INSTALL_DIR/xcrun"
 
 # Copy the native libraries next to the prefix, preserving permissions and
 # symlinks (`cp -a`).  Existing files with the same name are overwritten, which

--- a/packages/cli_kit/lib/src/process.dart
+++ b/packages/cli_kit/lib/src/process.dart
@@ -49,8 +49,8 @@ abstract final class ProcessRunner {
       arguments,
       workingDirectory: workingDirectory,
       environment: environment,
-      stdoutEncoding: utf8,
-      stderrEncoding: utf8,
+      stdoutEncoding: const Utf8Codec(allowMalformed: true),
+      stderrEncoding: const Utf8Codec(allowMalformed: true),
     );
     return CapturedProcess(
       result.exitCode,
@@ -199,8 +199,12 @@ abstract final class ProcessRunner {
     }
 
     final drained = Future.wait([
-      process.stdout.transform(utf8.decoder).forEach(sink),
-      process.stderr.transform(utf8.decoder).forEach(sink),
+      process.stdout
+          .transform(const Utf8Decoder(allowMalformed: true))
+          .forEach(sink),
+      process.stderr
+          .transform(const Utf8Decoder(allowMalformed: true))
+          .forEach(sink),
     ]);
 
     unawaited(process.stdin.done.catchError((Object _) {}));

--- a/packages/cli_kit/test/process_test.dart
+++ b/packages/cli_kit/test/process_test.dart
@@ -306,6 +306,22 @@ void main() {
         expect(result.stdout + result.stderr, contains('Dart'));
       },
     );
+
+    test('replaces malformed UTF-8 from a successful process', () async {
+      final directory = Directory.systemTemp.createTempSync('process-output-');
+      addTearDown(() => directory.deleteSync(recursive: true));
+      final script = File(p.join(directory.path, 'output.dart'))
+        ..writeAsStringSync(
+          "import 'dart:io'; void main() { stdout.add([255]); }",
+        );
+
+      final result = await ProcessRunner.run(Platform.resolvedExecutable, [
+        script.path,
+      ]);
+
+      expect(result.exitCode, 0);
+      expect(result.stdout, '\u{fffd}');
+    });
   });
 
   group('runChecked', () {

--- a/packages/darwin_sdk_kit/lib/src/darwin_sdk.dart
+++ b/packages/darwin_sdk_kit/lib/src/darwin_sdk.dart
@@ -308,12 +308,13 @@ final class DarwinSdk {
     }
 
     final output = '${result.stdout}\n${result.stderr}';
-    if (_unsupportedPlatform.hasMatch(output)) {
+    final unsupported = _unsupportedIosLink.firstMatch(output);
+    if (unsupported != null) {
       return _rememberIosSupport(
         linker,
         output
             .split('\n')
-            .firstWhere(_unsupportedPlatform.hasMatch)
+            .firstWhere(_unsupportedIosLink.hasMatch)
             .trim()
             .replaceFirst(RegExp('^.*?: *'), ''),
       );
@@ -449,8 +450,9 @@ final class DarwinSdk {
   /// Probe verdicts by linker path; the empty string means "usable".
   static final Map<String, String> _iosSupport = {};
 
-  static final RegExp _unsupportedPlatform = RegExp(
-    'does not support linking for platform|unknown platform',
+  static final RegExp _unsupportedIosLink = RegExp(
+    'does not support linking for platform|unknown platform|'
+    'missing or unsupported -arch',
     caseSensitive: false,
   );
 

--- a/packages/darwin_sdk_kit/test/darwin_sdk_test.dart
+++ b/packages/darwin_sdk_kit/test/darwin_sdk_test.dart
@@ -267,6 +267,18 @@ void main() {
       expect(failure, contains('does not support linking for platform iOS'));
     });
 
+    test('rejects a linker without ARM64 Mach-O support', () async {
+      final failure = await DarwinSdk.probeIosSupport(
+        p.join(tmp.path, 'unsupported-arch-ld64.lld'),
+        runProcess: (executable, arguments) async => const CapturedProcess(
+          1,
+          '',
+          'ld64.lld: error: missing or unsupported -arch arm64',
+        ),
+      );
+      expect(failure, contains('missing or unsupported -arch arm64'));
+    });
+
     test('rejects a linker that dies without saying anything', () async {
       final failure = await DarwinSdk.probeIosSupport(
         p.join(tmp.path, 'crashing-ld64.lld'),

--- a/packages/xcross/bin/xcrun.dart
+++ b/packages/xcross/bin/xcrun.dart
@@ -1,0 +1,122 @@
+import 'dart:io';
+
+import 'package:darwin_sdk_kit/darwin_sdk_kit.dart';
+import 'package:path/path.dart' as p;
+
+Future<void> main(List<String> arguments) async {
+  if (Platform.isMacOS) {
+    stderr.writeln('xcross xcrun is only intended for Windows and Linux.');
+    exitCode = 1;
+    return;
+  }
+
+  try {
+    exitCode = await runXcrun(arguments);
+  } on Object catch (error) {
+    stderr.writeln('xcrun: $error');
+    exitCode = 1;
+  }
+}
+
+Future<int> runXcrun(List<String> arguments) async {
+  final sdk = DarwinSdk.current();
+  if (sdk == null) {
+    stderr.writeln(
+      'xcrun: no Darwin SDK installed; run `xcross sdk install` first',
+    );
+    return 1;
+  }
+
+  if (arguments.contains('--show-sdk-path')) {
+    stdout.writeln(sdk.iPhoneOSSdk());
+    return 0;
+  }
+
+  final find = arguments.indexOf('--find');
+  if (find >= 0) {
+    if (find + 1 >= arguments.length) return 1;
+    final tool = await _resolveTool(sdk, arguments[find + 1]);
+    if (tool == null) return 1;
+    stdout.writeln(tool);
+    return 0;
+  }
+
+  final toolIndex = _toolIndex(arguments);
+  if (toolIndex == -1) return 1;
+  final tool = await _resolveTool(sdk, arguments[toolIndex]);
+  if (tool == null) {
+    stderr.writeln('xcrun: unknown tool ${arguments[toolIndex]}');
+    return 1;
+  }
+  final process = await Process.start(
+    tool,
+    arguments.sublist(toolIndex + 1),
+    mode: ProcessStartMode.inheritStdio,
+  );
+  return process.exitCode;
+}
+
+int _toolIndex(List<String> arguments) {
+  for (var index = 0; index < arguments.length; index++) {
+    if (arguments[index] == '--sdk') {
+      index++;
+      continue;
+    }
+    if (!arguments[index].startsWith('-')) return index;
+  }
+  return -1;
+}
+
+Future<String?> _findOnPath(String name) async {
+  final executable = Platform.isWindows ? 'where' : 'which';
+  final result = await Process.run(executable, [name]);
+  if (result.exitCode != 0) return null;
+  final first = result.stdout.toString().split(RegExp(r'[\r\n]+')).first.trim();
+  return first.isEmpty ? null : first;
+}
+
+Future<String?> _resolveTool(DarwinSdk sdk, String name) async {
+  final pathTool = await _findOnPath(name);
+  if (pathTool != null &&
+      p.canonicalize(pathTool) != p.canonicalize(Platform.resolvedExecutable)) {
+    return pathTool;
+  }
+  switch (name) {
+    case 'clang':
+    case 'clang++':
+      return DarwinSdk.resolveDarwinClang(sdk, name: name);
+    case 'ld':
+      return DarwinSdk.resolveLd64Lld(sdk);
+    case 'ar':
+      final clang = await DarwinSdk.resolveDarwinClang(sdk);
+      final sibling = p.join(
+        p.dirname(clang),
+        'llvm-ar${Platform.isWindows ? '.exe' : ''}',
+      );
+      if (File(sibling).existsSync()) return sibling;
+      return DarwinSdk.locateLlvmTool(
+        Platform.isWindows ? 'llvm-ar.exe' : 'llvm-ar',
+      );
+    case 'lipo':
+      return DarwinSdk.locateLlvmTool(
+        Platform.isWindows ? 'llvm-lipo.exe' : 'llvm-lipo',
+      );
+    case 'otool':
+      return await DarwinSdk.locateLlvmTool(
+            Platform.isWindows ? 'llvm-otool.exe' : 'llvm-otool',
+          ) ??
+          DarwinSdk.locateLlvmTool(
+            Platform.isWindows ? 'llvm-objdump.exe' : 'llvm-objdump',
+          );
+    case 'install_name_tool':
+      return DarwinSdk.locateLlvmTool(
+        Platform.isWindows
+            ? 'llvm-install-name-tool.exe'
+            : 'llvm-install-name-tool',
+      );
+    case 'codesign':
+      return null;
+    default:
+      return DarwinSdk.locateLlvmTool(Platform.isWindows ? '$name.exe' : name);
+  }
+}

--- a/packages/xcross/lib/src/cli/basic/sdk_install.dart
+++ b/packages/xcross/lib/src/cli/basic/sdk_install.dart
@@ -452,7 +452,7 @@ abstract final class SdkInstall {
     run,
   ) async {
     final file = File(File(path).resolveSymbolicLinksSync());
-    final result = await run(file.path, const ['--version']);
+    final result = await run(path, const ['--version']);
     if (result.exitCode != 0) {
       throw StateError('$name --version failed: ${result.stderr.trim()}');
     }

--- a/packages/xcross/lib/src/cli/basic/sdk_install.dart
+++ b/packages/xcross/lib/src/cli/basic/sdk_install.dart
@@ -2,8 +2,8 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:cli_kit/cli_kit.dart';
+import 'package:crypto/crypto.dart';
 import 'package:darwin_sdk_kit/darwin_sdk_kit.dart';
-import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:xcross/src/cli/basic/internal/hard_link_payloads.dart';
 import 'package:xcross/src/cli/basic/internal/swift_sibling_clang.dart';
@@ -379,7 +379,103 @@ abstract final class SdkInstall {
   /// toolchain upgrades — and the version alone is not enough either, since
   /// two builds of the same version can differ in module ABI (the reported
   /// "swiftlang-…" build differs between a vendor and a swift.org build).
-  @visibleForTesting
+  static Future<Map<String, Object>> swiftPmBuildToolchainIdentity({
+    required String cCompilerPath,
+    required String cxxCompilerPath,
+    required String linkerPath,
+    required String librarianPath,
+    bool? windows,
+    Future<String> Function(String name)? locateTool,
+    Future<CapturedProcess> Function(String executable, List<String> arguments)?
+    runProcess,
+  }) async {
+    final locate = locateTool ?? ProcessRunner.locateTool;
+    final run = runProcess ?? ProcessRunner.run;
+    final toolNames = (windows ?? Platform.isWindows)
+        ? const ['swift-package', 'swift-build', 'swiftc']
+        : const ['swift', 'swiftc'];
+    return {
+      for (final name in toolNames)
+        name: await _executableBuildIdentity(name, locate, run),
+      'clang': await _fileBuildIdentity(cCompilerPath),
+      'clang++': await _fileBuildIdentity(cxxCompilerPath),
+      'ld64.lld': await _fileBuildIdentity(linkerPath),
+      'librarian': await _fileBuildIdentity(librarianPath),
+    };
+  }
+
+  static Future<Map<String, Object>> sdkBuildIdentity(String sdkRoot) async {
+    final files = <String>{
+      'info.json',
+      'swift-sdk.json',
+      'toolset.json',
+      hostToolchainStampName,
+    };
+    final sdk = DarwinSdk(sdkRoot);
+    try {
+      final iphoneOs = sdk.iPhoneOSSdk();
+      for (final name in const [
+        'SDKSettings.json',
+        'SDKSettings.plist',
+        'System/Library/CoreServices/SystemVersion.plist',
+      ]) {
+        files.add(p.relative(p.join(iphoneOs, name), from: sdkRoot));
+      }
+    } on Object catch (error) {
+      Log.logTrace('Could not resolve iPhoneOS SDK identity metadata: $error');
+    }
+    final metadata = <String, Object>{};
+    for (final relative in files.toList()..sort()) {
+      final file = File(p.join(sdkRoot, relative));
+      if (!file.existsSync()) continue;
+      final stat = file.statSync();
+      metadata[relative.replaceAll(r'\', '/')] = {
+        'size': stat.size,
+        'modified': stat.modified.microsecondsSinceEpoch,
+        'digest': sha256.convert(file.readAsBytesSync()).toString(),
+      };
+    }
+    return {'path': p.normalize(p.absolute(sdkRoot)), 'metadata': metadata};
+  }
+
+  static Future<Map<String, Object>> _executableBuildIdentity(
+    String name,
+    Future<String> Function(String name) locate,
+    Future<CapturedProcess> Function(String executable, List<String> arguments)
+    run,
+  ) async => _executablePathBuildIdentity(name, await locate(name), run);
+
+  static Future<Map<String, Object>> _executablePathBuildIdentity(
+    String name,
+    String path,
+    Future<CapturedProcess> Function(String executable, List<String> arguments)
+    run,
+  ) async {
+    final file = File(File(path).resolveSymbolicLinksSync());
+    final result = await run(file.path, const ['--version']);
+    if (result.exitCode != 0) {
+      throw StateError('$name --version failed: ${result.stderr.trim()}');
+    }
+    final output = result.stdout.trim().isEmpty
+        ? result.stderr.trim()
+        : result.stdout.trim();
+    return {
+      ...await _fileBuildIdentity(file.path),
+      'version': _firstLine(output),
+    };
+  }
+
+  static Future<Map<String, Object>> _fileBuildIdentity(String path) {
+    final file = File(File(path).resolveSymbolicLinksSync());
+    final stat = file.statSync();
+    return Future.value({
+      'path': file.path,
+      'size': stat.size,
+      'modified': stat.modified.microsecondsSinceEpoch,
+      'digest': sha256.convert(file.readAsBytesSync()).toString(),
+    });
+  }
+
   static Future<Map<String, String>> hostToolchainIdentity({
     Future<String> Function(String name)? locateTool,
     Future<CapturedProcess> Function(String executable, List<String> arguments)?

--- a/packages/xcross/lib/src/cli/runner.dart
+++ b/packages/xcross/lib/src/cli/runner.dart
@@ -39,8 +39,10 @@ Future<int?> runPreparedToolAlias(
               ? p.windows.basenameWithoutExtension(path)
               : p.basenameWithoutExtension(path))
           .toLowerCase();
+  if (name == 'plutil') return runPlutilAlias(arguments);
   final variable = _toolAliasVariables[name];
   if (variable == null) return null;
+
   final mapping = File('$path.path');
   final target = mapping.existsSync()
       ? mapping.readAsStringSync().trim()
@@ -63,6 +65,32 @@ Future<int?> runPreparedToolAlias(
     return 0;
   }
   return invoke(target, arguments);
+}
+
+Future<int> runPlutilAlias(List<String> arguments) async {
+  if (arguments case [
+    '-replace',
+    'MinimumOSVersion',
+    '-string',
+    final String version,
+    final String path,
+  ]) {
+    final file = File(path);
+    if (!file.existsSync()) return 1;
+    final original = await file.readAsString();
+    final pattern = RegExp(
+      r'<key>MinimumOSVersion</key>\s*<string>[^<]*</string>',
+    );
+    if (!pattern.hasMatch(original)) return 1;
+    await file.writeAsString(
+      original.replaceFirst(
+        pattern,
+        '<key>MinimumOSVersion</key>\n\t<string>$version</string>',
+      ),
+    );
+    return 0;
+  }
+  return 1;
 }
 
 Future<int> _runToolAlias(String executable, List<String> arguments) async {

--- a/packages/xcross/lib/src/cli/runner.dart
+++ b/packages/xcross/lib/src/cli/runner.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:apple_developer_kit/apple_developer_kit.dart';
@@ -64,7 +65,36 @@ Future<int?> runPreparedToolAlias(
   if (name == 'dsymutil' && !File(target).existsSync()) {
     return 0;
   }
-  return invoke(target, arguments);
+  final prefix = File('$path.args');
+  final forwarded = prefix.existsSync() && _isAppleCompilerInvocation(arguments)
+      ? [
+          ...(jsonDecode(prefix.readAsStringSync()) as List).cast<String>(),
+          ...arguments,
+        ]
+      : arguments;
+  return invoke(target, forwarded);
+}
+
+bool _isAppleCompilerInvocation(List<String> arguments) {
+  for (var index = 0; index < arguments.length; index++) {
+    final argument = arguments[index];
+    if (argument == '-arch' ||
+        argument.startsWith('-arch=') ||
+        argument.startsWith('-miphoneos-version-min=') ||
+        argument.startsWith('-mios-simulator-version-min=')) {
+      return true;
+    }
+    if ((argument == '-target' || argument == '--target') &&
+        index + 1 < arguments.length &&
+        arguments[index + 1].contains('-apple-')) {
+      return true;
+    }
+    if ((argument.startsWith('-target=') || argument.startsWith('--target=')) &&
+        argument.contains('-apple-')) {
+      return true;
+    }
+  }
+  return false;
 }
 
 Future<int> runPlutilAlias(List<String> arguments) async {

--- a/packages/xcross/lib/src/cli/runner.dart
+++ b/packages/xcross/lib/src/cli/runner.dart
@@ -41,7 +41,10 @@ Future<int?> runPreparedToolAlias(
           .toLowerCase();
   final variable = _toolAliasVariables[name];
   if (variable == null) return null;
-  final target = (environment ?? Platform.environment)[variable];
+  final mapping = File('$path.path');
+  final target = mapping.existsSync()
+      ? mapping.readAsStringSync().trim()
+      : (environment ?? Platform.environment)[variable];
   if (target == null || target.isEmpty) {
     stderr.writeln('error: missing trusted tool mapping $variable');
     return 1;
@@ -67,6 +70,7 @@ Future<int> _runToolAlias(String executable, List<String> arguments) async {
     executable,
     arguments,
     mode: ProcessStartMode.inheritStdio,
+    runInShell: Platform.isWindows && executable.endsWith('.bat'),
   );
   return process.exitCode;
 }
@@ -78,6 +82,8 @@ const _toolAliasVariables = {
   'libtool': 'XCROSS_APPLE_TOOL_LIBTOOL',
   'clang': 'XCROSS_APPLE_TOOL_CLANG',
   'clang++': 'XCROSS_APPLE_TOOL_CLANGXX',
+  'cc': 'XCROSS_APPLE_TOOL_CC',
+  'ar': 'XCROSS_APPLE_TOOL_AR',
 };
 
 /// Namespace for building and running the xcross CLI.

--- a/packages/xcross/lib/src/flutter/build/flutter_pack_operation.dart
+++ b/packages/xcross/lib/src/flutter/build/flutter_pack_operation.dart
@@ -1,8 +1,15 @@
+import 'dart:convert';
 import 'dart:io';
 
+import 'package:darwin_sdk_kit/darwin_sdk_kit.dart';
 import 'package:path/path.dart' as p;
+import 'package:xcross/src/cli/basic/sdk_install.dart';
 import 'package:xcross/src/flutter/build/flutter_packer.dart';
+import 'package:xcross/src/flutter/build/internal/swiftpm_gate_evidence.dart';
+import 'package:xcross/src/flutter/build/internal/swiftpm_workspace.dart';
 import 'package:xcross/src/flutter/build/ios_bundle_id.dart';
+import 'package:xcross/src/flutter/build/ios_plugin_package.dart';
+import 'package:xcross/src/flutter/errors.dart';
 import 'package:xcross/src/flutter/models/flutter/flutter_build_options.dart';
 import 'package:xcross/src/models/pack_result.dart';
 
@@ -12,14 +19,81 @@ abstract final class FlutterPackOperation {
   ///
   /// Bundle id comes from `ios/Runner/Info.plist` / `project.pbxproj` (same
   /// sources Flutter tooling uses). Deletes any prior bundle, then packs.
+  static Future<({bool swiftPmArtifact, bool packageLocalArtifact})>
+  artifactJunctionCapabilities({
+    required String evidenceRoot,
+    required String platformIdentity,
+    required String toolchainIdentity,
+    required String sdkIdentity,
+    Map<String, String> environment = const {},
+    SwiftPmGateProbe probe = probeSwiftPmGate,
+    SwiftPmGateRuntimeBinding? runtimeBinding,
+  }) async {
+    final evidence = SwiftPmGateEvidence(evidenceRoot);
+    return (
+      swiftPmArtifact: await evidence.verifies(
+        mode: SwiftPmGateMode.swiftPmArtifact,
+        platformIdentity: platformIdentity,
+        toolchainIdentity: toolchainIdentity,
+        sdkIdentity: sdkIdentity,
+        probe: probe,
+        runtimeBinding: runtimeBinding,
+      ),
+      packageLocalArtifact: await evidence.verifies(
+        mode: SwiftPmGateMode.packageLocalArtifact,
+        platformIdentity: platformIdentity,
+        toolchainIdentity: toolchainIdentity,
+        sdkIdentity: sdkIdentity,
+        probe: probe,
+        runtimeBinding: runtimeBinding,
+      ),
+    );
+  }
+
+  static Future<({bool swiftPmArtifact, bool packageLocalArtifact})>
+  resolveArtifactJunctionCapabilities({
+    required SwiftPmWorkspace workspace,
+    DarwinSdk? Function() currentDarwinSdk = DarwinSdk.current,
+    bool? windows,
+  }) async {
+    final sdk = currentDarwinSdk();
+    final isWindows = windows ?? Platform.isWindows;
+    if (isWindows && sdk == null) {
+      throw FlutterBuildError(
+        'Darwin Swift SDK not found. Run '
+        '`xcross sdk install <Xcode.xip>` first.',
+      );
+    }
+    final sdkIdentity = jsonEncode(
+      sdk == null
+          ? const <String, Object>{}
+          : await SdkInstall.sdkBuildIdentity(sdk.swiftSdkPath),
+    );
+    final toolchainIdentity = jsonEncode(
+      isWindows
+          ? await GeneratedPluginsPackage.resolveBuildToolchainIdentity(sdk!)
+          : await SdkInstall.hostToolchainIdentity(),
+    );
+    return artifactJunctionCapabilities(
+      evidenceRoot: workspace.gateEvidence,
+      platformIdentity:
+          '${Platform.operatingSystem}-${Platform.operatingSystemVersion}',
+      toolchainIdentity: toolchainIdentity,
+      sdkIdentity: sdkIdentity,
+    );
+  }
+
   static Future<PackResult> pack({required FlutterBuildOptions options}) async {
     final projectRoot = Directory.current.path;
     final bundleId = IosBundleId.resolve(projectRoot);
+    final workspace = SwiftPmWorkspace.forProject(projectRoot);
 
     final packer = FlutterPacker(
       projectRoot: projectRoot,
       bundleId: bundleId,
       options: options,
+      artifactJunctionCapabilityResolver: () =>
+          resolveArtifactJunctionCapabilities(workspace: workspace),
     );
 
     // Always delete any previous bundle BEFORE packing, otherwise stale

--- a/packages/xcross/lib/src/flutter/build/flutter_packer.dart
+++ b/packages/xcross/lib/src/flutter/build/flutter_packer.dart
@@ -261,9 +261,9 @@ final class FlutterPacker {
     final workspace = SwiftPmWorkspace.forProject(projectRoot);
     return GeneratedPluginsPackage.build(
       projectRoot: projectRoot,
+      workspace: workspace,
       plugins: spmPlugins,
       flutterXcframework: xcframework,
-      outputDir: workspace.packages,
       deploymentTarget: deploymentTarget,
       verbose: verbose,
     );

--- a/packages/xcross/lib/src/flutter/build/flutter_packer.dart
+++ b/packages/xcross/lib/src/flutter/build/flutter_packer.dart
@@ -260,9 +260,7 @@ final class FlutterPacker {
       projectRoot: projectRoot,
       plugins: spmPlugins,
       flutterXcframework: xcframework,
-      outputDir: Platform.isWindows
-          ? p.join(projectRoot, 'build', '.xp')
-          : p.join(projectRoot, 'build', 'xcross-flutter-plugins'),
+      outputDir: p.join(projectRoot, 'build', '.xp'),
       deploymentTarget: deploymentTarget,
       verbose: verbose,
     );

--- a/packages/xcross/lib/src/flutter/build/flutter_packer.dart
+++ b/packages/xcross/lib/src/flutter/build/flutter_packer.dart
@@ -9,12 +9,14 @@ import 'package:xcross/src/flutter/build/flutter_debug_bundler.dart';
 import 'package:xcross/src/flutter/build/info_plist.dart';
 import 'package:xcross/src/flutter/build/internal/recursive_directory_copy.dart';
 import 'package:xcross/src/flutter/build/internal/runner_binary.dart';
+import 'package:xcross/src/flutter/build/internal/swiftpm_workspace.dart';
 import 'package:xcross/src/flutter/build/ios_app_extensions.dart';
 import 'package:xcross/src/flutter/build/ios_bundle_resources.dart';
 import 'package:xcross/src/flutter/build/ios_bundle_versions.dart';
 import 'package:xcross/src/flutter/build/ios_deployment_target.dart';
 import 'package:xcross/src/flutter/build/ios_engine_cache.dart';
 import 'package:xcross/src/flutter/build/ios_native_assets.dart';
+
 import 'package:xcross/src/flutter/build/ios_plugin_package.dart';
 import 'package:xcross/src/flutter/build/ios_plugins.dart';
 import 'package:xcross/src/flutter/build/runner_shim.dart';
@@ -256,11 +258,12 @@ final class FlutterPacker {
       flutterRoot: flutterRoot,
     ).flutterXcframework;
 
+    final workspace = SwiftPmWorkspace.forProject(projectRoot);
     return GeneratedPluginsPackage.build(
       projectRoot: projectRoot,
       plugins: spmPlugins,
       flutterXcframework: xcframework,
-      outputDir: p.join(projectRoot, 'build', 'plugins'),
+      outputDir: workspace.packages,
       deploymentTarget: deploymentTarget,
       verbose: verbose,
     );

--- a/packages/xcross/lib/src/flutter/build/flutter_packer.dart
+++ b/packages/xcross/lib/src/flutter/build/flutter_packer.dart
@@ -43,6 +43,9 @@ final class FlutterPacker {
   final String projectRoot;
   final String bundleId;
   final FlutterBuildOptions options;
+  final bool swiftPmArtifactJunctionCapability;
+  final bool packageLocalArtifactJunctionCapability;
+  final ArtifactJunctionCapabilityResolver? artifactJunctionCapabilityResolver;
 
   /// App name read from `pubspec.yaml` `name:` key.
   final String appName;
@@ -51,6 +54,9 @@ final class FlutterPacker {
     required this.projectRoot,
     required this.bundleId,
     required this.options,
+    this.swiftPmArtifactJunctionCapability = false,
+    this.packageLocalArtifactJunctionCapability = false,
+    this.artifactJunctionCapabilityResolver,
   }) : appName = PubspecInfo.loadSync(projectRoot).name,
        _versions = IosBundleVersions.resolve(
          projectRoot,
@@ -257,6 +263,12 @@ final class FlutterPacker {
     final xcframework = IosEngineCache(
       flutterRoot: flutterRoot,
     ).flutterXcframework;
+    final capabilities =
+        await artifactJunctionCapabilityResolver?.call() ??
+        (
+          swiftPmArtifact: swiftPmArtifactJunctionCapability,
+          packageLocalArtifact: packageLocalArtifactJunctionCapability,
+        );
 
     final workspace = SwiftPmWorkspace.forProject(projectRoot);
     return GeneratedPluginsPackage.build(
@@ -266,6 +278,8 @@ final class FlutterPacker {
       flutterXcframework: xcframework,
       deploymentTarget: deploymentTarget,
       verbose: verbose,
+      swiftPmArtifactJunctionCapability: capabilities.swiftPmArtifact,
+      packageLocalArtifactJunctionCapability: capabilities.packageLocalArtifact,
     );
   }
 

--- a/packages/xcross/lib/src/flutter/build/flutter_packer.dart
+++ b/packages/xcross/lib/src/flutter/build/flutter_packer.dart
@@ -260,7 +260,7 @@ final class FlutterPacker {
       projectRoot: projectRoot,
       plugins: spmPlugins,
       flutterXcframework: xcframework,
-      outputDir: p.join(projectRoot, 'build', '.xp'),
+      outputDir: p.join(projectRoot, 'build', 'plugins'),
       deploymentTarget: deploymentTarget,
       verbose: verbose,
     );

--- a/packages/xcross/lib/src/flutter/build/flutter_packer.dart
+++ b/packages/xcross/lib/src/flutter/build/flutter_packer.dart
@@ -141,8 +141,16 @@ final class FlutterPacker {
     }
 
     final flutter = await ProcessRunner.locateTool('flutter');
+    final resolved = File(flutter).resolveSymbolicLinksSync();
+    if (Platform.isWindows && p.basename(p.dirname(resolved)) == 'shims') {
+      final result = await Process.run('mise', ['where', 'flutter']);
+      if (result.exitCode == 0) {
+        final root = result.stdout.toString().trim();
+        if (Directory(p.join(root, 'bin')).existsSync()) return root;
+      }
+    }
     // The `flutter` script lives at <root>/bin/flutter.
-    return p.dirname(p.dirname(File(flutter).resolveSymbolicLinksSync()));
+    return p.dirname(p.dirname(resolved));
   }
 
   /// Run `flutter pub get`. Tolerates failures when `package_config.json`
@@ -252,7 +260,9 @@ final class FlutterPacker {
       projectRoot: projectRoot,
       plugins: spmPlugins,
       flutterXcframework: xcframework,
-      outputDir: p.join(projectRoot, 'build', 'xcross-flutter-plugins'),
+      outputDir: Platform.isWindows
+          ? p.join(projectRoot, 'build', '.xp')
+          : p.join(projectRoot, 'build', 'xcross-flutter-plugins'),
       deploymentTarget: deploymentTarget,
       verbose: verbose,
     );
@@ -445,6 +455,7 @@ final class FlutterPacker {
       );
     }
   }
+
   /// Generate and write `Info.plist` into [bundleDir] with `$(VAR)`
   /// substitution, mandatory iOS keys, storyboard stripping, and ObjC class
   /// name normalization.

--- a/packages/xcross/lib/src/flutter/build/internal/apple_tool_shim_templates.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/apple_tool_shim_templates.dart
@@ -76,7 +76,9 @@ if (!\$hasDeployment) { \$defaults += '-miphoneos-version-min=$deploymentTarget'
 if (!\$hasFuseLd) { \$defaults += '-fuse-ld=lld' }
 if (!\$hasLdPath) { \$defaults += ${powerShellQuote('--ld-path=$linker')} }
 \$defaults += @('-Xlinker', '-arch', '-Xlinker', 'arm64', '-Xlinker', '-platform_version', '-Xlinker', 'ios', '-Xlinker', '$deploymentTarget', '-Xlinker', '26.5')
-& ${powerShellQuote(clang)} @(\$defaults + \$Arguments)
+\$compiler = ${powerShellQuote(clang)}
+\$compilerArguments = @(\$defaults + \$Arguments)
+& \$compiler @compilerArguments
 exit \$LASTEXITCODE
 ''';
 

--- a/packages/xcross/lib/src/flutter/build/internal/apple_tool_shim_templates.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/apple_tool_shim_templates.dart
@@ -55,7 +55,7 @@ String renderPowerShellCompilerShim({
   required String deploymentTarget,
 }) =>
     '''
-\$Arguments = \$args
+\$Arguments = @(\$args | ForEach-Object { \$_.TrimEnd("`r") })
 \$isAppleTarget = \$false; \$hasTarget = \$false; \$hasSysroot = \$false; \$hasDeployment = \$false
 \$hasFuseLd = \$false; \$hasLdPath = \$false
 for (\$i = 0; \$i -lt \$Arguments.Count; \$i++) {

--- a/packages/xcross/lib/src/flutter/build/internal/apple_tool_shim_templates.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/apple_tool_shim_templates.dart
@@ -47,35 +47,6 @@ done
 exec ${shellQuote(clang)} "\$@"
 ''';
 
-String renderUnixXcrunShim({
-  required String iosSdk,
-  required Map<String, String> tools,
-}) =>
-    '''
-#!/bin/sh
-while [ "\$#" -gt 0 ]; do
-  case "\$1" in
-    --sdk) shift; [ "\$#" -gt 0 ] && shift;;
-    --show-sdk-path) echo ${shellQuote(iosSdk)}; exit 0;;
-    --find)
-      shift
-      case "\${1-}" in
-${tools.entries.map((tool) => '        ${tool.key}) echo ${shellQuote(tool.value)};;').join('\n')}
-        *) exit 1;;
-      esac
-      exit 0;;
-    *)
-      tool="\$1"; shift
-      case "\$tool" in
-${tools.entries.map((tool) => '        ${tool.key}) exec ${shellQuote(tool.value)} "\$@";;').join('\n')}
-        codesign) exit 0;;
-        *) echo "xcrun: unknown tool \$tool" >&2; exit 1;;
-      esac;;
-  esac
-done
-exit 1
-''';
-
 String renderPowerShellCompilerShim({
   required String iosSdk,
   required String clang,
@@ -107,38 +78,6 @@ if (!\$hasLdPath) { \$defaults += ${powerShellQuote('--ld-path=$linker')} }
 & ${powerShellQuote(clang)} @(\$defaults + \$Arguments)
 exit \$LASTEXITCODE
 ''';
-
-String renderPowerShellXcrunShim({
-  required String iosSdk,
-  required Map<String, String> tools,
-}) {
-  final toolMap = tools.entries
-      .map((tool) => '${tool.key} = ${powerShellQuote(tool.value)}')
-      .join('; ');
-  return '''
-param([Parameter(ValueFromRemainingArguments = \$true)][string[]]\$Arguments)
-\$tools = @{ $toolMap }
-for (\$i = 0; \$i -lt \$Arguments.Count; \$i++) {
-  switch (\$Arguments[\$i]) {
-    '--sdk' { \$i++; continue }
-    '--show-sdk-path' { Write-Output ${powerShellQuote(iosSdk)}; exit 0 }
-    '--find' {
-      if (++\$i -ge \$Arguments.Count -or !\$tools[\$Arguments[\$i]]) { exit 1 }
-      Write-Output \$tools[\$Arguments[\$i]]; exit 0
-    }
-    default {
-      if (\$Arguments[\$i] -eq 'codesign') { exit 0 }
-      \$tool = \$tools[\$Arguments[\$i]]
-      if (!\$tool) { Write-Error "xcrun: unknown tool \$(\$Arguments[\$i])"; exit 1 }
-      \$tail = if (\$i + 1 -lt \$Arguments.Count) { \$Arguments[(\$i + 1)..(\$Arguments.Count - 1)] } else { @() }
-      & \$tool @tail
-      exit \$LASTEXITCODE
-    }
-  }
-}
-exit 1
-''';
-}
 
 String renderUnixOtoolShim({required String tool, required bool usesObjdump}) =>
     usesObjdump

--- a/packages/xcross/lib/src/flutter/build/internal/apple_tool_shim_templates.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/apple_tool_shim_templates.dart
@@ -84,7 +84,7 @@ String renderPowerShellCompilerShim({
   required String deploymentTarget,
 }) =>
     '''
-param([Parameter(ValueFromRemainingArguments = \$true)][string[]]\$Arguments)
+\$Arguments = \$args
 \$isAppleTarget = \$false; \$hasTarget = \$false; \$hasSysroot = \$false; \$hasDeployment = \$false
 \$hasFuseLd = \$false; \$hasLdPath = \$false
 for (\$i = 0; \$i -lt \$Arguments.Count; \$i++) {
@@ -159,10 +159,10 @@ String renderPowerShellOtoolShim({
   required bool usesObjdump,
 }) => usesObjdump
     ? '''
-param([Parameter(ValueFromRemainingArguments = \$true)][string[]]\$Arguments)
-if (\$Arguments.Count -eq 0) { Write-Error 'otool: missing option'; exit 64 }
-\$option = \$Arguments[0]
-\$tail = if (\$Arguments.Count -gt 1) { \$Arguments[1..(\$Arguments.Count - 1)] } else { @() }
+\$ToolArguments = \$args
+if (\$ToolArguments.Count -eq 0) { Write-Error 'otool: missing option'; exit 64 }
+\$option = \$ToolArguments[0]
+\$tail = if (\$ToolArguments.Count -gt 1) { \$ToolArguments[1..(\$ToolArguments.Count - 1)] } else { @() }
 \$translated = switch (\$option) {
   '-L' { @('--macho', '--dylibs-used') }
   '-D' { @('--macho', '--dylib-id') }

--- a/packages/xcross/lib/src/flutter/build/internal/apple_tool_shim_templates.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/apple_tool_shim_templates.dart
@@ -75,6 +75,7 @@ if (!\$hasSysroot) { \$defaults += @('-isysroot', ${powerShellQuote(iosSdk)}) }
 if (!\$hasDeployment) { \$defaults += '-miphoneos-version-min=$deploymentTarget' }
 if (!\$hasFuseLd) { \$defaults += '-fuse-ld=lld' }
 if (!\$hasLdPath) { \$defaults += ${powerShellQuote('--ld-path=$linker')} }
+\$defaults += @('-Wl,-arch,arm64', '-Wl,-platform_version,ios,$deploymentTarget,26.5')
 & ${powerShellQuote(clang)} @(\$defaults + \$Arguments)
 exit \$LASTEXITCODE
 ''';

--- a/packages/xcross/lib/src/flutter/build/internal/apple_tool_shim_templates.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/apple_tool_shim_templates.dart
@@ -75,7 +75,7 @@ if (!\$hasSysroot) { \$defaults += @('-isysroot', ${powerShellQuote(iosSdk)}) }
 if (!\$hasDeployment) { \$defaults += '-miphoneos-version-min=$deploymentTarget' }
 if (!\$hasFuseLd) { \$defaults += '-fuse-ld=lld' }
 if (!\$hasLdPath) { \$defaults += ${powerShellQuote('--ld-path=$linker')} }
-\$defaults += @('-Wl,-arch,arm64', '-Wl,-platform_version,ios,$deploymentTarget,26.5')
+\$defaults += @('-Xlinker', '-arch', '-Xlinker', 'arm64', '-Xlinker', '-platform_version', '-Xlinker', 'ios', '-Xlinker', '$deploymentTarget', '-Xlinker', '26.5')
 & ${powerShellQuote(clang)} @(\$defaults + \$Arguments)
 exit \$LASTEXITCODE
 ''';

--- a/packages/xcross/lib/src/flutter/build/internal/apple_tool_shim_templates.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/apple_tool_shim_templates.dart
@@ -75,7 +75,7 @@ if (!\$hasSysroot) { \$defaults += @('-isysroot', ${powerShellQuote(iosSdk)}) }
 if (!\$hasDeployment) { \$defaults += '-miphoneos-version-min=$deploymentTarget' }
 if (!\$hasFuseLd) { \$defaults += '-fuse-ld=lld' }
 if (!\$hasLdPath) { \$defaults += ${powerShellQuote('--ld-path=$linker')} }
-\$defaults += @('-Xlinker', '-arch', '-Xlinker', 'arm64', '-Xlinker', '-platform_version', '-Xlinker', 'ios', '-Xlinker', '$deploymentTarget', '-Xlinker', '26.5')
+\$defaults += @('-Wl,-arch,arm64', '-Wl,-platform_version,ios,$deploymentTarget,26.5')
 \$compiler = ${powerShellQuote(clang)}
 \$compilerArguments = @(\$defaults + \$Arguments)
 & \$compiler @compilerArguments

--- a/packages/xcross/lib/src/flutter/build/internal/apple_tool_shims.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/apple_tool_shims.dart
@@ -77,6 +77,16 @@ Future<String> resolveXcrun() async {
 Future<String> resolveHostCompiler(String clang, {bool? windows}) async =>
     (windows ?? Platform.isWindows) ? clang : ProcessRunner.locateTool('cc');
 
+Future<String?> resolveNativeAssetToolForwarder(
+  String executable, {
+  bool? windows,
+  Future<String?> Function()? findInstalled,
+}) async {
+  if (!(windows ?? Platform.isWindows)) return executable;
+  if (p.basename(executable).toLowerCase() == 'xcross.exe') return executable;
+  return (findInstalled ?? () => ProcessRunner.which('xcross.exe'))();
+}
+
 Future<String> _locateArchiver(String clang) async {
   final besideClang = p.join(
     p.dirname(clang),

--- a/packages/xcross/lib/src/flutter/build/internal/apple_tool_shims.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/apple_tool_shims.dart
@@ -95,8 +95,9 @@ Future<String> locateLlvmTool(String name) async {
 /// Installs the Apple command-line surface needed by Flutter build hooks.
 Future<void> installAppleToolShims(
   String directory,
-  AppleToolShimConfig config,
-) async {
+  AppleToolShimConfig config, {
+  String? launcherExecutable,
+}) async {
   await Directory(directory).create(recursive: true);
   final compilerShim = p.join(
     directory,
@@ -116,6 +117,85 @@ Future<void> installAppleToolShims(
   };
 
   if (Platform.isWindows) {
+    if (launcherExecutable != null) {
+      final source = p.join(directory, 'xcrun.dart');
+      await File(source).writeAsString(r'''
+import 'dart:io';
+
+Future<void> main(List<String> arguments) async {
+  final executable = Platform.resolvedExecutable;
+  final directory = File(executable).parent.path;
+  final name = executable.split(Platform.pathSeparator).last.split('.').first;
+  if (name != 'xcrun') {
+    final target = File('$directory\\$name.path').readAsStringSync();
+    final process = await Process.start(
+      target,
+      arguments,
+      mode: ProcessStartMode.inheritStdio,
+    );
+    exitCode = await process.exitCode;
+    return;
+  }
+  if (arguments.contains('--show-sdk-path')) {
+    stdout.writeln(File('$executable.sdk').readAsStringSync());
+    return;
+  }
+  final toolIndex = arguments.indexWhere(
+    (argument) => !argument.startsWith('-') && File('$directory\\$argument.bat').existsSync(),
+  );
+  if (toolIndex >= 0) {
+    final process = await Process.start(
+      '$directory\\${arguments[toolIndex]}.bat',
+      arguments.sublist(toolIndex + 1),
+      mode: ProcessStartMode.inheritStdio,
+      runInShell: true,
+    );
+    exitCode = await process.exitCode;
+    return;
+  }
+  final find = arguments.indexOf('--find');
+  if (find >= 0 && find + 1 < arguments.length) {
+    final tool = arguments[find + 1];
+    final shim = '$directory\\$tool.bat';
+    if (File(shim).existsSync()) {
+      stdout.writeln(shim);
+      return;
+    }
+    final mapping = File('$directory\\$tool.path');
+    if (mapping.existsSync()) {
+      stdout.writeln(mapping.readAsStringSync());
+      return;
+    }
+
+  }
+  stderr.writeln('error: unsupported xcrun invocation: ${arguments.join(' ')}');
+  exitCode = 1;
+}
+''');
+      await ProcessRunner.runChecked(launcherExecutable, [
+        'compile',
+        'exe',
+        source,
+        '-o',
+        p.join(directory, 'xcrun.exe'),
+      ], label: 'xcrun shim');
+      await File(
+        p.join(directory, 'xcrun.exe.sdk'),
+      ).writeAsString(config.iosSdk);
+      for (final entry in {
+        'ar': config.archiver,
+        'ld': config.linker,
+        'cc': compilerShim,
+      }.entries) {
+        await File(
+          p.join(directory, '${entry.key}.path'),
+        ).writeAsString(entry.value);
+        await File(
+          p.join(directory, 'xcrun.exe'),
+        ).copy(p.join(directory, '${entry.key}.exe'));
+      }
+    }
+
     if (config.otool case final otool?) {
       await File(p.join(directory, 'otool.ps1')).writeAsString(
         renderPowerShellOtoolShim(
@@ -143,19 +223,33 @@ Future<void> installAppleToolShims(
       'clang',
       renderBatchPowerShellShim('clang.ps1'),
     );
-    await _writeWindowsShim(
-      directory,
-      'cc',
-      renderBatchPowerShellShim('clang.ps1'),
-    );
-    await File(p.join(directory, 'xcrun.ps1')).writeAsString(
-      renderPowerShellXcrunShim(iosSdk: config.iosSdk, tools: tools),
-    );
-    await _writeWindowsShim(
-      directory,
-      'xcrun',
-      renderBatchPowerShellShim('xcrun.ps1'),
-    );
+    if (launcherExecutable == null) {
+      await _writeWindowsShim(
+        directory,
+        'cc',
+        renderBatchPowerShellShim('clang.ps1'),
+      );
+      await _writeWindowsShim(
+        directory,
+        'ar',
+        renderBatchToolShim(config.archiver),
+      );
+      await _writeWindowsShim(
+        directory,
+        'ld',
+        renderBatchToolShim(config.linker),
+      );
+    }
+    if (launcherExecutable == null) {
+      await File(p.join(directory, 'xcrun.ps1')).writeAsString(
+        renderPowerShellXcrunShim(iosSdk: config.iosSdk, tools: tools),
+      );
+      await _writeWindowsShim(
+        directory,
+        'xcrun',
+        renderBatchPowerShellShim('xcrun.ps1'),
+      );
+    }
     for (final tool in tools.entries.skip(3)) {
       if (tool.key != 'otool') {
         await _writeWindowsShim(
@@ -165,7 +259,27 @@ Future<void> installAppleToolShims(
         );
       }
     }
+    if (config.installNameTool == null) {
+      await _writeWindowsShim(
+        directory,
+        'install_name_tool',
+        batchCodesignShim,
+      );
+    }
     await _writeWindowsShim(directory, 'codesign', batchCodesignShim);
+    await File(p.join(directory, 'rsync.ps1')).writeAsString(r'''
+$items = @($args | Where-Object { -not $_.StartsWith('-') -and $_ -ne '.DS_Store/' })
+if ($items.Count -lt 2) { exit 1 }
+$source = $items[$items.Count - 2]
+$destination = $items[$items.Count - 1]
+Copy-Item -LiteralPath $source -Destination $destination -Recurse -Force
+exit 0
+''');
+    await _writeWindowsShim(
+      directory,
+      'rsync',
+      renderBatchPowerShellShim('rsync.ps1'),
+    );
     return;
   }
 

--- a/packages/xcross/lib/src/flutter/build/internal/apple_tool_shims.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/apple_tool_shims.dart
@@ -179,6 +179,9 @@ Future<void> main(List<String> arguments) async {
         '-o',
         p.join(directory, 'xcrun.exe'),
       ], label: 'xcrun shim');
+      if (!File(p.join(directory, 'xcrun.exe')).existsSync()) {
+        throw FlutterBuildError('Failed to create the xcrun executable shim.');
+      }
       await File(
         p.join(directory, 'xcrun.exe.sdk'),
       ).writeAsString(config.iosSdk);

--- a/packages/xcross/lib/src/flutter/build/internal/apple_tool_shims.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/apple_tool_shims.dart
@@ -96,7 +96,7 @@ Future<String> locateLlvmTool(String name) async {
 Future<void> installAppleToolShims(
   String directory,
   AppleToolShimConfig config, {
-  String? launcherExecutable,
+  String? toolForwarderExecutable,
 }) async {
   await Directory(directory).create(recursive: true);
   final compilerShim = p.join(
@@ -117,39 +117,14 @@ Future<void> installAppleToolShims(
   };
 
   if (Platform.isWindows) {
-    if (launcherExecutable != null) {
-      final source = p.join(directory, 'tool_launcher.dart');
-      await File(source).writeAsString(r'''
-import 'dart:io';
-
-Future<void> main(List<String> arguments) async {
-  final executable = Platform.resolvedExecutable;
-  final mapping = File('$executable.path');
-  final target = mapping.readAsStringSync();
-  final process = await Process.start(
-    target,
-    arguments,
-    mode: ProcessStartMode.inheritStdio,
-    runInShell: target.endsWith('.bat'),
-  );
-  exitCode = await process.exitCode;
-}
-''');
-      final launcher = p.join(directory, 'tool_launcher.exe');
-      await ProcessRunner.runChecked(launcherExecutable, [
-        'compile',
-        'exe',
-        source,
-        '-o',
-        launcher,
-      ], label: 'Apple tool launcher');
+    if (toolForwarderExecutable != null) {
       for (final entry in {
         'cc': compilerShim,
         'ar': config.archiver,
         'ld': config.linker,
       }.entries) {
         final executable = p.join(directory, '${entry.key}.exe');
-        await File(launcher).copy(executable);
+        await File(toolForwarderExecutable).copy(executable);
         await File('$executable.path').writeAsString(entry.value);
       }
     }
@@ -181,7 +156,7 @@ Future<void> main(List<String> arguments) async {
       'clang',
       renderBatchPowerShellShim('clang.ps1'),
     );
-    if (launcherExecutable == null) {
+    if (toolForwarderExecutable == null) {
       await _writeWindowsShim(
         directory,
         'cc',

--- a/packages/xcross/lib/src/flutter/build/internal/apple_tool_shims.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/apple_tool_shims.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:cli_kit/cli_kit.dart';
@@ -163,13 +164,26 @@ Future<void> _installWindowsToolShims(
 }) async {
   if (toolForwarderExecutable != null) {
     for (final entry in {
-      'cc': compilerShim,
+      'cc': config.clang,
       'ar': config.archiver,
       'ld': config.linker,
     }.entries) {
       final executable = p.join(directory, '${entry.key}.exe');
       await File(toolForwarderExecutable).copy(executable);
       await File('$executable.path').writeAsString(entry.value);
+      if (entry.key == 'cc') {
+        await File('$executable.args').writeAsString(
+          jsonEncode([
+            '-isysroot',
+            config.iosSdk,
+            '-miphoneos-version-min=${config.deploymentTarget}',
+            '-fuse-ld=lld',
+            '--ld-path=${config.linker}',
+            '-Wl,-arch,arm64',
+            '-Wl,-platform_version,ios,${config.deploymentTarget},26.5',
+          ]),
+        );
+      }
     }
     await File(config.xcrun).copy(p.join(directory, 'xcrun.exe'));
     await File(toolForwarderExecutable).copy(p.join(directory, 'plutil.exe'));

--- a/packages/xcross/lib/src/flutter/build/internal/apple_tool_shims.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/apple_tool_shims.dart
@@ -28,7 +28,6 @@ final class AppleToolShimConfig {
     required this.installNameTool,
     required this.xcrun,
     required this.deploymentTarget,
-
   });
 
   final String iosSdk;
@@ -41,7 +40,6 @@ final class AppleToolShimConfig {
   final String? installNameTool;
   final String xcrun;
   final String deploymentTarget;
-
 
   static Future<AppleToolShimConfig> resolve(String deploymentTarget) async {
     final sdk = DarwinSdk.current();
@@ -63,7 +61,6 @@ final class AppleToolShimConfig {
       installNameTool: await findLlvmTool('llvm-install-name-tool'),
       xcrun: await resolveXcrun(),
       deploymentTarget: deploymentTarget,
-
     );
   }
 }
@@ -78,7 +75,6 @@ Future<String> resolveXcrun() async {
 }
 
 Future<String> resolveHostCompiler(String clang, {bool? windows}) async =>
-
     (windows ?? Platform.isWindows) ? clang : ProcessRunner.locateTool('cc');
 
 Future<String> _locateArchiver(String clang) async {
@@ -144,7 +140,8 @@ Future<void> installAppleToolShims(
         await File('$executable.path').writeAsString(entry.value);
       }
       await File(config.xcrun).copy(p.join(directory, 'xcrun.exe'));
-
+      final plutil = p.join(directory, 'plutil.exe');
+      await File(toolForwarderExecutable).copy(plutil);
     }
 
     if (config.otool case final otool?) {
@@ -245,7 +242,13 @@ exit 0
   await _writeUnixShim(directory, 'clang', compilerScript);
   await _writeUnixShim(directory, 'cc', compilerScript);
   await _writeUnixShim(directory, 'xcrun', renderUnixToolShim(config.xcrun));
-
+  if (toolForwarderExecutable != null) {
+    await _writeUnixShim(
+      directory,
+      'plutil',
+      renderUnixToolShim(toolForwarderExecutable),
+    );
+  }
 
   for (final tool in tools.entries.skip(3)) {
     if (tool.key != 'otool') {

--- a/packages/xcross/lib/src/flutter/build/internal/apple_tool_shims.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/apple_tool_shims.dart
@@ -119,94 +119,111 @@ Future<void> installAppleToolShims(
     directory,
     Platform.isWindows ? 'otool.bat' : 'otool',
   );
-  final tools = <String, String>{
-    'clang': compilerShim,
-    'ar': config.archiver,
-    'ld': config.linker,
+  final auxiliaryTools = <String, String>{
     'lipo': config.lipo,
     if (config.otool != null) 'otool': otoolShim,
     if (config.installNameTool case final tool?) 'install_name_tool': tool,
   };
 
   if (Platform.isWindows) {
-    if (toolForwarderExecutable != null) {
-      for (final entry in {
-        'cc': compilerShim,
-        'ar': config.archiver,
-        'ld': config.linker,
-      }.entries) {
-        final executable = p.join(directory, '${entry.key}.exe');
-        await File(toolForwarderExecutable).copy(executable);
-        await File('$executable.path').writeAsString(entry.value);
-      }
-      await File(config.xcrun).copy(p.join(directory, 'xcrun.exe'));
-      final plutil = p.join(directory, 'plutil.exe');
-      await File(toolForwarderExecutable).copy(plutil);
-    }
+    await _installWindowsToolShims(
+      directory,
+      config,
+      compilerShim: compilerShim,
+      auxiliaryTools: auxiliaryTools,
+      toolForwarderExecutable: toolForwarderExecutable,
+    );
+    return;
+  }
 
-    if (config.otool case final otool?) {
-      await File(p.join(directory, 'otool.ps1')).writeAsString(
-        renderPowerShellOtoolShim(
-          tool: otool.executable,
-          usesObjdump: otool.usesObjdump,
-        ),
-      );
-      await _writeWindowsShim(
-        directory,
-        'otool',
-        renderBatchPowerShellShim('otool.ps1'),
-      );
+  await _installUnixToolShims(
+    directory,
+    config,
+    auxiliaryTools: auxiliaryTools,
+    toolForwarderExecutable: toolForwarderExecutable,
+  );
+}
+
+Future<void> _installWindowsToolShims(
+  String directory,
+  AppleToolShimConfig config, {
+  required String compilerShim,
+  required Map<String, String> auxiliaryTools,
+  required String? toolForwarderExecutable,
+}) async {
+  if (toolForwarderExecutable != null) {
+    for (final entry in {
+      'cc': compilerShim,
+      'ar': config.archiver,
+      'ld': config.linker,
+    }.entries) {
+      final executable = p.join(directory, '${entry.key}.exe');
+      await File(toolForwarderExecutable).copy(executable);
+      await File('$executable.path').writeAsString(entry.value);
     }
-    await File(p.join(directory, 'clang.ps1')).writeAsString(
-      renderPowerShellCompilerShim(
-        iosSdk: config.iosSdk,
-        clang: config.clang,
-        hostCompiler: config.hostCompiler,
-        linker: config.linker,
-        deploymentTarget: config.deploymentTarget,
+    await File(config.xcrun).copy(p.join(directory, 'xcrun.exe'));
+    await File(toolForwarderExecutable).copy(p.join(directory, 'plutil.exe'));
+  }
+
+  if (config.otool case final otool?) {
+    await File(p.join(directory, 'otool.ps1')).writeAsString(
+      renderPowerShellOtoolShim(
+        tool: otool.executable,
+        usesObjdump: otool.usesObjdump,
       ),
     );
     await _writeWindowsShim(
       directory,
-      'clang',
+      'otool',
+      renderBatchPowerShellShim('otool.ps1'),
+    );
+  }
+  await File(p.join(directory, 'clang.ps1')).writeAsString(
+    renderPowerShellCompilerShim(
+      iosSdk: config.iosSdk,
+      clang: config.clang,
+      hostCompiler: config.hostCompiler,
+      linker: config.linker,
+      deploymentTarget: config.deploymentTarget,
+    ),
+  );
+  await _writeWindowsShim(
+    directory,
+    'clang',
+    renderBatchPowerShellShim('clang.ps1'),
+  );
+  if (toolForwarderExecutable == null) {
+    await _writeWindowsShim(
+      directory,
+      'cc',
       renderBatchPowerShellShim('clang.ps1'),
     );
-    if (toolForwarderExecutable == null) {
-      await _writeWindowsShim(
-        directory,
-        'cc',
-        renderBatchPowerShellShim('clang.ps1'),
-      );
-      await _writeWindowsShim(
-        directory,
-        'ar',
-        renderBatchToolShim(config.archiver),
-      );
-      await _writeWindowsShim(
-        directory,
-        'ld',
-        renderBatchToolShim(config.linker),
-      );
-    }
+    await _writeWindowsShim(
+      directory,
+      'ar',
+      renderBatchToolShim(config.archiver),
+    );
+    await _writeWindowsShim(
+      directory,
+      'ld',
+      renderBatchToolShim(config.linker),
+    );
+  }
 
-    for (final tool in tools.entries.skip(3)) {
-      if (tool.key != 'otool') {
-        await _writeWindowsShim(
-          directory,
-          tool.key,
-          renderBatchToolShim(tool.value),
-        );
-      }
-    }
-    if (config.installNameTool == null) {
+  for (final tool in auxiliaryTools.entries) {
+    if (tool.key != 'otool') {
       await _writeWindowsShim(
         directory,
-        'install_name_tool',
-        batchCodesignShim,
+        tool.key,
+        renderBatchToolShim(tool.value),
       );
     }
-    await _writeWindowsShim(directory, 'codesign', batchCodesignShim);
-    await File(p.join(directory, 'rsync.ps1')).writeAsString(r'''
+  }
+  if (config.installNameTool == null) {
+    await _writeWindowsShim(directory, 'install_name_tool', batchCodesignShim);
+  }
+  await _writeWindowsShim(directory, 'codesign', batchCodesignShim);
+  await File(p.join(directory, 'rsync.ps1')).writeAsString(r'''
 $items = @($args | Where-Object { -not $_.StartsWith('-') -and $_ -ne '.DS_Store/' })
 if ($items.Count -lt 2) { exit 1 }
 $source = $items[$items.Count - 2]
@@ -214,14 +231,19 @@ $destination = $items[$items.Count - 1]
 Copy-Item -LiteralPath $source -Destination $destination -Recurse -Force
 exit 0
 ''');
-    await _writeWindowsShim(
-      directory,
-      'rsync',
-      renderBatchPowerShellShim('rsync.ps1'),
-    );
-    return;
-  }
+  await _writeWindowsShim(
+    directory,
+    'rsync',
+    renderBatchPowerShellShim('rsync.ps1'),
+  );
+}
 
+Future<void> _installUnixToolShims(
+  String directory,
+  AppleToolShimConfig config, {
+  required Map<String, String> auxiliaryTools,
+  required String? toolForwarderExecutable,
+}) async {
   if (config.otool case final otool?) {
     await _writeUnixShim(
       directory,
@@ -250,7 +272,7 @@ exit 0
     );
   }
 
-  for (final tool in tools.entries.skip(3)) {
+  for (final tool in auxiliaryTools.entries) {
     if (tool.key != 'otool') {
       await _writeUnixShim(directory, tool.key, renderUnixToolShim(tool.value));
     }

--- a/packages/xcross/lib/src/flutter/build/internal/apple_tool_shims.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/apple_tool_shims.dart
@@ -26,7 +26,9 @@ final class AppleToolShimConfig {
     required this.lipo,
     required this.otool,
     required this.installNameTool,
+    required this.xcrun,
     required this.deploymentTarget,
+
   });
 
   final String iosSdk;
@@ -37,7 +39,9 @@ final class AppleToolShimConfig {
   final String lipo;
   final OtoolConfig? otool;
   final String? installNameTool;
+  final String xcrun;
   final String deploymentTarget;
+
 
   static Future<AppleToolShimConfig> resolve(String deploymentTarget) async {
     final sdk = DarwinSdk.current();
@@ -57,12 +61,24 @@ final class AppleToolShimConfig {
       lipo: await locateLlvmTool('llvm-lipo'),
       otool: await resolveOtool(),
       installNameTool: await findLlvmTool('llvm-install-name-tool'),
+      xcrun: await resolveXcrun(),
       deploymentTarget: deploymentTarget,
+
     );
   }
 }
 
+Future<String> resolveXcrun() async {
+  final sibling = p.join(
+    p.dirname(Platform.resolvedExecutable),
+    ProcessRunner.hostExecutableName('xcrun'),
+  );
+  if (File(sibling).existsSync()) return sibling;
+  return ProcessRunner.locateTool('xcrun');
+}
+
 Future<String> resolveHostCompiler(String clang, {bool? windows}) async =>
+
     (windows ?? Platform.isWindows) ? clang : ProcessRunner.locateTool('cc');
 
 Future<String> _locateArchiver(String clang) async {
@@ -127,6 +143,8 @@ Future<void> installAppleToolShims(
         await File(toolForwarderExecutable).copy(executable);
         await File('$executable.path').writeAsString(entry.value);
       }
+      await File(config.xcrun).copy(p.join(directory, 'xcrun.exe'));
+
     }
 
     if (config.otool case final otool?) {
@@ -226,6 +244,8 @@ exit 0
   );
   await _writeUnixShim(directory, 'clang', compilerScript);
   await _writeUnixShim(directory, 'cc', compilerScript);
+  await _writeUnixShim(directory, 'xcrun', renderUnixToolShim(config.xcrun));
+
 
   for (final tool in tools.entries.skip(3)) {
     if (tool.key != 'otool') {

--- a/packages/xcross/lib/src/flutter/build/internal/apple_tool_shims.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/apple_tool_shims.dart
@@ -95,8 +95,9 @@ Future<String> locateLlvmTool(String name) async {
 /// Installs the Apple command-line surface needed by Flutter build hooks.
 Future<void> installAppleToolShims(
   String directory,
-  AppleToolShimConfig config,
-) async {
+  AppleToolShimConfig config, {
+  String? launcherExecutable,
+}) async {
   await Directory(directory).create(recursive: true);
   final compilerShim = p.join(
     directory,
@@ -116,6 +117,43 @@ Future<void> installAppleToolShims(
   };
 
   if (Platform.isWindows) {
+    if (launcherExecutable != null) {
+      final source = p.join(directory, 'tool_launcher.dart');
+      await File(source).writeAsString(r'''
+import 'dart:io';
+
+Future<void> main(List<String> arguments) async {
+  final executable = Platform.resolvedExecutable;
+  final mapping = File('$executable.path');
+  final target = mapping.readAsStringSync();
+  final process = await Process.start(
+    target,
+    arguments,
+    mode: ProcessStartMode.inheritStdio,
+    runInShell: target.endsWith('.bat'),
+  );
+  exitCode = await process.exitCode;
+}
+''');
+      final launcher = p.join(directory, 'tool_launcher.exe');
+      await ProcessRunner.runChecked(launcherExecutable, [
+        'compile',
+        'exe',
+        source,
+        '-o',
+        launcher,
+      ], label: 'Apple tool launcher');
+      for (final entry in {
+        'cc': compilerShim,
+        'ar': config.archiver,
+        'ld': config.linker,
+      }.entries) {
+        final executable = p.join(directory, '${entry.key}.exe');
+        await File(launcher).copy(executable);
+        await File('$executable.path').writeAsString(entry.value);
+      }
+    }
+
     if (config.otool case final otool?) {
       await File(p.join(directory, 'otool.ps1')).writeAsString(
         renderPowerShellOtoolShim(
@@ -143,21 +181,23 @@ Future<void> installAppleToolShims(
       'clang',
       renderBatchPowerShellShim('clang.ps1'),
     );
-    await _writeWindowsShim(
-      directory,
-      'cc',
-      renderBatchPowerShellShim('clang.ps1'),
-    );
-    await _writeWindowsShim(
-      directory,
-      'ar',
-      renderBatchToolShim(config.archiver),
-    );
-    await _writeWindowsShim(
-      directory,
-      'ld',
-      renderBatchToolShim(config.linker),
-    );
+    if (launcherExecutable == null) {
+      await _writeWindowsShim(
+        directory,
+        'cc',
+        renderBatchPowerShellShim('clang.ps1'),
+      );
+      await _writeWindowsShim(
+        directory,
+        'ar',
+        renderBatchToolShim(config.archiver),
+      );
+      await _writeWindowsShim(
+        directory,
+        'ld',
+        renderBatchToolShim(config.linker),
+      );
+    }
 
     for (final tool in tools.entries.skip(3)) {
       if (tool.key != 'otool') {

--- a/packages/xcross/lib/src/flutter/build/internal/apple_tool_shims.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/apple_tool_shims.dart
@@ -95,9 +95,8 @@ Future<String> locateLlvmTool(String name) async {
 /// Installs the Apple command-line surface needed by Flutter build hooks.
 Future<void> installAppleToolShims(
   String directory,
-  AppleToolShimConfig config, {
-  String? launcherExecutable,
-}) async {
+  AppleToolShimConfig config,
+) async {
   await Directory(directory).create(recursive: true);
   final compilerShim = p.join(
     directory,
@@ -117,88 +116,6 @@ Future<void> installAppleToolShims(
   };
 
   if (Platform.isWindows) {
-    if (launcherExecutable != null) {
-      final source = p.join(directory, 'xcrun.dart');
-      await File(source).writeAsString(r'''
-import 'dart:io';
-
-Future<void> main(List<String> arguments) async {
-  final executable = Platform.resolvedExecutable;
-  final directory = File(executable).parent.path;
-  final name = executable.split(Platform.pathSeparator).last.split('.').first;
-  if (name != 'xcrun') {
-    final target = File('$directory\\$name.path').readAsStringSync();
-    final process = await Process.start(
-      target,
-      arguments,
-      mode: ProcessStartMode.inheritStdio,
-    );
-    exitCode = await process.exitCode;
-    return;
-  }
-  if (arguments.contains('--show-sdk-path')) {
-    stdout.writeln(File('$executable.sdk').readAsStringSync());
-    return;
-  }
-  final toolIndex = arguments.indexWhere(
-    (argument) => !argument.startsWith('-') && File('$directory\\$argument.bat').existsSync(),
-  );
-  if (toolIndex >= 0) {
-    final process = await Process.start(
-      '$directory\\${arguments[toolIndex]}.bat',
-      arguments.sublist(toolIndex + 1),
-      mode: ProcessStartMode.inheritStdio,
-      runInShell: true,
-    );
-    exitCode = await process.exitCode;
-    return;
-  }
-  final find = arguments.indexOf('--find');
-  if (find >= 0 && find + 1 < arguments.length) {
-    final tool = arguments[find + 1];
-    final shim = '$directory\\$tool.bat';
-    if (File(shim).existsSync()) {
-      stdout.writeln(shim);
-      return;
-    }
-    final mapping = File('$directory\\$tool.path');
-    if (mapping.existsSync()) {
-      stdout.writeln(mapping.readAsStringSync());
-      return;
-    }
-
-  }
-  stderr.writeln('error: unsupported xcrun invocation: ${arguments.join(' ')}');
-  exitCode = 1;
-}
-''');
-      await ProcessRunner.runChecked(launcherExecutable, [
-        'compile',
-        'exe',
-        source,
-        '-o',
-        p.join(directory, 'xcrun.exe'),
-      ], label: 'xcrun shim');
-      if (!File(p.join(directory, 'xcrun.exe')).existsSync()) {
-        throw FlutterBuildError('Failed to create the xcrun executable shim.');
-      }
-      await File(
-        p.join(directory, 'xcrun.exe.sdk'),
-      ).writeAsString(config.iosSdk);
-      for (final entry in {
-        'ar': config.archiver,
-        'ld': config.linker,
-        'cc': compilerShim,
-      }.entries) {
-        await File(
-          p.join(directory, '${entry.key}.path'),
-        ).writeAsString(entry.value);
-        await File(
-          p.join(directory, 'xcrun.exe'),
-        ).copy(p.join(directory, '${entry.key}.exe'));
-      }
-    }
-
     if (config.otool case final otool?) {
       await File(p.join(directory, 'otool.ps1')).writeAsString(
         renderPowerShellOtoolShim(
@@ -226,33 +143,22 @@ Future<void> main(List<String> arguments) async {
       'clang',
       renderBatchPowerShellShim('clang.ps1'),
     );
-    if (launcherExecutable == null) {
-      await _writeWindowsShim(
-        directory,
-        'cc',
-        renderBatchPowerShellShim('clang.ps1'),
-      );
-      await _writeWindowsShim(
-        directory,
-        'ar',
-        renderBatchToolShim(config.archiver),
-      );
-      await _writeWindowsShim(
-        directory,
-        'ld',
-        renderBatchToolShim(config.linker),
-      );
-    }
-    if (launcherExecutable == null) {
-      await File(p.join(directory, 'xcrun.ps1')).writeAsString(
-        renderPowerShellXcrunShim(iosSdk: config.iosSdk, tools: tools),
-      );
-      await _writeWindowsShim(
-        directory,
-        'xcrun',
-        renderBatchPowerShellShim('xcrun.ps1'),
-      );
-    }
+    await _writeWindowsShim(
+      directory,
+      'cc',
+      renderBatchPowerShellShim('clang.ps1'),
+    );
+    await _writeWindowsShim(
+      directory,
+      'ar',
+      renderBatchToolShim(config.archiver),
+    );
+    await _writeWindowsShim(
+      directory,
+      'ld',
+      renderBatchToolShim(config.linker),
+    );
+
     for (final tool in tools.entries.skip(3)) {
       if (tool.key != 'otool') {
         await _writeWindowsShim(
@@ -305,11 +211,7 @@ exit 0
   );
   await _writeUnixShim(directory, 'clang', compilerScript);
   await _writeUnixShim(directory, 'cc', compilerScript);
-  await _writeUnixShim(
-    directory,
-    'xcrun',
-    renderUnixXcrunShim(iosSdk: config.iosSdk, tools: tools),
-  );
+
   for (final tool in tools.entries.skip(3)) {
     if (tool.key != 'otool') {
       await _writeUnixShim(directory, tool.key, renderUnixToolShim(tool.value));

--- a/packages/xcross/lib/src/flutter/build/internal/swiftpm_binary_fixture.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/swiftpm_binary_fixture.dart
@@ -161,10 +161,13 @@ public final class BinaryFixturePlugin: NSObject, FlutterPlugin {
     final binaryTarget = path != null
         ? '.binaryTarget(name: "$targetName", path: "$path")'
         : '.binaryTarget(name: "$targetName", url: "$url", checksum: "$checksum")';
+    File(p.join(root, 'Sources', 'GateProbe', 'GateProbe.swift'))
+      ..createSync(recursive: true)
+      ..writeAsStringSync('public enum GateProbe {}\n');
     File(p.join(root, 'Package.swift')).writeAsStringSync('''
 // swift-tools-version: 6.0
 import PackageDescription
-let package = Package(name: "Gate", products: [.library(name: "Gate", targets: ["$targetName"])], targets: [$binaryTarget])
+let package = Package(name: "Gate", products: [.library(name: "Gate", targets: ["GateProbe"])], targets: [$binaryTarget, .target(name: "GateProbe", dependencies: ["$targetName"])])
 ''');
   }
 

--- a/packages/xcross/lib/src/flutter/build/internal/swiftpm_binary_fixture.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/swiftpm_binary_fixture.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -173,7 +174,27 @@ let package = Package(name: "Gate", products: [.library(name: "Gate", targets: [
 
   static Uint8List _emptyMachO() {
     final bytes = Uint8List(32);
-    ByteData.sublistView(bytes).setUint32(0, 0xfeedfacf, Endian.little);
-    return bytes;
+    final data = ByteData.sublistView(bytes);
+    data
+      ..setUint32(0, 0xfeedfacf, Endian.little)
+      ..setUint32(4, 0x0100000c, Endian.little)
+      ..setUint32(12, 1, Endian.little);
+    final name = utf8.encode('fixture.o/');
+    final header = Uint8List.fromList([
+      ...utf8.encode('!<arch>\n'),
+      ...name,
+      ...List<int>.filled(16 - name.length, 0x20),
+      ...utf8.encode('0'.padRight(12)),
+      ...utf8.encode('0'.padRight(6)),
+      ...utf8.encode('0'.padRight(6)),
+      ...utf8.encode('100644'.padRight(8)),
+      ...utf8.encode('${bytes.length}'.padRight(10)),
+      0x60,
+      0x0a,
+      ...bytes,
+    ]);
+    return header.length.isEven
+        ? header
+        : Uint8List.fromList([...header, 0x0a]);
   }
 }

--- a/packages/xcross/lib/src/flutter/build/internal/swiftpm_binary_fixture.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/swiftpm_binary_fixture.dart
@@ -179,22 +179,30 @@ let package = Package(name: "Gate", products: [.library(name: "Gate", targets: [
       ..setUint32(0, 0xfeedfacf, Endian.little)
       ..setUint32(4, 0x0100000c, Endian.little)
       ..setUint32(12, 1, Endian.little);
-    final name = utf8.encode('fixture.o/');
-    final header = Uint8List.fromList([
+    List<int> member(String name, List<int> content) {
+      final encodedName = utf8.encode('$name\u0000');
+      final size = encodedName.length + content.length;
+      final member = <int>[
+        ...utf8.encode('#1/${encodedName.length}'.padRight(16)),
+        ...utf8.encode('0'.padRight(12)),
+        ...utf8.encode('0'.padRight(6)),
+        ...utf8.encode('0'.padRight(6)),
+        ...utf8.encode('100644'.padRight(8)),
+        ...utf8.encode('$size'.padRight(10)),
+        0x60,
+        0x0a,
+        ...encodedName,
+        ...content,
+      ];
+      if (member.length.isOdd) member.add(0x0a);
+      return member;
+    }
+
+    final index = ByteData(8);
+    return Uint8List.fromList([
       ...utf8.encode('!<arch>\n'),
-      ...name,
-      ...List<int>.filled(16 - name.length, 0x20),
-      ...utf8.encode('0'.padRight(12)),
-      ...utf8.encode('0'.padRight(6)),
-      ...utf8.encode('0'.padRight(6)),
-      ...utf8.encode('100644'.padRight(8)),
-      ...utf8.encode('${bytes.length}'.padRight(10)),
-      0x60,
-      0x0a,
-      ...bytes,
+      ...member('__.SYMDEF', index.buffer.asUint8List()),
+      ...member('fixture.o', bytes),
     ]);
-    return header.length.isEven
-        ? header
-        : Uint8List.fromList([...header, 0x0a]);
   }
 }

--- a/packages/xcross/lib/src/flutter/build/internal/swiftpm_binary_fixture.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/swiftpm_binary_fixture.dart
@@ -1,0 +1,176 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:crypto/crypto.dart';
+import 'package:path/path.dart' as p;
+import 'package:propertylistserialization/propertylistserialization.dart';
+
+final class SwiftPmBinaryFixture {
+  const SwiftPmBinaryFixture({
+    required this.pluginRoot,
+    required this.archive,
+    required this.checksum,
+  });
+
+  final Directory pluginRoot;
+  final File archive;
+  final String checksum;
+
+  factory SwiftPmBinaryFixture.generate({
+    required String root,
+    required Uri archiveUrl,
+  }) {
+    final output = Directory(root)..createSync(recursive: true);
+    final plugin = Directory(p.join(output.path, 'binary_fixture_plugin'))
+      ..createSync(recursive: true);
+    final archive = File(p.join(output.path, 'BinaryFixture.zip'));
+    final entries = <String, List<int>>{
+      'BinaryFixture.xcframework/Info.plist': Uint8List.fromList(
+        PropertyListSerialization.stringWithPropertyList({
+          'AvailableLibraries': [
+            {
+              'LibraryIdentifier': 'ios-arm64',
+              'LibraryPath': 'BinaryFixture.framework',
+              'SupportedArchitectures': ['arm64'],
+              'SupportedPlatform': 'ios',
+            },
+          ],
+          'CFBundlePackageType': 'XFWK',
+          'XCFrameworkFormatVersion': '1.0',
+        }).codeUnits,
+      ),
+      'BinaryFixture.xcframework/ios-arm64/BinaryFixture.framework/BinaryFixture':
+          _emptyMachO(),
+    };
+    final zip = Archive();
+    for (final name in entries.keys.toList()..sort()) {
+      zip.addFile(
+        ArchiveFile(name, entries[name]!.length, entries[name]!)
+          ..lastModTime = 0,
+      );
+    }
+    archive.writeAsBytesSync(ZipEncoder().encode(zip), flush: true);
+    final checksum = sha256.convert(archive.readAsBytesSync()).toString();
+
+    File(p.join(plugin.path, 'pubspec.yaml')).writeAsStringSync('''
+name: binary_fixture_plugin
+description: Generated SwiftPM binary artifact integration fixture.
+version: 0.0.1
+publish_to: none
+environment:
+  sdk: ^3.10.0
+dependencies:
+  flutter:
+    sdk: flutter
+flutter:
+  plugin:
+    platforms:
+      ios:
+        pluginClass: BinaryFixturePlugin
+''');
+    final swiftPackage = Directory(
+      p.join(plugin.path, 'ios', 'binary_fixture_plugin'),
+    )..createSync(recursive: true);
+    File(p.join(swiftPackage.path, 'Package.swift')).writeAsStringSync('''
+// swift-tools-version: 5.9
+import PackageDescription
+let package = Package(
+  name: "binary_fixture_plugin",
+  platforms: [.iOS(.v13)],
+  products: [.library(name: "binary-fixture-plugin", type: .dynamic, targets: ["binary_fixture_plugin"])],
+  targets: [
+    .binaryTarget(name: "BinaryFixture", url: "$archiveUrl", checksum: "$checksum"),
+    .target(name: "binary_fixture_plugin", dependencies: ["BinaryFixture"])
+  ]
+)
+''');
+    final sources = Directory(
+      p.join(swiftPackage.path, 'Sources', 'binary_fixture_plugin'),
+    )..createSync(recursive: true);
+    File(p.join(sources.path, 'BinaryFixturePlugin.swift')).writeAsStringSync(
+      '''
+import Flutter
+import UIKit
+public final class BinaryFixturePlugin: NSObject, FlutterPlugin {
+  public static func register(with registrar: FlutterPluginRegistrar) {}
+}
+''',
+    );
+    return SwiftPmBinaryFixture(
+      pluginRoot: plugin,
+      archive: archive,
+      checksum: checksum,
+    );
+  }
+
+  static Directory generateXcframework({
+    required String root,
+    required String name,
+  }) {
+    final framework = Directory(p.join(root, '$name.xcframework'));
+    File(p.join(framework.path, 'Info.plist'))
+      ..createSync(recursive: true)
+      ..writeAsStringSync(
+        PropertyListSerialization.stringWithPropertyList({
+          'AvailableLibraries': [
+            {
+              'LibraryIdentifier': 'ios-arm64',
+              'LibraryPath': '$name.framework',
+              'SupportedArchitectures': ['arm64'],
+              'SupportedPlatform': 'ios',
+            },
+          ],
+          'CFBundlePackageType': 'XFWK',
+          'XCFrameworkFormatVersion': '1.0',
+        }),
+      );
+    File(p.join(framework.path, 'ios-arm64', '$name.framework', name))
+      ..createSync(recursive: true)
+      ..writeAsBytesSync(_emptyMachO());
+    return framework;
+  }
+
+  static File archiveXcframework({
+    required Directory framework,
+    required String output,
+  }) {
+    final archive = Archive();
+    for (final entity in framework.listSync(recursive: true)) {
+      if (entity is! File) continue;
+      final name = p.relative(entity.path, from: framework.parent.path);
+      archive.addFile(
+        ArchiveFile(name, entity.lengthSync(), entity.readAsBytesSync())
+          ..lastModTime = 0,
+      );
+    }
+    return File(output)
+      ..writeAsBytesSync(ZipEncoder().encode(archive), flush: true);
+  }
+
+  static void writeGatePackage({
+    required String root,
+    required String targetName,
+    String? path,
+    Uri? url,
+    String? checksum,
+  }) {
+    if ((path == null) == (url == null || checksum == null)) {
+      throw ArgumentError('Specify either path or URL and checksum');
+    }
+    final binaryTarget = path != null
+        ? '.binaryTarget(name: "$targetName", path: "$path")'
+        : '.binaryTarget(name: "$targetName", url: "$url", checksum: "$checksum")';
+    File(p.join(root, 'Package.swift')).writeAsStringSync('''
+// swift-tools-version: 6.0
+import PackageDescription
+let package = Package(name: "Gate", products: [.library(name: "Gate", targets: ["$targetName"])], targets: [$binaryTarget])
+''');
+  }
+
+  static Uint8List _emptyMachO() {
+    final bytes = Uint8List(32);
+    ByteData.sublistView(bytes).setUint32(0, 0xfeedfacf, Endian.little);
+    return bytes;
+  }
+}

--- a/packages/xcross/lib/src/flutter/build/internal/swiftpm_gate_evidence.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/swiftpm_gate_evidence.dart
@@ -527,9 +527,16 @@ Future<bool> _runSwift(
     swift,
     arguments,
     environment: environment,
-    timeout: const Duration(seconds: 25),
+    timeout: const Duration(minutes: 2),
   );
-  return result.exitCode == 0;
+  if (result.exitCode != 0) {
+    stderr.writeln(
+      'SwiftPM junction gate command failed (${result.exitCode}): '
+      '${result.stderr}\n${result.stdout}',
+    );
+    return false;
+  }
+  return true;
 }
 
 Future<ProcessResult> _runBounded(

--- a/packages/xcross/lib/src/flutter/build/internal/swiftpm_gate_evidence.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/swiftpm_gate_evidence.dart
@@ -339,7 +339,6 @@ Future<bool> probeSwiftPmGate({
 }) async {
   if (!(windows ?? Platform.isWindows)) return false;
   Directory? probeRoot;
-  HttpServer? server;
   var stage = 'validating toolchain';
   try {
     final identity = jsonDecode(toolchainIdentity);
@@ -386,22 +385,14 @@ Future<bool> probeSwiftPmGate({
       stage = 'creating package-local junction';
       if (!await _createJunction(junction, fixture.path, run)) return false;
     } else {
-      final archive = SwiftPmBinaryFixture.archiveXcframework(
+      SwiftPmBinaryFixture.archiveXcframework(
         framework: fixture,
-        output: p.join(probeRoot.path, 'GateFixture.zip'),
+        output: p.join(package.path, 'GateFixture.zip'),
       );
-      server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
-      server.listen((request) async {
-        request.response.add(await archive.readAsBytes());
-        await request.response.close();
-      });
       SwiftPmBinaryFixture.writeGatePackage(
         root: package.path,
         targetName: 'GateFixture',
-        url: Uri.parse(
-          'http://${server.address.host}:${server.port}/GateFixture.zip',
-        ),
-        checksum: sha256.convert(archive.readAsBytesSync()).toString(),
+        path: 'GateFixture.zip',
       );
     }
 
@@ -492,7 +483,6 @@ Future<bool> probeSwiftPmGate({
     stderr.writeln(stackTrace);
     return false;
   } finally {
-    await server?.close(force: true);
     if (probeRoot != null && probeRoot.existsSync()) {
       await probeRoot.delete(recursive: true);
       final parent = probeRoot.parent;

--- a/packages/xcross/lib/src/flutter/build/internal/swiftpm_gate_evidence.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/swiftpm_gate_evidence.dart
@@ -340,6 +340,7 @@ Future<bool> probeSwiftPmGate({
   if (!(windows ?? Platform.isWindows)) return false;
   Directory? probeRoot;
   HttpServer? server;
+  var stage = 'validating toolchain';
   try {
     final identity = jsonDecode(toolchainIdentity);
     if (identity is! Map) return false;
@@ -362,6 +363,7 @@ Future<bool> probeSwiftPmGate({
       return false;
     }
 
+    stage = 'creating fixture';
     probeRoot = await Directory(
       p.join(root, '.probe-${mode.name}'),
     ).createTemp('run-');
@@ -381,6 +383,7 @@ Future<bool> probeSwiftPmGate({
         targetName: 'GateFixture',
         path: 'artifacts/GateFixture.xcframework',
       );
+      stage = 'creating package-local junction';
       if (!await _createJunction(junction, fixture.path, run)) return false;
     } else {
       final archive = SwiftPmBinaryFixture.archiveXcframework(
@@ -402,6 +405,7 @@ Future<bool> probeSwiftPmGate({
       );
     }
 
+    stage = 'writing toolset';
     final toolset = await GeneratedPluginsPackage.writeToolset(
       outputDir: package.path,
       linkerPath: toolPath('ld64.lld'),
@@ -451,25 +455,41 @@ Future<bool> probeSwiftPmGate({
     }
 
     for (var repetition = 0; repetition < 2; repetition++) {
+      stage = 'resolve ${repetition + 1}';
       if (!await _runSwift(
-            swiftPackage,
-            resolve.skip(1).toList(),
-            environment,
-            run,
-          ) ||
-          !await _runSwift(
-            swiftBuild,
-            build.skip(1).toList(),
-            environment,
-            run,
-          ) ||
-          p.normalize(await Directory(junction!).resolveSymbolicLinks()) !=
-              p.normalize(await fixture.resolveSymbolicLinks())) {
+        swiftPackage,
+        resolve.skip(1).toList(),
+        environment,
+        run,
+      )) {
+        return false;
+      }
+      stage = 'build ${repetition + 1}';
+      if (!await _runSwift(
+        swiftBuild,
+        build.skip(1).toList(),
+        environment,
+        run,
+      )) {
+        return false;
+      }
+      stage = 'verifying junction ${repetition + 1}';
+      final actual = p.normalize(
+        await Directory(junction!).resolveSymbolicLinks(),
+      );
+      final expected = p.normalize(await fixture.resolveSymbolicLinks());
+      if (!p.equals(actual, expected)) {
+        stderr.writeln(
+          'SwiftPM junction gate target mismatch at $stage: '
+          'expected $expected, got $actual',
+        );
         return false;
       }
     }
     return true;
-  } on Object {
+  } on Object catch (error, stackTrace) {
+    stderr.writeln('SwiftPM junction gate failed at $stage: $error');
+    stderr.writeln(stackTrace);
     return false;
   } finally {
     await server?.close(force: true);

--- a/packages/xcross/lib/src/flutter/build/internal/swiftpm_gate_evidence.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/swiftpm_gate_evidence.dart
@@ -364,9 +364,9 @@ Future<bool> probeSwiftPmGate({
     }
 
     stage = 'creating fixture';
-    probeRoot = await Directory(
-      p.join(root, '.probe-${mode.name}'),
-    ).createTemp('run-');
+    final probeParent = Directory(p.join(root, '.probe-${mode.name}'));
+    await probeParent.create(recursive: true);
+    probeRoot = await probeParent.createTemp('run-');
     final fixture = SwiftPmBinaryFixture.generateXcframework(
       root: probeRoot.path,
       name: 'GateFixture',
@@ -495,6 +495,10 @@ Future<bool> probeSwiftPmGate({
     await server?.close(force: true);
     if (probeRoot != null && probeRoot.existsSync()) {
       await probeRoot.delete(recursive: true);
+      final parent = probeRoot.parent;
+      if (parent.existsSync() && parent.listSync().isEmpty) {
+        await parent.delete();
+      }
     }
   }
 }

--- a/packages/xcross/lib/src/flutter/build/internal/swiftpm_gate_evidence.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/swiftpm_gate_evidence.dart
@@ -89,7 +89,7 @@ final class SwiftPmGateEvidence {
             root: root,
             toolchainIdentity: toolchainIdentity,
             sdkIdentity: sdkIdentity,
-          ).timeout(const Duration(minutes: 2), onTimeout: () => false);
+          ).timeout(const Duration(minutes: 10), onTimeout: () => false);
           if (!passed) return false;
           final binding =
               runtime ??

--- a/packages/xcross/lib/src/flutter/build/internal/swiftpm_gate_evidence.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/swiftpm_gate_evidence.dart
@@ -544,8 +544,12 @@ Future<ProcessResult> _runBounded(
     environment: environment,
   );
   try {
-    final output = process.stdout.transform(utf8.decoder).join();
-    final error = process.stderr.transform(utf8.decoder).join();
+    final output = process.stdout
+        .transform(const Utf8Decoder(allowMalformed: true))
+        .join();
+    final error = process.stderr
+        .transform(const Utf8Decoder(allowMalformed: true))
+        .join();
     final exitCode = await process.exitCode.timeout(timeout);
     return ProcessResult(process.pid, exitCode, await output, await error);
   } on TimeoutException {

--- a/packages/xcross/lib/src/flutter/build/internal/swiftpm_gate_evidence.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/swiftpm_gate_evidence.dart
@@ -1,0 +1,582 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:crypto/crypto.dart';
+import 'package:darwin_sdk_kit/darwin_sdk_kit.dart';
+import 'package:path/path.dart' as p;
+import 'package:xcross/src/flutter/build/internal/swiftpm_binary_fixture.dart';
+import 'package:xcross/src/flutter/build/ios_plugin_package.dart';
+
+enum SwiftPmGateMode { swiftPmArtifact, packageLocalArtifact }
+
+typedef SwiftPmGateProbe =
+    Future<bool> Function({
+      required SwiftPmGateMode mode,
+      required String root,
+      required String toolchainIdentity,
+      required String sdkIdentity,
+    });
+
+typedef SwiftPmGateRuntimeBinding =
+    Future<Map<String, Object?>?> Function({
+      required SwiftPmGateMode mode,
+      required String root,
+      required String platformIdentity,
+      required String toolchainIdentity,
+      required String sdkIdentity,
+    });
+
+typedef SwiftPmGateRun =
+    Future<ProcessResult> Function(
+      String executable,
+      List<String> arguments, {
+      required Duration timeout,
+      Map<String, String>? environment,
+    });
+
+final _probeResults = <String, Future<bool>>{};
+const _gateImplementationVersion = 3;
+const _extractorBuildVersion = 'xcross-1.3.1-swiftpm-gate-3';
+
+final class SwiftPmGateEvidence {
+  const SwiftPmGateEvidence(this.root);
+
+  final String root;
+
+  Future<bool> verifies({
+    required SwiftPmGateMode mode,
+    required String platformIdentity,
+    required String toolchainIdentity,
+    required String sdkIdentity,
+    SwiftPmGateProbe probe = probeSwiftPmGate,
+    SwiftPmGateRuntimeBinding? runtimeBinding,
+  }) async {
+    if (!Platform.isWindows && platformIdentity.startsWith('windows-')) {
+      return false;
+    }
+    try {
+      final resolveRuntime = runtimeBinding ?? _defaultRuntimeBinding;
+      final runtime = await resolveRuntime(
+        mode: mode,
+        root: root,
+        platformIdentity: platformIdentity,
+        toolchainIdentity: toolchainIdentity,
+        sdkIdentity: sdkIdentity,
+      );
+      if (runtime != null && await _validEvidence(mode, runtime)) return true;
+
+      final cacheKey = sha256
+          .convert(
+            utf8.encode(
+              jsonEncode(
+                runtime ??
+                    {
+                      'mode': mode.name,
+                      'platform': platformIdentity,
+                      'toolchain': toolchainIdentity,
+                      'sdk': sdkIdentity,
+                    },
+              ),
+            ),
+          )
+          .toString();
+      final result = _probeResults.putIfAbsent(cacheKey, () async {
+        try {
+          final passed = await probe(
+            mode: mode,
+            root: root,
+            toolchainIdentity: toolchainIdentity,
+            sdkIdentity: sdkIdentity,
+          ).timeout(const Duration(minutes: 2), onTimeout: () => false);
+          if (!passed) return false;
+          final binding =
+              runtime ??
+              await resolveRuntime(
+                mode: mode,
+                root: root,
+                platformIdentity: platformIdentity,
+                toolchainIdentity: toolchainIdentity,
+                sdkIdentity: sdkIdentity,
+              );
+          if (binding == null) return false;
+          await _record(mode, binding);
+          return await _validEvidence(mode, binding);
+        } on Object {
+          return false;
+        }
+      });
+      final passed = await result;
+      if (passed && identical(_probeResults[cacheKey], result)) {
+        unawaited(_probeResults.remove(cacheKey));
+      }
+      return passed;
+    } on Object {
+      return false;
+    }
+  }
+
+  String _path(SwiftPmGateMode mode) =>
+      p.join(root, '${mode.name}.evidence.json');
+
+  Future<void> _record(
+    SwiftPmGateMode mode,
+    Map<String, Object?> binding,
+  ) async {
+    final proofParent = Directory(p.join(root, 'proofs'))
+      ..createSync(recursive: true);
+    final proof = await proofParent.createTemp('${mode.name}-');
+    final nonce = List<int>.generate(32, (_) => _secureRandomByte());
+    final target = Directory(p.join(proof.path, 'target'))..createSync();
+    final result = File(p.join(target.path, 'probe-result.bin'))
+      ..writeAsBytesSync(nonce, flush: true);
+    final alias = p.join(proof.path, 'junction');
+    if (!await _createProofAlias(alias, target.path)) {
+      await proof.delete(recursive: true);
+      throw StateError('Could not create proof junction');
+    }
+    final payload = {
+      ...binding,
+      'proof': {
+        'directory': p.relative(proof.path, from: root),
+        'resultDigest': sha256.convert(result.readAsBytesSync()).toString(),
+      },
+    };
+    final file = File(_path(mode));
+    await file.parent.create(recursive: true);
+    final temporary = File('${file.path}.tmp-$pid');
+    await temporary.writeAsString(jsonEncode(payload), flush: true);
+    await temporary.rename(file.path);
+  }
+
+  Future<bool> _validEvidence(
+    SwiftPmGateMode mode,
+    Map<String, Object?> binding,
+  ) async {
+    final file = File(_path(mode));
+    if (!file.existsSync()) return false;
+    final encoded = jsonDecode(await file.readAsString());
+    if (encoded is! Map) return false;
+    final proof = encoded['proof'];
+    if (proof is! Map || proof['directory'] is! String) return false;
+    final persistedBinding = Map<String, Object?>.from(encoded)
+      ..remove('proof');
+    if (!const DeepCollectionEquality().equals(persistedBinding, binding)) {
+      return false;
+    }
+    final proofRoot = p.normalize(p.join(root, proof['directory'] as String));
+    if (!p.isWithin(p.normalize(root), proofRoot)) return false;
+    final target = Directory(p.join(proofRoot, 'target'));
+    final alias = Directory(p.join(proofRoot, 'junction'));
+    final result = File(p.join(target.path, 'probe-result.bin'));
+    if (!target.existsSync() || !alias.existsSync() || !result.existsSync()) {
+      return false;
+    }
+    if (sha256.convert(result.readAsBytesSync()).toString() !=
+        proof['resultDigest']) {
+      return false;
+    }
+    if (p.normalize(await alias.resolveSymbolicLinks()) !=
+        p.normalize(await target.resolveSymbolicLinks())) {
+      return false;
+    }
+    return !Platform.isWindows || await _isJunction(alias.path);
+  }
+}
+
+Future<Map<String, Object?>?> _defaultRuntimeBinding({
+  required SwiftPmGateMode mode,
+  required String root,
+  required String platformIdentity,
+  required String toolchainIdentity,
+  required String sdkIdentity,
+}) async {
+  final toolchain = _decodedMap(toolchainIdentity);
+  final sdk = _decodedMap(sdkIdentity);
+  if (toolchain == null || sdk == null) return null;
+  if (!await validSwiftPmGateToolchainIdentity(toolchain) ||
+      !await _validSdkIdentity(sdk)) {
+    return null;
+  }
+  await Directory(root).create(recursive: true);
+  final volume = await _volumeIdentity(root);
+  if (volume == null) return null;
+  return {
+    'formatVersion': 3,
+    'gateImplementationVersion': _gateImplementationVersion,
+    'extractorBuildVersion': _extractorBuildVersion,
+    'mode': mode.name,
+    'platform': platformIdentity,
+    'toolchain': toolchain,
+    'sdk': sdk,
+    'volume': volume,
+  };
+}
+
+Map<String, Object?>? _decodedMap(String encoded) {
+  try {
+    final value = jsonDecode(encoded);
+    return value is Map ? Map<String, Object?>.from(value) : null;
+  } on FormatException {
+    return null;
+  }
+}
+
+Future<bool> validSwiftPmGateToolchainIdentity(
+  Map<String, Object?> identity,
+) async {
+  const versionedTools = {'swift-package', 'swift-build', 'swiftc'};
+  const tools = {
+    ...versionedTools,
+    'clang',
+    'clang++',
+    'ld64.lld',
+    'librarian',
+  };
+  if (identity.keys.toSet().difference(tools).isNotEmpty ||
+      tools.difference(identity.keys.toSet()).isNotEmpty) {
+    return false;
+  }
+  for (final name in tools) {
+    final executable = identity[name];
+    if (executable is! Map ||
+        executable['path'] is! String ||
+        executable['size'] is! int ||
+        executable['modified'] is! int ||
+        executable['digest'] is! String ||
+        (versionedTools.contains(name) && executable['version'] is! String)) {
+      return false;
+    }
+    final file = File(executable['path'] as String);
+    if (!file.existsSync()) return false;
+    final resolved = file.resolveSymbolicLinksSync();
+    final stat = File(resolved).statSync();
+    if (p.normalize(resolved) != p.normalize(executable['path'] as String) ||
+        stat.size != executable['size'] ||
+        stat.modified.microsecondsSinceEpoch != executable['modified'] ||
+        sha256.convert(File(resolved).readAsBytesSync()).toString() !=
+            executable['digest']) {
+      return false;
+    }
+  }
+  return true;
+}
+
+Future<bool> _validSdkIdentity(Map<String, Object?> identity) async {
+  if (identity['path'] is! String || identity['metadata'] is! Map) return false;
+  final root = identity['path']! as String;
+  if (!DarwinSdk.isValidBundle(root)) return false;
+  final metadata = identity['metadata']! as Map;
+  if (metadata.isEmpty) return false;
+  for (final entry in metadata.entries) {
+    if (entry.key is! String || entry.value is! Map) return false;
+    final expected = entry.value as Map;
+    if (expected['size'] is! int ||
+        expected['modified'] is! int ||
+        expected['digest'] is! String) {
+      return false;
+    }
+    final file = File(p.join(root, entry.key as String));
+    if (!file.existsSync()) return false;
+    final stat = file.statSync();
+    if (stat.size != expected['size'] ||
+        stat.modified.microsecondsSinceEpoch != expected['modified'] ||
+        sha256.convert(file.readAsBytesSync()).toString() !=
+            expected['digest']) {
+      return false;
+    }
+  }
+  return true;
+}
+
+Future<String?> _volumeIdentity(String path) async {
+  if (!Platform.isWindows) {
+    final stat = await FileStat.stat(path);
+    return '${stat.mode}:${stat.changed.microsecondsSinceEpoch}';
+  }
+  final result = await _runBounded('fsutil.exe', [
+    'fsinfo',
+    'volumeinfo',
+    p.windows.rootPrefix(p.windows.absolute(path)),
+  ], timeout: const Duration(seconds: 5));
+  if (result.exitCode != 0) return null;
+  final match = RegExp(
+    r'Volume Serial Number\s*:\s*(\S+)',
+    caseSensitive: false,
+  ).firstMatch('${result.stdout}');
+  return match?.group(1)?.toLowerCase();
+}
+
+int _secureRandomByte() => Random.secure().nextInt(256);
+
+Future<bool> _createProofAlias(String alias, String target) async {
+  if (Platform.isWindows) return _createJunction(alias, target, _runBounded);
+  await Link(alias).create(target);
+  return Directory(alias).existsSync();
+}
+
+Future<bool> _isJunction(String path) async {
+  final result = await _runBounded('fsutil.exe', [
+    'reparsepoint',
+    'query',
+    path,
+  ], timeout: const Duration(seconds: 5));
+  return result.exitCode == 0 &&
+      RegExp(
+        r'Reparse Tag Value\s*:\s*0xa0000003',
+        caseSensitive: false,
+      ).hasMatch('${result.stdout}');
+}
+
+Future<bool> probeSwiftPmGate({
+  required SwiftPmGateMode mode,
+  required String root,
+  required String toolchainIdentity,
+  required String sdkIdentity,
+  SwiftPmGateRun run = _runBounded,
+  bool? windows,
+}) async {
+  if (!(windows ?? Platform.isWindows)) return false;
+  Directory? probeRoot;
+  HttpServer? server;
+  try {
+    final identity = jsonDecode(toolchainIdentity);
+    if (identity is! Map) return false;
+    final swiftPackage = await _boundExecutable(identity['swift-package'], run);
+    final swiftBuild = await _boundExecutable(identity['swift-build'], run);
+    if (swiftPackage == null ||
+        swiftBuild == null ||
+        !await validSwiftPmGateToolchainIdentity(
+          Map<String, Object?>.from(identity),
+        )) {
+      return false;
+    }
+    String toolPath(String name) => (identity[name] as Map)['path']! as String;
+    final encodedSdk = _decodedMap(sdkIdentity);
+    final sdkPath = encodedSdk?['path'];
+    if (sdkPath is! String) return false;
+    final sdk = DarwinSdk(sdkPath);
+    if (!DarwinSdk.isValidBundle(sdkPath) ||
+        p.normalize(sdk.swiftSdkPath) != p.normalize(sdkPath)) {
+      return false;
+    }
+
+    probeRoot = await Directory(
+      p.join(root, '.probe-${mode.name}'),
+    ).createTemp('run-');
+    final fixture = SwiftPmBinaryFixture.generateXcframework(
+      root: probeRoot.path,
+      name: 'GateFixture',
+    );
+    final package = Directory(p.join(probeRoot.path, 'package'))..createSync();
+    final scratch = p.join(probeRoot.path, 'scratch');
+    String? junction;
+
+    if (mode == SwiftPmGateMode.packageLocalArtifact) {
+      junction = p.join(package.path, 'artifacts', 'GateFixture.xcframework');
+      Directory(p.dirname(junction)).createSync();
+      SwiftPmBinaryFixture.writeGatePackage(
+        root: package.path,
+        targetName: 'GateFixture',
+        path: 'artifacts/GateFixture.xcframework',
+      );
+      if (!await _createJunction(junction, fixture.path, run)) return false;
+    } else {
+      final archive = SwiftPmBinaryFixture.archiveXcframework(
+        framework: fixture,
+        output: p.join(probeRoot.path, 'GateFixture.zip'),
+      );
+      server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      server.listen((request) async {
+        request.response.add(await archive.readAsBytes());
+        await request.response.close();
+      });
+      SwiftPmBinaryFixture.writeGatePackage(
+        root: package.path,
+        targetName: 'GateFixture',
+        url: Uri.parse(
+          'http://${server.address.host}:${server.port}/GateFixture.zip',
+        ),
+        checksum: sha256.convert(archive.readAsBytesSync()).toString(),
+      );
+    }
+
+    final toolset = await GeneratedPluginsPackage.writeToolset(
+      outputDir: package.path,
+      linkerPath: toolPath('ld64.lld'),
+      cCompilerPath: toolPath('clang'),
+      cxxCompilerPath: toolPath('clang++'),
+      librarianPath: toolPath('librarian'),
+      windows: true,
+    );
+    final swiftSdksPath = p.dirname(sdkPath);
+    final resolve = GeneratedPluginsPackage.swiftResolveArguments(
+      pluginsDir: package.path,
+      scratchPath: scratch,
+      swiftSdksPath: swiftSdksPath,
+      toolsetPath: toolset,
+    );
+    final build = GeneratedPluginsPackage.swiftBuildArguments(
+      pluginsDir: package.path,
+      scratchPath: scratch,
+      swiftSdksPath: swiftSdksPath,
+      iosSdk: sdk.iPhoneOSSdk(),
+      flutterFrameworkSlice: package.path,
+      toolsetPath: toolset,
+      windows: true,
+    );
+    final environment = GeneratedPluginsPackage.swiftProcessEnvironment(
+      windows: true,
+    );
+
+    if (mode == SwiftPmGateMode.swiftPmArtifact) {
+      if (!await _runSwift(
+        swiftPackage,
+        resolve.skip(1).toList(),
+        environment,
+        run,
+      )) {
+        return false;
+      }
+      final artifacts = Directory(scratch)
+          .listSync(recursive: true, followLinks: false)
+          .whereType<Directory>()
+          .where((entry) => p.basename(entry.path) == 'GateFixture.xcframework')
+          .toList();
+      if (artifacts.length != 1) return false;
+      junction = artifacts.single.path;
+      await artifacts.single.delete(recursive: true);
+      if (!await _createJunction(junction, fixture.path, run)) return false;
+    }
+
+    for (var repetition = 0; repetition < 2; repetition++) {
+      if (!await _runSwift(
+            swiftPackage,
+            resolve.skip(1).toList(),
+            environment,
+            run,
+          ) ||
+          !await _runSwift(
+            swiftBuild,
+            build.skip(1).toList(),
+            environment,
+            run,
+          ) ||
+          p.normalize(await Directory(junction!).resolveSymbolicLinks()) !=
+              p.normalize(await fixture.resolveSymbolicLinks())) {
+        return false;
+      }
+    }
+    return true;
+  } on Object {
+    return false;
+  } finally {
+    await server?.close(force: true);
+    if (probeRoot != null && probeRoot.existsSync()) {
+      await probeRoot.delete(recursive: true);
+    }
+  }
+}
+
+Future<String?> _boundExecutable(Object? encoded, SwiftPmGateRun run) async {
+  if (encoded is! Map ||
+      encoded['path'] is! String ||
+      encoded['version'] is! String) {
+    return null;
+  }
+  final recordedPath = encoded['path'] as String;
+  if (recordedPath.isEmpty || !File(recordedPath).existsSync()) return null;
+  final resolvedPath = await File(recordedPath).resolveSymbolicLinks();
+  if (p.normalize(resolvedPath) != p.normalize(recordedPath)) return null;
+  final result = await run(resolvedPath, const [
+    '--version',
+  ], timeout: const Duration(seconds: 5));
+  final output = '${result.stdout}'.trim().isEmpty
+      ? '${result.stderr}'.trim()
+      : '${result.stdout}'.trim();
+  if (result.exitCode != 0 ||
+      output.split(RegExp(r'\r?\n')).first != encoded['version']) {
+    return null;
+  }
+  return resolvedPath;
+}
+
+Future<bool> _createJunction(
+  String alias,
+  String target,
+  SwiftPmGateRun run,
+) async {
+  final result = await run('cmd.exe', [
+    '/c',
+    'mklink',
+    '/J',
+    p.windows.normalize(alias),
+    p.windows.normalize(target),
+  ], timeout: const Duration(seconds: 5));
+  return result.exitCode == 0 && Directory(alias).existsSync();
+}
+
+Future<bool> _runSwift(
+  String swift,
+  List<String> arguments,
+  Map<String, String>? environment,
+  SwiftPmGateRun run,
+) async {
+  final result = await run(
+    swift,
+    arguments,
+    environment: environment,
+    timeout: const Duration(seconds: 25),
+  );
+  return result.exitCode == 0;
+}
+
+Future<ProcessResult> _runBounded(
+  String executable,
+  List<String> arguments, {
+  required Duration timeout,
+  Map<String, String>? environment,
+}) async {
+  final process = await Process.start(
+    executable,
+    arguments,
+    environment: environment,
+  );
+  try {
+    final output = process.stdout.transform(utf8.decoder).join();
+    final error = process.stderr.transform(utf8.decoder).join();
+    final exitCode = await process.exitCode.timeout(timeout);
+    return ProcessResult(process.pid, exitCode, await output, await error);
+  } on TimeoutException {
+    process.kill();
+    await process.exitCode.timeout(
+      const Duration(seconds: 2),
+      onTimeout: () => -1,
+    );
+    rethrow;
+  }
+}
+
+final class DeepCollectionEquality {
+  const DeepCollectionEquality();
+
+  bool equals(Object? left, Object? right) {
+    if (left is Map && right is Map) {
+      if (left.length != right.length) return false;
+      return left.entries.every(
+        (entry) =>
+            right.containsKey(entry.key) &&
+            equals(entry.value, right[entry.key]),
+      );
+    }
+    if (left is List && right is List) {
+      if (left.length != right.length) return false;
+      for (var index = 0; index < left.length; index++) {
+        if (!equals(left[index], right[index])) return false;
+      }
+      return true;
+    }
+    return left == right;
+  }
+}

--- a/packages/xcross/lib/src/flutter/build/internal/swiftpm_gate_evidence.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/swiftpm_gate_evidence.dart
@@ -551,7 +551,7 @@ Future<bool> _runSwift(
     swift,
     arguments,
     environment: environment,
-    timeout: const Duration(minutes: 2),
+    timeout: const Duration(minutes: 5),
   );
   if (result.exitCode != 0) {
     stderr.writeln(

--- a/packages/xcross/lib/src/flutter/build/internal/swiftpm_workspace.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/swiftpm_workspace.dart
@@ -5,10 +5,15 @@ import 'package:crypto/crypto.dart';
 import 'package:path/path.dart' as p;
 
 final class SwiftPmWorkspace {
-  const SwiftPmWorkspace._(this.root);
+  const SwiftPmWorkspace._({required this.cacheRoot, required this.root});
 
+  final String cacheRoot;
   final String root;
 
+  String get binaryArtifactStore =>
+      p.join(cacheRoot, 'swiftpm', 'binary-artifacts-v1');
+  String get binaryArtifactFallback => p.join(root, 'binary-artifacts');
+  String get gateEvidence => p.join(cacheRoot, 'swiftpm', 'gate-evidence-v2');
   String get packages => p.join(root, 'plugins');
   String get scratch => p.join(root, 'scratch');
   String get vendor => p.join(root, 'vendor');
@@ -28,7 +33,10 @@ final class SwiftPmWorkspace {
         .convert(utf8.encode(canonical))
         .toString()
         .substring(0, 16);
-    return SwiftPmWorkspace._(p.join(base, 'swiftpm', key));
+    return SwiftPmWorkspace._(
+      cacheRoot: base,
+      root: p.join(base, 'swiftpm', key),
+    );
   }
 
   static String _defaultCacheRoot(

--- a/packages/xcross/lib/src/flutter/build/internal/swiftpm_workspace.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/swiftpm_workspace.dart
@@ -1,0 +1,59 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:path/path.dart' as p;
+
+final class SwiftPmWorkspace {
+  const SwiftPmWorkspace._(this.root);
+
+  final String root;
+
+  String get packages => p.join(root, 'plugins');
+  String get scratch => p.join(root, 'scratch');
+  String get vendor => p.join(root, 'vendor');
+
+  factory SwiftPmWorkspace.forProject(
+    String projectRoot, {
+    Map<String, String>? environment,
+    bool? windows,
+  }) {
+    final env = environment ?? Platform.environment;
+    final cache = env['XCROSS_CACHE_DIR'];
+    final base = cache != null && cache.isNotEmpty
+        ? cache
+        : _defaultCacheRoot(env, windows: windows);
+    final canonical = _canonicalProjectPath(projectRoot);
+    final key = sha256
+        .convert(utf8.encode(canonical))
+        .toString()
+        .substring(0, 16);
+    return SwiftPmWorkspace._(p.join(base, 'swiftpm', key));
+  }
+
+  static String _defaultCacheRoot(
+    Map<String, String> environment, {
+    bool? windows,
+  }) {
+    if (windows ?? Platform.isWindows) {
+      final localAppData = environment['LOCALAPPDATA'];
+      if (localAppData != null && localAppData.isNotEmpty) {
+        return p.join(localAppData, 'xcross');
+      }
+    }
+    final xdg = environment['XDG_CACHE_HOME'];
+    if (xdg != null && xdg.isNotEmpty) return p.join(xdg, 'xcross');
+    final home = environment['HOME'] ?? environment['USERPROFILE'] ?? '.';
+    return p.join(home, '.cache', 'xcross');
+  }
+
+  static String _canonicalProjectPath(String projectRoot) {
+    final absolute = p.normalize(p.absolute(projectRoot));
+    try {
+      final resolved = Directory(absolute).resolveSymbolicLinksSync();
+      return Platform.isWindows ? resolved.toLowerCase() : resolved;
+    } on FileSystemException {
+      return Platform.isWindows ? absolute.toLowerCase() : absolute;
+    }
+  }
+}

--- a/packages/xcross/lib/src/flutter/build/ios_native_assets.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_native_assets.dart
@@ -77,14 +77,7 @@ final class IosNativeAssetsBuilder {
       await installAppleToolShims(
         shims.path,
         tools,
-        launcherExecutable: p.join(
-          flutterRoot,
-          'bin',
-          'cache',
-          'dart-sdk',
-          'bin',
-          ProcessRunner.hostExecutableName('dart'),
-        ),
+        toolForwarderExecutable: Platform.resolvedExecutable,
       );
       await _runFlutterAssemble(output, shims.path, tools.iosSdk);
     } finally {

--- a/packages/xcross/lib/src/flutter/build/ios_native_assets.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_native_assets.dart
@@ -5,10 +5,10 @@ import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:xcross/src/flutter/build/internal/apple_tool_shims.dart';
 import 'package:xcross/src/flutter/build/internal/native_asset_frameworks.dart';
-import 'package:xcross/src/flutter/build/internal/recursive_directory_copy.dart';
-import 'package:xcross/src/flutter/build/ios_engine_cache.dart';
 import 'package:xcross/src/flutter/build/internal/native_assets_hook_discovery.dart';
+import 'package:xcross/src/flutter/build/internal/recursive_directory_copy.dart';
 import 'package:xcross/src/flutter/build/ios_deployment_target.dart';
+import 'package:xcross/src/flutter/build/ios_engine_cache.dart';
 import 'package:xcross/src/flutter/errors.dart';
 
 /// Native code assets produced by Flutter's Dart build-hook pipeline.
@@ -77,7 +77,14 @@ final class IosNativeAssetsBuilder {
       await installAppleToolShims(
         shims.path,
         tools,
-        launcherExecutable: Platform.resolvedExecutable,
+        launcherExecutable: p.join(
+          flutterRoot,
+          'bin',
+          'cache',
+          'dart-sdk',
+          'bin',
+          ProcessRunner.hostExecutableName('dart'),
+        ),
       );
       await _runFlutterAssemble(output, shims.path, tools.iosSdk);
     } finally {

--- a/packages/xcross/lib/src/flutter/build/ios_native_assets.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_native_assets.dart
@@ -5,6 +5,8 @@ import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:xcross/src/flutter/build/internal/apple_tool_shims.dart';
 import 'package:xcross/src/flutter/build/internal/native_asset_frameworks.dart';
+import 'package:xcross/src/flutter/build/internal/recursive_directory_copy.dart';
+import 'package:xcross/src/flutter/build/ios_engine_cache.dart';
 import 'package:xcross/src/flutter/build/internal/native_assets_hook_discovery.dart';
 import 'package:xcross/src/flutter/build/ios_deployment_target.dart';
 import 'package:xcross/src/flutter/errors.dart';
@@ -52,12 +54,37 @@ final class IosNativeAssetsBuilder {
     }
 
     final tools = await AppleToolShimConfig.resolve(deploymentTarget.version);
+    final engineCache = IosEngineCache(flutterRoot: flutterRoot);
+    await engineCache.ensureArtifactsAvailable();
+    final flutterCachedFramework = p.join(
+      flutterRoot,
+      'bin',
+      'cache',
+      'artifacts',
+      'engine',
+      'ios',
+      'Flutter.xcframework',
+    );
+    final stagedEngine = !Directory(flutterCachedFramework).existsSync();
+    if (stagedEngine) {
+      await copyDirectoryPreservingSymlinks(
+        engineCache.flutterXcframework,
+        flutterCachedFramework,
+      );
+    }
     final shims = await Directory.systemTemp.createTemp('xcross-apple-tools-');
     try {
-      await installAppleToolShims(shims.path, tools);
+      await installAppleToolShims(
+        shims.path,
+        tools,
+        launcherExecutable: Platform.resolvedExecutable,
+      );
       await _runFlutterAssemble(output, shims.path, tools.iosSdk);
     } finally {
       await shims.delete(recursive: true);
+      if (stagedEngine) {
+        await Directory(flutterCachedFramework).delete(recursive: true);
+      }
     }
 
     final manifest = p.join(

--- a/packages/xcross/lib/src/flutter/build/ios_native_assets.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_native_assets.dart
@@ -77,7 +77,9 @@ final class IosNativeAssetsBuilder {
       await installAppleToolShims(
         shims.path,
         tools,
-        toolForwarderExecutable: Platform.resolvedExecutable,
+        toolForwarderExecutable: await resolveNativeAssetToolForwarder(
+          Platform.resolvedExecutable,
+        ),
       );
       await _runFlutterAssemble(output, shims.path, tools.iosSdk);
     } finally {

--- a/packages/xcross/lib/src/flutter/build/ios_native_assets.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_native_assets.dart
@@ -74,18 +74,7 @@ final class IosNativeAssetsBuilder {
     }
     final shims = await Directory.systemTemp.createTemp('xcross-apple-tools-');
     try {
-      await installAppleToolShims(
-        shims.path,
-        tools,
-        launcherExecutable: p.join(
-          flutterRoot,
-          'bin',
-          'cache',
-          'dart-sdk',
-          'bin',
-          ProcessRunner.hostExecutableName('dart'),
-        ),
-      );
+      await installAppleToolShims(shims.path, tools);
       await _runFlutterAssemble(output, shims.path, tools.iosSdk);
     } finally {
       await shims.delete(recursive: true);

--- a/packages/xcross/lib/src/flutter/build/ios_native_assets.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_native_assets.dart
@@ -74,7 +74,18 @@ final class IosNativeAssetsBuilder {
     }
     final shims = await Directory.systemTemp.createTemp('xcross-apple-tools-');
     try {
-      await installAppleToolShims(shims.path, tools);
+      await installAppleToolShims(
+        shims.path,
+        tools,
+        launcherExecutable: p.join(
+          flutterRoot,
+          'bin',
+          'cache',
+          'dart-sdk',
+          'bin',
+          ProcessRunner.hostExecutableName('dart'),
+        ),
+      );
       await _runFlutterAssemble(output, shims.path, tools.iosSdk);
     } finally {
       await shims.delete(recursive: true);

--- a/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
@@ -3531,16 +3531,10 @@ $diagnosticsStart$registrations$diagnosticsEnd}
   }) async {
     await _deleteEntity(destination);
     if (Platform.isWindows) {
-      final result = await Process.run('robocopy', [
-        source,
-        destination,
-        '/E',
-        '/NFL',
-        '/NDL',
-        '/NJH',
-        '/NJS',
-        '/NP',
-      ]);
+      final result = await Process.run(
+        'robocopy',
+        windowsCopyArguments(source, destination),
+      );
       if (result.exitCode > 7) {
         throw FileSystemException(
           '$failureDescription: ${result.stderr}',
@@ -3557,6 +3551,22 @@ $diagnosticsStart$registrations$diagnosticsEnd}
       );
     }
   }
+
+  @visibleForTesting
+  static List<String> windowsCopyArguments(String source, String destination) =>
+      [
+        source,
+        destination,
+        '/E',
+        '/R:0',
+        '/W:0',
+        '/MT:8',
+        '/NFL',
+        '/NDL',
+        '/NJH',
+        '/NJS',
+        '/NP',
+      ];
 
   static Future<void> _deleteUnless(
     String path,

--- a/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
@@ -94,7 +94,32 @@ abstract final class GeneratedPluginsPackage {
           'spmPlugins=${[for (final plugin in spmPlugins) plugin.name]}',
         );
 
+        final workspace = SwiftPmWorkspace.forProject(projectRoot);
+        final targetDebugDir = p.join(
+          workspace.scratch,
+          'arm64-apple-ios',
+          'debug',
+        );
+        final fingerprint = await incrementalBuildFingerprint(
+          plugins: spmPlugins,
+          flutterXcframework: flutterXcframework,
+          deploymentTarget: deploymentTarget,
+          verbose: verbose,
+        );
+        final fingerprintFile = File(
+          p.join(outputDir, '.xcross-build-fingerprint'),
+        );
+        if (fingerprintFile.existsSync() &&
+            await fingerprintFile.readAsString() == fingerprint &&
+            File(
+              p.join(targetDebugDir, 'lib$_pluginsProductName.dylib'),
+            ).existsSync()) {
+          Log.logTrace('reusing unchanged SwiftPM plugin build');
+          return discoverAndRewriteDylibs(targetDebugDir);
+        }
+
         final interopProductsByPlugin = <String, Set<String>>{};
+
         for (final plugin in spmPlugins) {
           final manifest = await File(
             p.join(plugin.swiftPackageDir, 'Package.swift'),
@@ -108,8 +133,8 @@ abstract final class GeneratedPluginsPackage {
           for (final products in interopProductsByPlugin.values) ...products,
         };
 
-        final workspace = SwiftPmWorkspace.forProject(projectRoot);
         await writeGeneratedPackages(
+
           outputDir: outputDir,
           plugins: spmPlugins,
           flutterXcframework: flutterXcframework,
@@ -147,12 +172,79 @@ abstract final class GeneratedPluginsPackage {
           },
         );
 
-        return discoverAndRewriteDylibs(
-          p.join(scratchPath, 'arm64-apple-ios', 'debug'),
-        );
+        final result = await discoverAndRewriteDylibs(targetDebugDir);
+        await _writeStable(fingerprintFile.path, fingerprint);
+        return result;
+
       });
 
+  @visibleForTesting
+  static Future<String> incrementalBuildFingerprint({
+    required List<IosPlugin> plugins,
+    required String flutterXcframework,
+    required IosDeploymentTarget deploymentTarget,
+    required bool verbose,
+    String? toolchainIdentity,
+    String? sdkIdentity,
+  }) async {
+    Digest? result;
+    final input = sha256.startChunkedConversion(
+      ChunkedConversionSink.withCallback((digests) => result = digests.single),
+    );
+
+    void add(String value) {
+      input.add(utf8.encode(value));
+      input.add(const [0]);
+    }
+
+    add('xcross-swiftpm-build-v1');
+    add(deploymentTarget.version);
+    add(verbose.toString());
+    final swift = toolchainIdentity ?? await ProcessRunner.locateTool('swift');
+    add(swift);
+    final sdk = sdkIdentity ?? DarwinSdk.current()?.swiftSdkPath;
+    add(sdk ?? '');
+
+    Future<void> addTree(String root) async {
+      final directory = Directory(root);
+      if (!directory.existsSync()) {
+        add('missing:$root');
+        return;
+      }
+      final files = <File>[];
+      await for (final entity in directory.list(recursive: true)) {
+        if (entity is File) files.add(entity);
+      }
+      files.sort((a, b) => a.path.compareTo(b.path));
+      for (final file in files) {
+        add(p.relative(file.path, from: root).replaceAll(r'\', '/'));
+        input.add(await file.readAsBytes());
+        input.add(const [0]);
+      }
+    }
+
+    for (final plugin in plugins.toList()..sort((a, b) => a.name.compareTo(b.name))) {
+      add(plugin.name);
+      add(plugin.platformDirectoryName);
+      await addTree(plugin.packageRoot);
+    }
+    final frameworkFiles = <File>[];
+    await for (final entity in Directory(flutterXcframework).list(recursive: true)) {
+      if (entity is File) frameworkFiles.add(entity);
+    }
+    frameworkFiles.sort((a, b) => a.path.compareTo(b.path));
+    for (final file in frameworkFiles) {
+      final stat = file.statSync();
+      add(p.relative(file.path, from: flutterXcframework).replaceAll(r'\', '/'));
+      add(stat.size.toString());
+      add(stat.modified.microsecondsSinceEpoch.toString());
+    }
+    input.close();
+    return result!.toString();
+  }
+
   /// Cross-compiles the synthesized packages in [pluginsDir] with
+
   /// `swift build --swift-sdk arm64-apple-ios`.
   static Future<void> _runSwiftBuild({
     required String outputDir,

--- a/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
@@ -324,7 +324,7 @@ abstract final class GeneratedPluginsPackage {
         in plugins.toList()..sort((a, b) => a.name.compareTo(b.name))) {
       add(plugin.name);
       add(plugin.platformDirectoryName);
-      await addTree(plugin.packageRoot);
+      await addTree(plugin.swiftPackageDir);
     }
     final frameworkFiles = <File>[];
     await for (final entity in Directory(
@@ -1809,6 +1809,8 @@ abstract final class GeneratedPluginsPackage {
     final pluginPackageDirs = <String, String>{};
     final vendorNormalizationCache = <String, Map<String, List<String>>>{};
     final dependencyEvaluationCache = <String, Future<Map<String, String>>>{};
+    final vendorCheckoutCache = <String, Future<void>>{};
+
     for (final plugin in plugins) {
       final packageAlias = p.join(packagesDir, plugin.name);
       pluginPackageDirs[plugin.name] = await _stagePluginPackage(
@@ -1820,7 +1822,9 @@ abstract final class GeneratedPluginsPackage {
         copySources: copyPluginPackages.contains(plugin.name),
         vendorNormalizationCache: vendorNormalizationCache,
         dependencyEvaluationCache: dependencyEvaluationCache,
+        vendorCheckoutCache: vendorCheckoutCache,
         scratchPath: scratchPath,
+
         binaryArtifactStore: binaryArtifactStore,
         binaryArtifactFallback: binaryArtifactFallback,
         swiftPmArtifactJunctionCapability: swiftPmArtifactJunctionCapability,
@@ -1828,6 +1832,18 @@ abstract final class GeneratedPluginsPackage {
             packageLocalArtifactJunctionCapability,
         evaluateDependencyRefs: evaluateDependencyRefs,
         clonePackage: clonePackage,
+      );
+    }
+    if (windows &&
+        shouldVendor &&
+        binaryArtifactStore != null &&
+        binaryArtifactFallback != null) {
+      await prepareSupportedBinaryArtifacts(
+        packageRoot: resolvedVendorDir,
+        binaryArtifactStore: binaryArtifactStore,
+        binaryArtifactFallback: binaryArtifactFallback,
+        packageLocalArtifactJunctionCapability:
+            packageLocalArtifactJunctionCapability,
       );
     }
     final packagesByDirectoryName = {
@@ -1884,7 +1900,9 @@ abstract final class GeneratedPluginsPackage {
     bool copySources = false,
     Map<String, Map<String, List<String>>>? vendorNormalizationCache,
     Map<String, Future<Map<String, String>>>? dependencyEvaluationCache,
+    Map<String, Future<void>>? vendorCheckoutCache,
     String? scratchPath,
+
     String? binaryArtifactStore,
     String? binaryArtifactFallback,
     bool swiftPmArtifactJunctionCapability = false,
@@ -1948,7 +1966,9 @@ abstract final class GeneratedPluginsPackage {
         fallbackSwiftModules: fallbackSwiftModules,
         normalizationCache: vendorNormalizationCache,
         evaluationCache: dependencyEvaluationCache,
+        checkoutCache: vendorCheckoutCache,
         scratchPath: scratchPath,
+
         binaryArtifactStore: binaryArtifactStore,
         binaryArtifactFallback: binaryArtifactFallback,
         swiftPmArtifactJunctionCapability: swiftPmArtifactJunctionCapability,
@@ -1992,16 +2012,8 @@ abstract final class GeneratedPluginsPackage {
         packageLocalArtifactJunctionCapability:
             packageLocalArtifactJunctionCapability,
       );
-      if (vendorDir != null) {
-        await prepareSupportedBinaryArtifacts(
-          packageRoot: vendorDir,
-          binaryArtifactStore: binaryArtifactStore,
-          binaryArtifactFallback: binaryArtifactFallback,
-          packageLocalArtifactJunctionCapability:
-              packageLocalArtifactJunctionCapability,
-        );
-      }
     }
+
     return stagedPackage;
   }
 
@@ -3654,7 +3666,9 @@ let package = Package(
     clonePackage,
     Map<String, Map<String, List<String>>>? normalizationCache,
     Map<String, Future<Map<String, String>>>? evaluationCache,
+    Map<String, Future<void>>? checkoutCache,
     String? scratchPath,
+
     String? binaryArtifactStore,
     String? binaryArtifactFallback,
     bool swiftPmArtifactJunctionCapability = false,
@@ -3753,8 +3767,25 @@ let package = Package(
       final identity = dep.identity;
       if (seen.add(dirName)) {
         final destination = p.join(vendorDir, dirName);
-        await clone(git, dep.url, ref, destination);
+        if (checkoutCache == null) {
+          await clone(git, dep.url, ref, destination);
+        } else {
+          final key = p.normalize(destination);
+          final pending = checkoutCache.putIfAbsent(
+            key,
+            () => clone(git, dep.url, ref, destination),
+          );
+          try {
+            await pending;
+          } on Object {
+            if (identical(checkoutCache[key], pending)) {
+              final _ = checkoutCache.remove(key);
+            }
+            rethrow;
+          }
+        }
         final consumedProducts = _consumedProducts(manifest, identity);
+
         final cacheKey = [
           p.normalize(destination),
           ...(consumedProducts.toList()..sort()),

--- a/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
@@ -8,6 +8,7 @@ import 'package:darwin_sdk_kit/darwin_sdk_kit.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:xcross/src/cli/basic/sdk_install.dart';
+import 'package:xcross/src/flutter/build/internal/swiftpm_workspace.dart';
 import 'package:xcross/src/flutter/build/ios_deployment_target.dart';
 import 'package:xcross/src/flutter/build/ios_linker_compatibility.dart';
 import 'package:xcross/src/flutter/build/ios_plugins.dart';
@@ -107,22 +108,31 @@ abstract final class GeneratedPluginsPackage {
           for (final products in interopProductsByPlugin.values) ...products,
         };
 
+        final workspace = SwiftPmWorkspace.forProject(projectRoot);
         await writeGeneratedPackages(
           outputDir: outputDir,
           plugins: spmPlugins,
           flutterXcframework: flutterXcframework,
-          copyPluginPackages: interopProductsByPlugin.keys.toSet(),
+          copyFlutterXcframework: true,
+          vendorDir: workspace.vendor,
+          copyPluginPackages: spmPlugins.map((plugin) => plugin.name).toSet(),
           deploymentTarget: deploymentTarget,
           verbose: verbose,
         );
 
         final pluginsDir = p.join(outputDir, 'Plugins');
-        final scratchPath = p.join(projectRoot, 'build', 'spm');
+        final scratchPath = workspace.scratch;
+        final stagedFlutterXcframework = p.join(
+          outputDir,
+          'Packages',
+          _flutterFrameworkPackageName,
+          'Flutter.xcframework',
+        );
         await _runSwiftBuild(
           outputDir: outputDir,
           pluginsDir: pluginsDir,
           scratchPath: scratchPath,
-          flutterXcframework: flutterXcframework,
+          flutterXcframework: stagedFlutterXcframework,
           interopTargetCandidates: interopTargetCandidates,
           interopConsumers: {
             for (final plugin in spmPlugins)
@@ -419,7 +429,7 @@ abstract final class GeneratedPluginsPackage {
       }
       if (firestore == null) rethrow;
       final vendorFramework = p.join(
-        p.dirname(p.dirname(outputDir)),
+        p.dirname(outputDir),
         'vendor',
         'fb@346daa9f4631',
         'FirebaseFirestoreInternal.xcframework',
@@ -1093,13 +1103,14 @@ abstract final class GeneratedPluginsPackage {
     bool verbose = false,
     bool? copyFlutterXcframework,
     bool? vendorRemotePackages,
+    String? vendorDir,
     Set<String> copyPluginPackages = const {},
   }) async {
     final windows = Platform.isWindows;
     final packagesDir = p.join(outputDir, 'Packages');
     final frameworkDir = p.join(packagesDir, _flutterFrameworkPackageName);
     final pluginsDir = p.join(outputDir, 'Plugins');
-    final vendorDir = p.join(p.dirname(p.dirname(outputDir)), 'vendor');
+    final resolvedVendorDir = vendorDir ?? p.join(outputDir, 'vendor');
     final shouldVendor = vendorRemotePackages ?? true;
 
     await Directory(packagesDir).create(recursive: true);
@@ -1121,7 +1132,7 @@ abstract final class GeneratedPluginsPackage {
         alias: packageAlias,
         target: plugin.swiftPackageDir,
         platformDir: plugin.platformDirectoryName,
-        vendorDir: shouldVendor ? vendorDir : null,
+        vendorDir: shouldVendor ? resolvedVendorDir : null,
         packageTargets: pluginTargets,
         copySources: copyPluginPackages.contains(plugin.name),
         vendorNormalizationCache: vendorNormalizationCache,

--- a/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
@@ -920,149 +920,199 @@ abstract final class GeneratedPluginsPackage {
     final artifactsRoot = p.join(scratchPath, 'artifacts');
     final artifacts = Directory(artifactsRoot);
     final vendor = Directory(vendorDir);
-    if (!artifacts.existsSync() || !vendor.existsSync()) return false;
+    final checkouts = Directory(p.join(scratchPath, 'checkouts'));
+    if (!artifacts.existsSync() ||
+        (!vendor.existsSync() && !checkouts.existsSync())) {
+      return false;
+    }
     final preparer = SwiftPmBinaryArtifactPreparer(
       store: SwiftPmBinaryArtifactStore(binaryArtifactStore),
     );
     var changed = false;
     final remove = removeDestination ?? _deleteEntity;
     final write = writeManifest ?? _writeAtomic;
-    await for (final package in vendor.list(followLinks: false)) {
-      if (package is! Directory) continue;
-      final packageIdentity = packageIdentities[p.normalize(package.path)];
-      if (packageIdentity == null) continue;
-      await for (final entity in package.list(followLinks: false)) {
-        if (entity is! File) continue;
-        final fileName = p.basename(entity.path);
-        if (fileName != 'Package.swift' &&
-            !(fileName.startsWith('Package@') && fileName.endsWith('.swift'))) {
-          continue;
-        }
-        final originalBytes = await entity.readAsBytes();
-        var manifest = utf8.decode(originalBytes);
-        final createdDestinations =
-            <
-              String,
-              ({String source, SwiftPmBinaryArtifactPublication publication})
-            >{};
-        final provenance = scanBinaryArtifactProvenance(
-          packageIdentity: packageIdentity,
-          manifestPath: entity.path,
-          manifest: manifest,
-        );
-        for (final candidate in provenance.reversed) {
-          final targetDirectory = Directory(
-            p.join(artifactsRoot, packageIdentity, candidate.target.name),
-          );
-          if (!targetDirectory.existsSync()) continue;
-          final archives = targetDirectory
-              .listSync(followLinks: false)
-              .whereType<File>()
-              .where((file) => file.path.toLowerCase().endsWith('.zip'))
-              .toList();
-          final verified = <SwiftPmBinaryArtifactEntry>[];
-          for (final archive in archives) {
-            try {
-              verified.add(
-                await preparer.prepareDownloadedArchive(
-                  target: candidate.target,
-                  archive: archive,
-                ),
-              );
-            } on FlutterBuildError catch (error) {
-              if (error.isSecurityFailure) rethrow;
-            }
+    final packageRoots = <Directory>[
+      if (vendor.existsSync()) vendor,
+      if (checkouts.existsSync()) checkouts,
+    ];
+    for (final packageRoot in packageRoots) {
+      await for (final package in packageRoot.list(followLinks: false)) {
+        if (package is! Directory) continue;
+        final packageIdentity =
+            packageIdentities[p.normalize(package.path)] ??
+            p.basename(package.path).toLowerCase();
+
+        await for (final entity in package.list(followLinks: false)) {
+          if (entity is! File) continue;
+          final fileName = p.basename(entity.path);
+          if (fileName != 'Package.swift' &&
+              !(fileName.startsWith('Package@') &&
+                  fileName.endsWith('.swift'))) {
+            continue;
           }
-          if (verified.length != 1) continue;
-          final relative = p.join(
-            'xcross-artifacts',
-            candidate.target.checksum.toLowerCase(),
-            candidate.target.name,
-            p.basename(verified.single.artifactPath),
+          final originalBytes = await entity.readAsBytes();
+          var manifest = utf8.decode(originalBytes);
+          final createdDestinations =
+              <
+                String,
+                ({String source, SwiftPmBinaryArtifactPublication publication})
+              >{};
+          final provenance = scanBinaryArtifactProvenance(
+            packageIdentity: packageIdentity,
+            manifestPath: entity.path,
+            manifest: manifest,
           );
-          final destination = p.join(package.path, relative);
-          final fallbackDestination = _binaryArtifactFallbackPath(
-            binaryArtifactFallback,
-            candidate.target.checksum,
-            candidate.target.name,
-            p.basename(verified.single.artifactPath),
-          );
-          final existed =
-              FileSystemEntity.typeSync(destination, followLinks: false) !=
-              FileSystemEntityType.notFound;
-          SwiftPmBinaryArtifactPublication? publication;
-          if (existed && packageLocalArtifactJunctionCapability) {
-            if (await preparer.validatesBinaryArtifactDestination(
-              source: verified.single.artifactPath,
-              destination: destination,
-              alias: true,
-            )) {
-              publication = SwiftPmBinaryArtifactPublication.reused;
-            }
-          } else if (await preparer.validatesMaterializedBinaryArtifact(
-            source: verified.single.artifactPath,
-            destination: fallbackDestination,
-          )) {
-            publication = SwiftPmBinaryArtifactPublication.reused;
-          } else {
-            publication = await recoverFinalBinaryArtifact(
-              provenance: candidate,
-              preparedArtifactPath: verified.single.artifactPath,
-              binaryArtifactStore: binaryArtifactStore,
-              destination: destination,
-              materializedDestination: fallbackDestination,
-              attemptState: attemptState,
-              packageLocalArtifactJunctionCapability:
-                  packageLocalArtifactJunctionCapability,
-              createAlias: createAlias,
-              materialize: materialize,
-              windows: windows,
+          for (final candidate in provenance.reversed) {
+            final targetDirectory = Directory(
+              p.join(artifactsRoot, packageIdentity, candidate.target.name),
             );
-          }
-          if (publication == null) continue;
-          final usedAlias =
-              packageLocalArtifactJunctionCapability &&
-              await preparer.validatesBinaryArtifactDestination(
+            if (!targetDirectory.existsSync()) continue;
+            final archives = targetDirectory
+                .listSync(followLinks: false)
+                .whereType<File>()
+                .where((file) => file.path.toLowerCase().endsWith('.zip'))
+                .toList();
+            final verified = <SwiftPmBinaryArtifactEntry>[];
+            for (final archive in archives) {
+              try {
+                verified.add(
+                  await preparer.prepareDownloadedArchive(
+                    target: candidate.target,
+                    archive: archive,
+                  ),
+                );
+              } on FlutterBuildError catch (error) {
+                if (error.isSecurityFailure) rethrow;
+              }
+            }
+            if (verified.isEmpty) {
+              final extracted = targetDirectory
+                  .listSync(followLinks: false)
+                  .whereType<Directory>()
+                  .where(
+                    (directory) =>
+                        directory.path.toLowerCase().endsWith('.xcframework'),
+                  )
+                  .toList();
+              if (extracted.length == 1) {
+                final staging = await Directory(
+                  binaryArtifactStore,
+                ).createTemp('.extracted-');
+                try {
+                  final artifactName = p.basename(extracted.single.path);
+                  await _copyResolvedArtifactTree(
+                    extracted.single.path,
+                    p.join(staging.path, artifactName),
+                    includeTopLevel: (name) =>
+                        name == 'Info.plist' || name == 'ios-arm64',
+                  );
+
+                  verified.add(
+                    await SwiftPmBinaryArtifactStore(
+                      binaryArtifactStore,
+                    ).publishTarget(
+                      checksum: candidate.target.checksum,
+                      targetName: candidate.target.name,
+                      stagingRoot: staging,
+                      artifactDirectoryName: artifactName,
+                      metadata: const {'source': 'swiftpm-extracted-artifact'},
+                    ),
+                  );
+                } finally {
+                  if (staging.existsSync()) {
+                    await staging.delete(recursive: true);
+                  }
+                }
+              }
+            }
+            if (verified.length != 1) continue;
+            final relative = p.join(
+              '.xa',
+              candidate.target.checksum.toLowerCase().substring(0, 16),
+              p.basename(verified.single.artifactPath),
+            );
+
+            final destination = p.join(package.path, relative);
+            final fallbackDestination = destination;
+
+            final existed =
+                FileSystemEntity.typeSync(destination, followLinks: false) !=
+                FileSystemEntityType.notFound;
+            SwiftPmBinaryArtifactPublication? publication;
+            if (existed && packageLocalArtifactJunctionCapability) {
+              if (await preparer.validatesBinaryArtifactDestination(
                 source: verified.single.artifactPath,
                 destination: destination,
                 alias: true,
-              );
-          final publishedDestination = usedAlias
-              ? destination
-              : fallbackDestination;
-          if (publication == SwiftPmBinaryArtifactPublication.published()) {
-            createdDestinations[publishedDestination] = (
-              source: verified.single.artifactPath,
-              publication: publication,
-            );
-          }
-          manifest = SwiftPmBinaryTargetManifest.rewriteToLocalPaths(manifest, {
-            candidate.target: usedAlias
-                ? relative
-                : _swiftPath(fallbackDestination),
-          });
-          changed = true;
-        }
-        if (!_sameBytes(originalBytes, utf8.encode(manifest))) {
-          try {
-            await write(entity.path, utf8.encode(manifest));
-          } on Object {
-            for (final created
-                in createdDestinations.entries.toList().reversed) {
-              if (removeDestination != null) {
-                await remove(created.key);
-              } else if (packageLocalArtifactJunctionCapability &&
-                  p.isWithin(package.path, created.key)) {
-                await preparer.removeBinaryArtifactAlias(created.key);
-              } else {
-                await preparer.removeMaterializedBinaryArtifact(
-                  source: created.value.source,
-                  destination: created.key,
-                  publication: created.value.publication,
-                );
+              )) {
+                publication = SwiftPmBinaryArtifactPublication.reused;
               }
+            } else if (await preparer.validatesMaterializedBinaryArtifact(
+              source: verified.single.artifactPath,
+              destination: fallbackDestination,
+            )) {
+              publication = SwiftPmBinaryArtifactPublication.reused;
+            } else {
+              publication = await recoverFinalBinaryArtifact(
+                provenance: candidate,
+                preparedArtifactPath: verified.single.artifactPath,
+                binaryArtifactStore: binaryArtifactStore,
+                destination: destination,
+                materializedDestination: fallbackDestination,
+                attemptState: attemptState,
+                packageLocalArtifactJunctionCapability:
+                    packageLocalArtifactJunctionCapability,
+                createAlias: createAlias,
+                materialize: materialize,
+                windows: windows,
+              );
             }
-            rethrow;
+            if (publication == null) continue;
+            final usedAlias =
+                packageLocalArtifactJunctionCapability &&
+                await preparer.validatesBinaryArtifactDestination(
+                  source: verified.single.artifactPath,
+                  destination: destination,
+                  alias: true,
+                );
+            final publishedDestination = usedAlias
+                ? destination
+                : fallbackDestination;
+            if (publication == SwiftPmBinaryArtifactPublication.published()) {
+              createdDestinations[publishedDestination] = (
+                source: verified.single.artifactPath,
+                publication: publication,
+              );
+            }
+            manifest = SwiftPmBinaryTargetManifest.rewriteToLocalPaths(
+              manifest,
+              {candidate.target: relative},
+            );
+
+            changed = true;
+          }
+          if (!_sameBytes(originalBytes, utf8.encode(manifest))) {
+            try {
+              await _clearPlaceholderAttributes(entity.path);
+              await write(entity.path, utf8.encode(manifest));
+            } on Object {
+              for (final created
+                  in createdDestinations.entries.toList().reversed) {
+                if (removeDestination != null) {
+                  await remove(created.key);
+                } else if (packageLocalArtifactJunctionCapability &&
+                    p.isWithin(package.path, created.key)) {
+                  await preparer.removeBinaryArtifactAlias(created.key);
+                } else {
+                  await preparer.removeMaterializedBinaryArtifact(
+                    source: created.value.source,
+                    destination: created.key,
+                    publication: created.value.publication,
+                  );
+                }
+              }
+              rethrow;
+            }
           }
         }
       }
@@ -4368,7 +4418,54 @@ $diagnosticsStart$registrations$diagnosticsEnd}
     return true;
   }
 
+  static Future<void> _copyResolvedArtifactTree(
+    String source,
+    String destination, {
+    String? artifactRoot,
+    bool Function(String name)? includeTopLevel,
+  }) async {
+    final root = artifactRoot ?? p.normalize(p.absolute(source));
+    await Directory(destination).create(recursive: true);
+    await for (final entity in Directory(source).list(followLinks: false)) {
+      final name = p.basename(entity.path);
+      if (artifactRoot == null &&
+          includeTopLevel != null &&
+          !includeTopLevel(name)) {
+        continue;
+      }
+      final target = p.join(destination, name);
+
+      final resolved = p.normalize(
+        p.absolute(
+          entity is Link ? entity.resolveSymbolicLinksSync() : entity.path,
+        ),
+      );
+      if (!p.equals(root, resolved) && !p.isWithin(root, resolved)) {
+        throw FlutterBuildError(
+          'SwiftPM binary artifact link escapes its artifact root',
+          isSecurityFailure: true,
+        );
+      }
+      if (Directory(resolved).existsSync()) {
+        await _copyResolvedArtifactTree(
+          resolved,
+          target,
+          artifactRoot: root,
+          includeTopLevel: includeTopLevel,
+        );
+      } else if (File(resolved).existsSync()) {
+        await File(resolved).copy(target);
+      } else {
+        throw FlutterBuildError(
+          'SwiftPM binary artifact contains an unresolved link',
+          isSecurityFailure: true,
+        );
+      }
+    }
+  }
+
   /// Mirrors [source] into [destination], resolving links to their
+
   /// targets, rewriting only differing files, and pruning entries the
   /// source no longer has. [preserve] names top-level entries the caller
   /// owns; [excludedSourcePath] guards against copying a destination that
@@ -4508,13 +4605,6 @@ $diagnosticsStart$registrations$diagnosticsEnd}
 
     await Link(alias).create(p.relative(target, from: p.dirname(alias)));
   }
-
-  static String _binaryArtifactFallbackPath(
-    String fallback,
-    String checksum,
-    String target,
-    String artifact,
-  ) => p.join(fallback, checksum.toLowerCase(), target, artifact);
 
   static String _jsonPath(String path) => path.replaceAll(r'\', '/');
 

--- a/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
@@ -134,7 +134,6 @@ abstract final class GeneratedPluginsPackage {
         };
 
         await writeGeneratedPackages(
-
           outputDir: outputDir,
           plugins: spmPlugins,
           flutterXcframework: flutterXcframework,
@@ -175,7 +174,6 @@ abstract final class GeneratedPluginsPackage {
         final result = await discoverAndRewriteDylibs(targetDebugDir);
         await _writeStable(fingerprintFile.path, fingerprint);
         return result;
-
       });
 
   @visibleForTesting
@@ -223,19 +221,24 @@ abstract final class GeneratedPluginsPackage {
       }
     }
 
-    for (final plugin in plugins.toList()..sort((a, b) => a.name.compareTo(b.name))) {
+    for (final plugin
+        in plugins.toList()..sort((a, b) => a.name.compareTo(b.name))) {
       add(plugin.name);
       add(plugin.platformDirectoryName);
       await addTree(plugin.packageRoot);
     }
     final frameworkFiles = <File>[];
-    await for (final entity in Directory(flutterXcframework).list(recursive: true)) {
+    await for (final entity in Directory(
+      flutterXcframework,
+    ).list(recursive: true)) {
       if (entity is File) frameworkFiles.add(entity);
     }
     frameworkFiles.sort((a, b) => a.path.compareTo(b.path));
     for (final file in frameworkFiles) {
       final stat = file.statSync();
-      add(p.relative(file.path, from: flutterXcframework).replaceAll(r'\', '/'));
+      add(
+        p.relative(file.path, from: flutterXcframework).replaceAll(r'\', '/'),
+      );
       add(stat.size.toString());
       add(stat.modified.microsecondsSinceEpoch.toString());
     }
@@ -344,6 +347,7 @@ abstract final class GeneratedPluginsPackage {
         ),
         ...selection,
       ];
+
       if (windows) arguments.removeAt(0);
       Future<void> invoke() => ProcessRunner.runChecked(
         swiftBuild,
@@ -481,7 +485,6 @@ abstract final class GeneratedPluginsPackage {
     required String vendorDir,
     required Map<String, String>? environment,
   }) async {
-
     Future<void> resolve() => ProcessRunner.runChecked(
       swift,
       swiftResolveArguments(
@@ -603,7 +606,6 @@ abstract final class GeneratedPluginsPackage {
   @visibleForTesting
   static Future<bool> normalizeResolvedPackageManifests(
     String scratchPath,
-
   ) async {
     final checkouts = Directory(p.join(scratchPath, 'checkouts'));
     var changed = false;
@@ -647,11 +649,8 @@ abstract final class GeneratedPluginsPackage {
         targetBuildDir,
         candidates: interopTargetCandidates,
       );
-      if (failure != null &&
-          !(windows ?? Platform.isWindows) &&
-          !isMissingSwiftInteropHeaderFailure(failure, targets)) {
-        return false;
-      }
+      if (failure != null && targets.isEmpty) return false;
+
       for (final target in targets) {
         await buildTarget(target);
       }

--- a/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
@@ -3912,7 +3912,9 @@ let package = Package(
       <int>[],
       (bytes, chunk) => bytes..addAll(chunk),
     );
-    final error = await process.stderr.transform(utf8.decoder).join();
+    final error = await process.stderr
+        .transform(const Utf8Decoder(allowMalformed: true))
+        .join();
     final exitCode = await process.exitCode;
     if (exitCode != 0) {
       throw FlutterBuildError(

--- a/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
@@ -1,12 +1,12 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:archive/archive.dart';
 import 'package:cli_kit/cli_kit.dart';
 import 'package:crypto/crypto.dart';
 import 'package:darwin_sdk_kit/darwin_sdk_kit.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
+import 'package:propertylistserialization/propertylistserialization.dart';
 import 'package:xcross/src/cli/basic/sdk_install.dart';
 import 'package:xcross/src/flutter/build/internal/swiftpm_workspace.dart';
 import 'package:xcross/src/flutter/build/ios_deployment_target.dart';
@@ -15,6 +15,9 @@ import 'package:xcross/src/flutter/build/ios_plugins.dart';
 import 'package:xcross/src/flutter/build/macho_dylib_rewriter.dart';
 import 'package:xcross/src/flutter/build/preview_macro_stub_source.dart';
 import 'package:xcross/src/flutter/build/swift_package_host_patches.dart';
+import 'package:xcross/src/flutter/build/swiftpm_binary_artifact_preparer.dart';
+import 'package:xcross/src/flutter/build/swiftpm_binary_artifact_store.dart';
+import 'package:xcross/src/flutter/build/swiftpm_binary_target.dart';
 import 'package:xcross/src/flutter/constants.dart';
 import 'package:xcross/src/flutter/errors.dart';
 
@@ -30,6 +33,61 @@ const String _flutterFrameworkPackageName = 'FlutterFramework';
 const String _pluginsProductName = 'FlutterPluginsGenerated';
 
 /// Result of building the aggregate Flutter-plugins Swift package.
+typedef SwiftPmDependencyRefEvaluator =
+    Future<Map<String, String>> Function(
+      String packageDirectory, {
+      required String? scratchPath,
+      required String? binaryArtifactStore,
+      required String? binaryArtifactFallback,
+      required bool swiftPmArtifactJunctionCapability,
+      required bool packageLocalArtifactJunctionCapability,
+      required List<SwiftPmPackageDependency> dependencies,
+    });
+
+typedef PrepareSwiftPmBinaryArtifact =
+    Future<SwiftPmPreparedBinaryArtifact> Function(
+      SwiftPmRemoteBinaryTarget target,
+    );
+typedef CreateSwiftPmBinaryAlias =
+    Future<void> Function({required String alias, required String target});
+typedef MaterializeSwiftPmBinaryArtifact =
+    Future<SwiftPmBinaryArtifactPublication> Function({
+      required String source,
+      required String destination,
+    });
+
+final class SwiftPmPackageDependency {
+  const SwiftPmPackageDependency({
+    required this.name,
+    required this.url,
+    required this.identity,
+    required this.match,
+  });
+
+  final String? name;
+  final String url;
+  final String identity;
+  final String match;
+}
+
+final class SwiftPmBinaryArtifactProvenance {
+  const SwiftPmBinaryArtifactProvenance({
+    required this.packageIdentity,
+    required this.target,
+    required this.manifestPath,
+  });
+
+  final String packageIdentity;
+  final SwiftPmRemoteBinaryTarget target;
+  final String manifestPath;
+}
+
+final class SwiftPmBinaryAttemptState {
+  final Set<String> bootstrapRecovered = {};
+  final Set<String> finalRecovered = {};
+  final Set<String> copied = {};
+}
+
 final class GeneratedPluginsBuildResult {
   /// Creates a result wrapping the built dylib paths.
   const GeneratedPluginsBuildResult({
@@ -63,6 +121,9 @@ final class GeneratedPluginsBuildResult {
 /// *dynamic* library, so its produced dylibs can be embedded under
 /// `Frameworks` and Runner can link only the aggregate instead of hand-deriving
 /// Swift-runtime autolink flags for a static library.
+typedef ArtifactJunctionCapabilityResolver =
+    Future<({bool swiftPmArtifact, bool packageLocalArtifact})> Function();
+
 abstract final class GeneratedPluginsPackage {
   /// Builds the aggregate dylib for the subset of [plugins] that use Swift
   /// Package Manager. Returns null if there is nothing to build.
@@ -79,6 +140,17 @@ abstract final class GeneratedPluginsPackage {
     required String flutterXcframework,
     required IosDeploymentTarget deploymentTarget,
     bool verbose = false,
+    bool swiftPmArtifactJunctionCapability = false,
+    bool packageLocalArtifactJunctionCapability = false,
+    ArtifactJunctionCapabilityResolver? artifactJunctionCapabilityResolver,
+    SwiftPmDependencyRefEvaluator? evaluateDependencyRefs,
+    Future<void> Function(
+      String git,
+      String url,
+      String ref,
+      String destination,
+    )?
+    clonePackage,
   }) =>
       Log.logStep('Building Flutter plugins (Swift Package Manager)', () async {
         final outputDir = workspace.packages;
@@ -86,6 +158,12 @@ abstract final class GeneratedPluginsPackage {
             .where((plugin) => plugin.usesSwiftPackageManager)
             .toList();
         if (spmPlugins.isEmpty) return null;
+        final capabilities =
+            await artifactJunctionCapabilityResolver?.call() ??
+            (
+              swiftPmArtifact: swiftPmArtifactJunctionCapability,
+              packageLocalArtifact: packageLocalArtifactJunctionCapability,
+            );
 
         Log.logTrace(
           'projectRoot=$projectRoot '
@@ -139,6 +217,14 @@ abstract final class GeneratedPluginsPackage {
           copyPluginPackages: spmPlugins.map((plugin) => plugin.name).toSet(),
           deploymentTarget: deploymentTarget,
           verbose: verbose,
+          scratchPath: workspace.scratch,
+          binaryArtifactStore: workspace.binaryArtifactStore,
+          binaryArtifactFallback: workspace.binaryArtifactFallback,
+          swiftPmArtifactJunctionCapability: capabilities.swiftPmArtifact,
+          packageLocalArtifactJunctionCapability:
+              capabilities.packageLocalArtifact,
+          evaluateDependencyRefs: evaluateDependencyRefs,
+          clonePackage: clonePackage,
         );
 
         final pluginsDir = p.join(outputDir, 'Plugins');
@@ -166,6 +252,9 @@ abstract final class GeneratedPluginsPackage {
                   p.basename(plugin.swiftPackageDir),
                 ): products,
           },
+          swiftPmArtifactJunctionCapability: capabilities.swiftPmArtifact,
+          packageLocalArtifactJunctionCapability:
+              capabilities.packageLocalArtifact,
         );
 
         final result = await discoverAndRewriteDylibs(targetDebugDir);
@@ -192,13 +281,26 @@ abstract final class GeneratedPluginsPackage {
       input.add(const [0]);
     }
 
-    add('xcross-swiftpm-build-v1');
+    add('xcross-swiftpm-build-v2');
     add(deploymentTarget.version);
     add(verbose.toString());
-    final swift = toolchainIdentity ?? await ProcessRunner.locateTool('swift');
-    add(swift);
-    final sdk = sdkIdentity ?? DarwinSdk.current()?.swiftSdkPath;
-    add(sdk ?? '');
+    final sdk = DarwinSdk.current();
+    if (toolchainIdentity == null && sdk == null) {
+      throw FlutterBuildError(
+        'Darwin Swift SDK not found. Run '
+        '`xcross sdk install <Xcode.xip>` first.',
+      );
+    }
+    final resolvedToolchainIdentity =
+        toolchainIdentity ??
+        jsonEncode(await resolveBuildToolchainIdentity(sdk!));
+    add(resolvedToolchainIdentity);
+    final resolvedSdkIdentity =
+        sdkIdentity ??
+        (sdk == null
+            ? ''
+            : jsonEncode(await SdkInstall.sdkBuildIdentity(sdk.swiftSdkPath)));
+    add(resolvedSdkIdentity);
 
     Future<void> addTree(String root) async {
       final directory = Directory(root);
@@ -253,6 +355,8 @@ abstract final class GeneratedPluginsPackage {
     required String flutterXcframework,
     required Set<String> interopTargetCandidates,
     required Map<String, Set<String>> interopConsumers,
+    bool swiftPmArtifactJunctionCapability = false,
+    bool packageLocalArtifactJunctionCapability = false,
   }) async {
     final outputDir = workspace.packages;
     final sdk = DarwinSdk.current();
@@ -324,6 +428,11 @@ abstract final class GeneratedPluginsPackage {
         swiftSdksPath: swiftSdksPath,
         toolsetPath: toolsetPath,
         vendorDir: workspace.vendor,
+        binaryArtifactStore: workspace.binaryArtifactStore,
+        binaryArtifactFallback: workspace.binaryArtifactFallback,
+        swiftPmArtifactJunctionCapability: swiftPmArtifactJunctionCapability,
+        packageLocalArtifactJunctionCapability:
+            packageLocalArtifactJunctionCapability,
         environment: environment,
       );
     }
@@ -481,6 +590,10 @@ abstract final class GeneratedPluginsPackage {
     required String swiftSdksPath,
     required String toolsetPath,
     required String vendorDir,
+    required String binaryArtifactStore,
+    required String binaryArtifactFallback,
+    required bool swiftPmArtifactJunctionCapability,
+    required bool packageLocalArtifactJunctionCapability,
     required Map<String, String>? environment,
   }) async {
     Future<void> resolve() => ProcessRunner.runChecked(
@@ -495,92 +608,464 @@ abstract final class GeneratedPluginsPackage {
       inheritStdio: Log.isVerbose,
       label: 'swift package resolve',
     );
+    final attemptState = SwiftPmBinaryAttemptState();
+    final packageIdentities = await _packageIdentitiesByDirectory(pluginsDir);
+    Future<bool> recover() => stageExtractedBinaryArtifacts(
+      scratchPath: scratchPath,
+      vendorDir: vendorDir,
+      packageIdentities: packageIdentities,
+      binaryArtifactStore: binaryArtifactStore,
+      binaryArtifactFallback: binaryArtifactFallback,
+      attemptState: attemptState,
+      packageLocalArtifactJunctionCapability:
+          packageLocalArtifactJunctionCapability,
+      windows: true,
+    );
+    await resolveWindowsDependencies(
+      resolve: resolve,
+      recoverBootstrap: recover,
+      materialize: () => materializeCheckoutSymlinks(scratchPath),
+      normalize: () => normalizeResolvedPackageManifests(scratchPath),
+      recoverFinal: recover,
+    );
+  }
+
+  @visibleForTesting
+  static Future<void> resolveWindowsDependencies({
+    required Future<void> Function() resolve,
+    required Future<bool> Function() recoverBootstrap,
+    required Future<bool> Function() materialize,
+    required Future<bool> Function() normalize,
+    required Future<bool> Function() recoverFinal,
+  }) async {
+    await resolveWithFinalBinaryRecovery(
+      resolve: resolve,
+      recover: recoverBootstrap,
+    );
+    final changed = await materialize() | await normalize();
+    if (changed) {
+      await resolveWithFinalBinaryRecovery(
+        resolve: resolve,
+        recover: recoverFinal,
+      );
+    }
+  }
+
+  @visibleForTesting
+  static Future<void> prepareSupportedBinaryArtifacts({
+    required String packageRoot,
+    required String binaryArtifactStore,
+    required String binaryArtifactFallback,
+    required bool packageLocalArtifactJunctionCapability,
+    PrepareSwiftPmBinaryArtifact? prepare,
+    CreateSwiftPmBinaryAlias? createAlias,
+    MaterializeSwiftPmBinaryArtifact? materialize,
+    Future<void> Function(String alias)? removeAlias,
+    Future<void> Function(String path, List<int> bytes)? writeManifest,
+    bool? windows,
+  }) async {
+    if (!(windows ?? Platform.isWindows)) return;
+    final root = Directory(packageRoot);
+    if (!root.existsSync()) return;
+    final store = SwiftPmBinaryArtifactStore(binaryArtifactStore);
+    final preparer = SwiftPmBinaryArtifactPreparer(store: store);
+    final runPrepare = prepare ?? preparer.prepare;
+    final create = createAlias ?? preparer.createBinaryArtifactJunction;
+    final copy = materialize ?? preparer.materializeBinaryArtifact;
+    final remove = removeAlias ?? preparer.removeBinaryArtifactAlias;
+    final write = writeManifest ?? _writeAtomic;
+    final manifests = root
+        .listSync(recursive: true, followLinks: false)
+        .whereType<File>()
+        .where((file) {
+          final name = p.basename(file.path);
+          return name == 'Package.swift' ||
+              (name.startsWith('Package@') && name.endsWith('.swift'));
+        });
+    for (final manifestFile in manifests) {
+      final original = await manifestFile.readAsString();
+      final targets = SwiftPmBinaryTargetManifest.discover(original);
+      if (targets.isEmpty) continue;
+      final createdDestinations =
+          <
+            String,
+            ({String source, SwiftPmBinaryArtifactPublication? publication})
+          >{};
+      final localPaths = <SwiftPmRemoteBinaryTarget, String>{};
+      try {
+        for (final target in targets) {
+          String? createdDestination;
+          try {
+            final started = Stopwatch()..start();
+            final reused = await store.findCompleteTarget(
+              target.checksum,
+              target.name,
+            );
+            final hadArchive = File(
+              store.archivePath(target.checksum),
+            ).existsSync();
+            final result = await runPrepare(target);
+            _traceBinaryOperation(
+              target: target.name,
+              operation: reused != null
+                  ? 'reuse'
+                  : hadArchive
+                  ? 'extract'
+                  : 'download',
+              archiveBytes: _fileBytes(store.archivePath(target.checksum)),
+              extractedBytes: _directoryBytes(result.entry.artifactPath),
+              elapsedMilliseconds: started.elapsedMilliseconds,
+              attempt: 0,
+            );
+            final artifact = result.entry.artifactPath;
+            var aliased = false;
+            if (packageLocalArtifactJunctionCapability) {
+              final relative = p.join(
+                'xcross-artifacts',
+                target.checksum.toLowerCase(),
+                target.name,
+                p.basename(artifact),
+              );
+              final alias = p.join(manifestFile.parent.path, relative);
+              await Directory(p.dirname(alias)).create(recursive: true);
+              try {
+                final existed =
+                    FileSystemEntity.typeSync(alias, followLinks: false) !=
+                    FileSystemEntityType.notFound;
+                if (existed) {
+                  if (!await preparer.validatesBinaryArtifactDestination(
+                    source: artifact,
+                    destination: alias,
+                    alias: true,
+                  )) {
+                    throw FileSystemException(
+                      'SwiftPM binary artifact alias already exists but is not managed for the expected artifact',
+                      alias,
+                    );
+                  }
+                } else {
+                  await create(alias: alias, target: artifact);
+                  createdDestination = alias;
+                  createdDestinations[alias] = (
+                    source: artifact,
+                    publication: null,
+                  );
+                }
+                localPaths[target] = relative;
+                aliased = true;
+              } on Object {
+                if (createdDestination == alias) {
+                  await remove(alias);
+                  createdDestinations.remove(alias);
+                  createdDestination = null;
+                }
+              }
+            }
+            if (!aliased) {
+              final destination = _binaryArtifactFallbackPath(
+                binaryArtifactFallback,
+                target.checksum,
+                target.name,
+                p.basename(artifact),
+              );
+              final publication = await copy(
+                source: artifact,
+                destination: destination,
+              );
+              if (publication == SwiftPmBinaryArtifactPublication.published()) {
+                createdDestination = destination;
+                createdDestinations[destination] = (
+                  source: artifact,
+                  publication: publication,
+                );
+              }
+              localPaths[target] = _swiftPath(destination);
+            }
+          } on FlutterBuildError catch (error) {
+            if (error.isSecurityFailure) rethrow;
+            localPaths.remove(target);
+            if (createdDestination != null) {
+              final created = createdDestinations.remove(createdDestination)!;
+              if (created.publication == null) {
+                await remove(createdDestination);
+              } else {
+                await preparer.removeMaterializedBinaryArtifact(
+                  source: created.source,
+                  destination: createdDestination,
+                  publication: created.publication!,
+                );
+              }
+            }
+          }
+        }
+        if (localPaths.isNotEmpty) {
+          final rewritten = SwiftPmBinaryTargetManifest.rewriteToLocalPaths(
+            original,
+            localPaths,
+          );
+          await write(manifestFile.path, utf8.encode(rewritten));
+        }
+      } on Object {
+        for (final created in createdDestinations.entries.toList().reversed) {
+          if (created.value.publication == null) {
+            await remove(created.key);
+          } else {
+            await preparer.removeMaterializedBinaryArtifact(
+              source: created.value.source,
+              destination: created.key,
+              publication: created.value.publication!,
+            );
+          }
+        }
+        rethrow;
+      }
+    }
+  }
+
+  @visibleForTesting
+  static Future<void> resolveWithFinalBinaryRecovery({
+    required Future<void> Function() resolve,
+    required Future<bool> Function() recover,
+  }) async {
     try {
       await resolve();
     } on Object {
-      if (!await repairWindowsBinaryArtifacts(scratchPath)) rethrow;
-      await stageExtractedBinaryArtifacts(
-        scratchPath: scratchPath,
-        vendorDir: vendorDir,
-      );
+      if (!await recover()) rethrow;
       await resolve();
     }
+  }
 
-    final materialized = await materializeCheckoutSymlinks(scratchPath);
-    final normalized = await normalizeResolvedPackageManifests(scratchPath);
-    if (materialized || normalized) await resolve();
+  @visibleForTesting
+  static Future<SwiftPmBinaryArtifactPublication?> recoverFinalBinaryArtifact({
+    required SwiftPmBinaryArtifactProvenance provenance,
+    required String preparedArtifactPath,
+    required String binaryArtifactStore,
+    required String destination,
+    required SwiftPmBinaryAttemptState attemptState,
+    required bool packageLocalArtifactJunctionCapability,
+    String? materializedDestination,
+    CreateSwiftPmBinaryAlias? createAlias,
+    MaterializeSwiftPmBinaryArtifact? materialize,
+    StartBinaryCopy? materializeStartProcess,
+    bool? windows,
+  }) async {
+    if (!(windows ?? Platform.isWindows)) return null;
+    final key = binaryArtifactAttemptKey(provenance, windows: windows);
+    if (attemptState.finalRecovered.contains(key)) return null;
+    attemptState.finalRecovered.add(key);
+    final preparer = SwiftPmBinaryArtifactPreparer(
+      store: SwiftPmBinaryArtifactStore(binaryArtifactStore),
+    );
+    final create = createAlias ?? preparer.createBinaryArtifactJunction;
+    final copy =
+        materialize ??
+        ({required source, required destination}) =>
+            preparer.materializeBinaryArtifact(
+              source: source,
+              destination: destination,
+              startProcess: materializeStartProcess,
+            );
+    if (packageLocalArtifactJunctionCapability) {
+      try {
+        final started = Stopwatch()..start();
+        await create(alias: destination, target: preparedArtifactPath);
+        _traceBinaryOperation(
+          target: provenance.target.name,
+          operation: 'recover',
+          extractedBytes: _directoryBytes(preparedArtifactPath),
+          elapsedMilliseconds: started.elapsedMilliseconds,
+          attempt: 1,
+        );
+        return SwiftPmBinaryArtifactPublication.published();
+      } on Object {
+        if (attemptState.copied.contains(key)) return null;
+      }
+    }
+    if (attemptState.copied.contains(key)) return null;
+    attemptState.copied.add(key);
+    final started = Stopwatch()..start();
+    final publication = await copy(
+      source: preparedArtifactPath,
+      destination: materializedDestination ?? destination,
+    );
+    _traceBinaryOperation(
+      target: provenance.target.name,
+      operation: 'copy',
+      extractedBytes: _directoryBytes(preparedArtifactPath),
+      elapsedMilliseconds: started.elapsedMilliseconds,
+      attempt: 1,
+    );
+    return publication;
   }
 
   @visibleForTesting
   static Future<bool> stageExtractedBinaryArtifacts({
     required String scratchPath,
     required String vendorDir,
+    Map<String, String> packageIdentities = const {},
+    String? binaryArtifactStore,
+    String? binaryArtifactFallback,
+    SwiftPmBinaryAttemptState? attemptState,
+    bool packageLocalArtifactJunctionCapability = false,
+    CreateSwiftPmBinaryAlias? createAlias,
+    MaterializeSwiftPmBinaryArtifact? materialize,
+    Future<void> Function(String destination)? removeDestination,
+    Future<void> Function(String path, List<int> bytes)? writeManifest,
+    bool? windows,
   }) async {
-    final artifacts = Directory(p.join(scratchPath, 'artifacts'));
-    final vendor = Directory(vendorDir);
-    if (!artifacts.existsSync()) return false;
-
-    final repairedFrameworksByTarget = <String, Directory>{};
-    for (final package in artifacts.listSync(followLinks: false)) {
-      if (package is! Directory || p.basename(package.path) == 'extract') {
-        continue;
-      }
-      for (final target in package.listSync(followLinks: false)) {
-        if (target is! Directory) continue;
-        for (final entity in target.listSync(followLinks: false)) {
-          if (entity is! Directory || !entity.path.endsWith('.xcframework')) {
-            continue;
-          }
-          final name = p.basenameWithoutExtension(entity.path);
-          if (File(p.join(entity.path, 'Info.plist')).existsSync()) {
-            repairedFrameworksByTarget[name] = entity;
-          }
-        }
-      }
+    if (!(windows ?? Platform.isWindows)) return false;
+    if (binaryArtifactStore == null ||
+        binaryArtifactFallback == null ||
+        attemptState == null) {
+      return false;
     }
-    if (repairedFrameworksByTarget.isEmpty) return false;
-
-    final manifestSearchRoots = <Directory>[
-      vendor,
-      Directory(p.join(scratchPath, 'checkouts')),
-    ];
+    final artifactsRoot = p.join(scratchPath, 'artifacts');
+    final artifacts = Directory(artifactsRoot);
+    final vendor = Directory(vendorDir);
+    if (!artifacts.existsSync() || !vendor.existsSync()) return false;
+    final preparer = SwiftPmBinaryArtifactPreparer(
+      store: SwiftPmBinaryArtifactStore(binaryArtifactStore),
+    );
     var changed = false;
-    for (final packageRoot in manifestSearchRoots) {
-      if (!packageRoot.existsSync()) continue;
-      await for (final package in packageRoot.list(followLinks: false)) {
-        if (package is! Directory) continue;
-        await for (final entity in package.list(followLinks: false)) {
-          if (entity is! File) continue;
-          final fileName = p.basename(entity.path);
-          if (fileName != 'Package.swift' &&
-              !(fileName.startsWith('Package@') &&
-                  fileName.endsWith('.swift'))) {
-            continue;
-          }
-          var manifest = await entity.readAsString();
-          final original = manifest;
-          for (final call in _swiftCalls(manifest, '.binaryTarget').reversed) {
-            final name = _namedString(call.text, 'name');
-            final framework = name == null
-                ? null
-                : repairedFrameworksByTarget[name];
-            if (framework == null || _namedString(call.text, 'url') == null) {
-              continue;
+    final remove = removeDestination ?? _deleteEntity;
+    final write = writeManifest ?? _writeAtomic;
+    await for (final package in vendor.list(followLinks: false)) {
+      if (package is! Directory) continue;
+      final packageIdentity = packageIdentities[p.normalize(package.path)];
+      if (packageIdentity == null) continue;
+      await for (final entity in package.list(followLinks: false)) {
+        if (entity is! File) continue;
+        final fileName = p.basename(entity.path);
+        if (fileName != 'Package.swift' &&
+            !(fileName.startsWith('Package@') && fileName.endsWith('.swift'))) {
+          continue;
+        }
+        final originalBytes = await entity.readAsBytes();
+        var manifest = utf8.decode(originalBytes);
+        final createdDestinations =
+            <
+              String,
+              ({String source, SwiftPmBinaryArtifactPublication publication})
+            >{};
+        final provenance = scanBinaryArtifactProvenance(
+          packageIdentity: packageIdentity,
+          manifestPath: entity.path,
+          manifest: manifest,
+        );
+        for (final candidate in provenance.reversed) {
+          final targetDirectory = Directory(
+            p.join(artifactsRoot, packageIdentity, candidate.target.name),
+          );
+          if (!targetDirectory.existsSync()) continue;
+          final archives = targetDirectory
+              .listSync(followLinks: false)
+              .whereType<File>()
+              .where((file) => file.path.toLowerCase().endsWith('.zip'))
+              .toList();
+          final verified = <SwiftPmBinaryArtifactEntry>[];
+          for (final archive in archives) {
+            try {
+              verified.add(
+                await preparer.prepareDownloadedArchive(
+                  target: candidate.target,
+                  archive: archive,
+                ),
+              );
+            } on FlutterBuildError catch (error) {
+              if (error.isSecurityFailure) rethrow;
             }
-            final destination = p.join(package.path, '$name.xcframework');
-            await _copyDirectoryPortable(
-              framework.path,
-              destination,
-              failureDescription: 'Could not stage repaired binary artifact',
-            );
-            manifest = manifest.replaceRange(
-              call.start,
-              call.end,
-              '.binaryTarget(name: "$name", path: "$name.xcframework")',
-            );
-            changed = true;
           }
-          if (manifest != original) await _writeStable(entity.path, manifest);
+          if (verified.length != 1) continue;
+          final relative = p.join(
+            'xcross-artifacts',
+            candidate.target.checksum.toLowerCase(),
+            candidate.target.name,
+            p.basename(verified.single.artifactPath),
+          );
+          final destination = p.join(package.path, relative);
+          final fallbackDestination = _binaryArtifactFallbackPath(
+            binaryArtifactFallback,
+            candidate.target.checksum,
+            candidate.target.name,
+            p.basename(verified.single.artifactPath),
+          );
+          final existed =
+              FileSystemEntity.typeSync(destination, followLinks: false) !=
+              FileSystemEntityType.notFound;
+          SwiftPmBinaryArtifactPublication? publication;
+          if (existed && packageLocalArtifactJunctionCapability) {
+            if (await preparer.validatesBinaryArtifactDestination(
+              source: verified.single.artifactPath,
+              destination: destination,
+              alias: true,
+            )) {
+              publication = SwiftPmBinaryArtifactPublication.reused;
+            }
+          } else if (await preparer.validatesMaterializedBinaryArtifact(
+            source: verified.single.artifactPath,
+            destination: fallbackDestination,
+          )) {
+            publication = SwiftPmBinaryArtifactPublication.reused;
+          } else {
+            publication = await recoverFinalBinaryArtifact(
+              provenance: candidate,
+              preparedArtifactPath: verified.single.artifactPath,
+              binaryArtifactStore: binaryArtifactStore,
+              destination: destination,
+              materializedDestination: fallbackDestination,
+              attemptState: attemptState,
+              packageLocalArtifactJunctionCapability:
+                  packageLocalArtifactJunctionCapability,
+              createAlias: createAlias,
+              materialize: materialize,
+              windows: windows,
+            );
+          }
+          if (publication == null) continue;
+          final usedAlias =
+              packageLocalArtifactJunctionCapability &&
+              await preparer.validatesBinaryArtifactDestination(
+                source: verified.single.artifactPath,
+                destination: destination,
+                alias: true,
+              );
+          final publishedDestination = usedAlias
+              ? destination
+              : fallbackDestination;
+          if (publication == SwiftPmBinaryArtifactPublication.published()) {
+            createdDestinations[publishedDestination] = (
+              source: verified.single.artifactPath,
+              publication: publication,
+            );
+          }
+          manifest = SwiftPmBinaryTargetManifest.rewriteToLocalPaths(manifest, {
+            candidate.target: usedAlias
+                ? relative
+                : _swiftPath(fallbackDestination),
+          });
+          changed = true;
+        }
+        if (!_sameBytes(originalBytes, utf8.encode(manifest))) {
+          try {
+            await write(entity.path, utf8.encode(manifest));
+          } on Object {
+            for (final created
+                in createdDestinations.entries.toList().reversed) {
+              if (removeDestination != null) {
+                await remove(created.key);
+              } else if (packageLocalArtifactJunctionCapability &&
+                  p.isWithin(package.path, created.key)) {
+                await preparer.removeBinaryArtifactAlias(created.key);
+              } else {
+                await preparer.removeMaterializedBinaryArtifact(
+                  source: created.value.source,
+                  destination: created.key,
+                  publication: created.value.publication,
+                );
+              }
+            }
+            rethrow;
+          }
         }
       }
     }
@@ -780,7 +1265,6 @@ abstract final class GeneratedPluginsPackage {
 
   /// Process-local settings for Windows SwiftPM dependency checkout and
   /// sentry-cocoa's source-build manifest lane.
-  @visibleForTesting
   static Map<String, String>? swiftProcessEnvironment({bool? windows}) {
     if (!(windows ?? Platform.isWindows)) return null;
     return {
@@ -793,7 +1277,6 @@ abstract final class GeneratedPluginsPackage {
 
   /// Resolves Windows dependencies before tracked symlink placeholders are
   /// materialized and automatic resolution is disabled for the build.
-  @visibleForTesting
   static List<String> swiftResolveArguments({
     required String pluginsDir,
     required String scratchPath,
@@ -933,7 +1416,6 @@ abstract final class GeneratedPluginsPackage {
 
   /// Arguments shared by Linux and Windows SwiftPM builds. SDK-owned compiler
   /// flags stay in SDK metadata; only package-specific flags belong here.
-  @visibleForTesting
   static List<String> swiftBuildArguments({
     required String pluginsDir,
     required String scratchPath,
@@ -1089,6 +1571,15 @@ abstract final class GeneratedPluginsPackage {
     );
   }
 
+  static Future<Map<String, Object>> resolveBuildToolchainIdentity(
+    DarwinSdk sdk,
+  ) async => SdkInstall.swiftPmBuildToolchainIdentity(
+    cCompilerPath: await DarwinSdk.resolveDarwinClang(sdk),
+    cxxCompilerPath: await DarwinSdk.resolveDarwinClang(sdk, name: 'clang++'),
+    linkerPath: await DarwinSdk.resolveLd64Lld(sdk),
+    librarianPath: await resolveLibrarian(),
+  );
+
   /// LLVM's drop-in replacement for Apple's `libtool`.
   static const _libtool = 'llvm-libtool-darwin';
 
@@ -1103,7 +1594,6 @@ abstract final class GeneratedPluginsPackage {
   /// `libtool`"), which no cross host has. Windows overrides the compilers and
   /// the linker on top; Linux passes its linker as a `swift build` flag
   /// instead.
-  @visibleForTesting
   static Future<String> writeToolset({
     required String outputDir,
     required String linkerPath,
@@ -1111,6 +1601,7 @@ abstract final class GeneratedPluginsPackage {
     String? cxxCompilerPath,
     bool? windows,
     Future<String?> Function(String name)? locateTool,
+    String? librarianPath,
   }) async {
     final onWindows = windows ?? Platform.isWindows;
     final output = Directory(outputDir);
@@ -1132,13 +1623,9 @@ abstract final class GeneratedPluginsPackage {
           : _jsonPath(File(path).resolveSymbolicLinksSync());
     }
 
-    final librarian = await _resolveLibrarian(onWindows, resolve);
-    if (librarian == null) {
-      throw FlutterBuildError(
-        'No Darwin-capable archiver found (${_librarians.join(' or ')}). '
-        'Install LLVM and retry.',
-      );
-    }
+    final librarian =
+        librarianPath ??
+        await resolveLibrarian(windows: onWindows, locateTool: locateTool);
     toolset['librarian'] = {'path': librarian};
 
     if (onWindows) {
@@ -1180,6 +1667,30 @@ abstract final class GeneratedPluginsPackage {
   /// on PATH, else the copy sitting next to `llvm-ar` inside LLVM's own bin
   /// directory (Debian and Ubuntu only symlink a subset of LLVM into
   /// `/usr/bin`), else `llvm-ar` itself.
+  @visibleForTesting
+  static Future<String> resolveLibrarian({
+    bool? windows,
+    Future<String?> Function(String name)? locateTool,
+  }) async {
+    final onWindows = windows ?? Platform.isWindows;
+    final locate = locateTool ?? DarwinSdk.locateLlvmTool;
+    Future<String?> resolve(String name) async {
+      final path = await locate(
+        ProcessRunner.hostExecutableName(name, windows: onWindows),
+      );
+      return path == null
+          ? null
+          : _jsonPath(File(path).resolveSymbolicLinksSync());
+    }
+
+    final librarian = await _resolveLibrarian(onWindows, resolve);
+    if (librarian != null) return librarian;
+    throw FlutterBuildError(
+      'No Darwin-capable archiver found (${_librarians.join(' or ')}). '
+      'Install LLVM and retry.',
+    );
+  }
+
   static Future<String?> _resolveLibrarian(
     bool windows,
     Future<String?> Function(String name) resolve,
@@ -1216,6 +1727,19 @@ abstract final class GeneratedPluginsPackage {
     bool? vendorRemotePackages,
     String? vendorDir,
     Set<String> copyPluginPackages = const {},
+    String? scratchPath,
+    String? binaryArtifactStore,
+    String? binaryArtifactFallback,
+    bool swiftPmArtifactJunctionCapability = false,
+    bool packageLocalArtifactJunctionCapability = false,
+    SwiftPmDependencyRefEvaluator? evaluateDependencyRefs,
+    Future<void> Function(
+      String git,
+      String url,
+      String ref,
+      String destination,
+    )?
+    clonePackage,
   }) async {
     final windows = Platform.isWindows;
     final packagesDir = p.join(outputDir, 'Packages');
@@ -1248,6 +1772,14 @@ abstract final class GeneratedPluginsPackage {
         copySources: copyPluginPackages.contains(plugin.name),
         vendorNormalizationCache: vendorNormalizationCache,
         dependencyEvaluationCache: dependencyEvaluationCache,
+        scratchPath: scratchPath,
+        binaryArtifactStore: binaryArtifactStore,
+        binaryArtifactFallback: binaryArtifactFallback,
+        swiftPmArtifactJunctionCapability: swiftPmArtifactJunctionCapability,
+        packageLocalArtifactJunctionCapability:
+            packageLocalArtifactJunctionCapability,
+        evaluateDependencyRefs: evaluateDependencyRefs,
+        clonePackage: clonePackage,
       );
     }
     final packagesByDirectoryName = {
@@ -1304,6 +1836,19 @@ abstract final class GeneratedPluginsPackage {
     bool copySources = false,
     Map<String, Map<String, List<String>>>? vendorNormalizationCache,
     Map<String, Future<Map<String, String>>>? dependencyEvaluationCache,
+    String? scratchPath,
+    String? binaryArtifactStore,
+    String? binaryArtifactFallback,
+    bool swiftPmArtifactJunctionCapability = false,
+    bool packageLocalArtifactJunctionCapability = false,
+    SwiftPmDependencyRefEvaluator? evaluateDependencyRefs,
+    Future<void> Function(
+      String git,
+      String url,
+      String ref,
+      String destination,
+    )?
+    clonePackage,
   }) async {
     var stagedPackage = alias;
     final shouldCopySources = vendorDir != null || copySources;
@@ -1355,6 +1900,14 @@ abstract final class GeneratedPluginsPackage {
         fallbackSwiftModules: fallbackSwiftModules,
         normalizationCache: vendorNormalizationCache,
         evaluationCache: dependencyEvaluationCache,
+        scratchPath: scratchPath,
+        binaryArtifactStore: binaryArtifactStore,
+        binaryArtifactFallback: binaryArtifactFallback,
+        swiftPmArtifactJunctionCapability: swiftPmArtifactJunctionCapability,
+        packageLocalArtifactJunctionCapability:
+            packageLocalArtifactJunctionCapability,
+        scopedDependencyRefEvaluator: evaluateDependencyRefs,
+        clonePackage: clonePackage,
       );
     }
 
@@ -1380,6 +1933,26 @@ abstract final class GeneratedPluginsPackage {
         stagedPackage,
         fallbackSwiftModules: fallbackSwiftModules,
       );
+    }
+    if (Platform.isWindows &&
+        binaryArtifactStore != null &&
+        binaryArtifactFallback != null) {
+      await prepareSupportedBinaryArtifacts(
+        packageRoot: stagedPackage,
+        binaryArtifactStore: binaryArtifactStore,
+        binaryArtifactFallback: binaryArtifactFallback,
+        packageLocalArtifactJunctionCapability:
+            packageLocalArtifactJunctionCapability,
+      );
+      if (vendorDir != null) {
+        await prepareSupportedBinaryArtifacts(
+          packageRoot: vendorDir,
+          binaryArtifactStore: binaryArtifactStore,
+          binaryArtifactFallback: binaryArtifactFallback,
+          packageLocalArtifactJunctionCapability:
+              packageLocalArtifactJunctionCapability,
+        );
+      }
     }
     return stagedPackage;
   }
@@ -1895,15 +2468,48 @@ let package = Package(
     return code;
   }
 
+  static Future<Map<String, String>> _packageIdentitiesByDirectory(
+    String root,
+  ) async {
+    final identities = <String, String>{};
+    final pending = <String>[root];
+    final visited = <String>{};
+    while (pending.isNotEmpty) {
+      final directory = p.normalize(pending.removeLast());
+      if (!visited.add(directory)) continue;
+      final manifestFile = File(p.join(directory, 'Package.swift'));
+      if (!manifestFile.existsSync()) continue;
+      final manifest = await manifestFile.readAsString();
+      for (final call in _swiftCalls(manifest, '.package')) {
+        final path = _namedString(call.text, 'path');
+        if (path == null) continue;
+        final dependencyDirectory = p.normalize(
+          p.isAbsolute(path) ? path : p.join(directory, path),
+        );
+        final dependencyManifest = File(
+          p.join(dependencyDirectory, 'Package.swift'),
+        );
+        final identity =
+            _namedString(call.text, 'name') ??
+            (dependencyManifest.existsSync()
+                ? RegExp(r'Package\s*\(\s*name\s*:\s*"([^"]+)"')
+                      .firstMatch(await dependencyManifest.readAsString())
+                      ?.group(1)
+                : null);
+        if (identity != null) identities[dependencyDirectory] = identity;
+        pending.add(dependencyDirectory);
+      }
+    }
+    return identities;
+  }
+
   /// Parses remote `.package(url:)` entries out of a Swift manifest.
   ///
   /// Uses parenthesis balancing so nested forms like
   /// `.upToNextMajor(from: "1.0.0")` are not truncated at the inner `)`.
   @visibleForTesting
-  static List<({String? name, String url, String match})> parseUrlPackageDeps(
-    String manifest,
-  ) {
-    final deps = <({String? name, String url, String match})>[];
+  static List<SwiftPmPackageDependency> parseUrlPackageDeps(String manifest) {
+    final deps = <SwiftPmPackageDependency>[];
     var searchFrom = 0;
     final startPattern = RegExp(r'\.package\s*\(');
     while (true) {
@@ -1922,11 +2528,16 @@ let package = Package(
         continue;
       }
       final nameMatch = RegExp(r'name:\s*"(?<name>[^"]*)"').firstMatch(inner);
-      deps.add((
-        name: nameMatch?.namedGroup('name'),
-        url: urlMatch.namedGroup('url')!,
-        match: manifest.substring(start, close + 1),
-      ));
+      final name = nameMatch?.namedGroup('name');
+      final url = urlMatch.namedGroup('url')!;
+      deps.add(
+        SwiftPmPackageDependency(
+          name: name,
+          url: url,
+          identity: name ?? packageIdentityFromUrl(url),
+          match: manifest.substring(start, close + 1),
+        ),
+      );
       searchFrom = close + 1;
     }
     return deps;
@@ -2616,26 +3227,287 @@ let package = Package(
         .toString();
   }
 
-  static Future<Map<String, String>> _evaluatedDependencyRefs(
+  @visibleForTesting
+  static List<SwiftPmBinaryArtifactProvenance> scanBinaryArtifactProvenance({
+    required String packageIdentity,
+    required String manifestPath,
+    required String manifest,
+  }) => [
+    for (final target in SwiftPmBinaryTargetManifest.discover(manifest))
+      SwiftPmBinaryArtifactProvenance(
+        packageIdentity: packageIdentity,
+        target: target,
+        manifestPath: manifestPath,
+      ),
+  ];
+
+  @visibleForTesting
+  static SwiftPmBinaryArtifactProvenance? matchBinaryArtifactProvenance({
+    required String artifactPath,
+    required String artifactsRoot,
+    required Iterable<SwiftPmBinaryArtifactProvenance> provenance,
+    bool? windows,
+  }) {
+    final relative = p.split(p.relative(artifactPath, from: artifactsRoot));
+    if (relative.length < 2 ||
+        _swiftPmComponent(relative.first, windows: windows) == 'extract') {
+      return null;
+    }
+    final identity = _swiftPmComponent(relative[0], windows: windows);
+    final target = _swiftPmComponent(relative[1], windows: windows);
+    final matches = provenance
+        .where(
+          (candidate) =>
+              _swiftPmComponent(candidate.packageIdentity, windows: windows) ==
+                  identity &&
+              _swiftPmComponent(candidate.target.name, windows: windows) ==
+                  target,
+        )
+        .toList();
+    return matches.length == 1 ? matches.single : null;
+  }
+
+  static String _swiftPmComponent(String value, {bool? windows}) =>
+      (windows ?? Platform.isWindows) ? value.toLowerCase() : value;
+
+  @visibleForTesting
+  static String binaryArtifactAttemptKey(
+    SwiftPmBinaryArtifactProvenance provenance, {
+    bool? windows,
+  }) => [
+    _swiftPmComponent(provenance.packageIdentity, windows: windows),
+    _swiftPmComponent(provenance.target.name, windows: windows),
+    provenance.target.checksum.toLowerCase(),
+  ].join('\u0000');
+
+  static Future<List<SwiftPmBinaryArtifactProvenance>>
+  _binaryArtifactProvenance(
     String packageDirectory,
-    Future<String> Function(String name) locateTool,
+    String scratchPath,
+    List<SwiftPmPackageDependency> dependencies,
   ) async {
-    final swift = await locateTool(
-      Platform.isWindows ? 'swift-package' : 'swift',
+    final result = <SwiftPmBinaryArtifactProvenance>[];
+    final packageRoot = Directory(packageDirectory);
+    final checkoutRoot = p.join(scratchPath, 'checkouts');
+    final roots = <String, String?>{packageRoot.path: null};
+    for (final dependency in dependencies) {
+      roots[p.join(checkoutRoot, dependency.identity)] = dependency.identity;
+      roots[p.join(checkoutRoot, packageIdentityFromUrl(dependency.url))] =
+          dependency.identity;
+    }
+    for (final entry in roots.entries) {
+      final root = Directory(entry.key);
+      if (!root.existsSync()) continue;
+      await for (final entity in root.list(
+        recursive: true,
+        followLinks: false,
+      )) {
+        if (entity is! File) continue;
+        final name = p.basename(entity.path);
+        if (name != 'Package.swift' &&
+            !(name.startsWith('Package@') && name.endsWith('.swift'))) {
+          continue;
+        }
+        final manifest = await entity.readAsString();
+        final declaredName = RegExp(
+          r'Package\s*\(\s*name\s*:\s*"([^"]+)"',
+        ).firstMatch(manifest)?.group(1);
+        final identity = entry.value ?? declaredName;
+        if (identity == null) continue;
+        result.addAll(
+          scanBinaryArtifactProvenance(
+            packageIdentity: identity,
+            manifestPath: entity.path,
+            manifest: manifest,
+          ),
+        );
+      }
+    }
+    return result;
+  }
+
+  @visibleForTesting
+  static Future<bool> recoverBootstrapBinaryArtifacts({
+    required String scratchPath,
+    required String binaryArtifactStore,
+    required Iterable<SwiftPmBinaryArtifactProvenance> provenance,
+    required SwiftPmBinaryAttemptState attemptState,
+    bool swiftPmArtifactJunctionCapability = false,
+    bool? windows,
+  }) async {
+    if (!(windows ?? Platform.isWindows)) return false;
+    final artifactsRoot = p.join(scratchPath, 'artifacts');
+    final artifacts = Directory(artifactsRoot);
+    if (!artifacts.existsSync()) return false;
+    final preparer = SwiftPmBinaryArtifactPreparer(
+      store: SwiftPmBinaryArtifactStore(binaryArtifactStore),
     );
+    final candidates =
+        <
+          String,
+          List<
+            ({Directory directory, SwiftPmBinaryArtifactProvenance provenance})
+          >
+        >{};
+    for (final package in artifacts.listSync(followLinks: false)) {
+      if (package is! Directory ||
+          _swiftPmComponent(p.basename(package.path), windows: windows) ==
+              'extract') {
+        continue;
+      }
+      for (final targetDirectory in package.listSync(followLinks: false)) {
+        if (targetDirectory is! Directory) continue;
+        final match = matchBinaryArtifactProvenance(
+          artifactPath: targetDirectory.path,
+          artifactsRoot: artifactsRoot,
+          provenance: provenance,
+          windows: windows,
+        );
+        if (match == null) continue;
+        final key = binaryArtifactAttemptKey(match, windows: windows);
+        (candidates[key] ??= []).add((
+          directory: targetDirectory,
+          provenance: match,
+        ));
+      }
+    }
+
+    var recovered = false;
+    for (final candidateList in candidates.values) {
+      if (candidateList.length != 1) continue;
+      final candidate = candidateList.single;
+      final key = binaryArtifactAttemptKey(
+        candidate.provenance,
+        windows: windows,
+      );
+      if (attemptState.bootstrapRecovered.contains(key)) continue;
+      final completeArtifacts = candidate.directory
+          .listSync(followLinks: false)
+          .whereType<Directory>()
+          .where(
+            (directory) =>
+                directory.path.toLowerCase().endsWith('.xcframework'),
+          );
+      var hasFinalArtifact = false;
+      for (final artifact in completeArtifacts) {
+        if (await hasCompleteSwiftPmArtifact(artifact)) {
+          hasFinalArtifact = true;
+          break;
+        }
+      }
+      if (hasFinalArtifact) continue;
+      final archives = candidate.directory
+          .listSync(followLinks: false)
+          .whereType<File>()
+          .where((file) => file.path.toLowerCase().endsWith('.zip'));
+      final verified = <SwiftPmPreparedBinaryArtifact>[];
+      for (final archive in archives) {
+        try {
+          verified.add(
+            SwiftPmPreparedBinaryArtifact(
+              target: candidate.provenance.target,
+              entry: await preparer.prepareDownloadedArchive(
+                target: candidate.provenance.target,
+                archive: archive,
+              ),
+            ),
+          );
+        } on FlutterBuildError catch (error) {
+          if (error.isSecurityFailure) rethrow;
+          continue;
+        } on Object {
+          continue;
+        }
+      }
+      if (verified.length != 1) continue;
+      final prepared = verified.single;
+      final destination = p.join(
+        candidate.directory.path,
+        p.basename(prepared.entry.artifactPath),
+      );
+      if (swiftPmArtifactJunctionCapability) {
+        try {
+          await preparer.createBinaryArtifactJunction(
+            alias: destination,
+            target: prepared.entry.artifactPath,
+          );
+        } on FileSystemException {
+          if (attemptState.copied.contains(key)) continue;
+          attemptState.copied.add(key);
+          await preparer.materializeBinaryArtifact(
+            source: prepared.entry.artifactPath,
+            destination: destination,
+          );
+        }
+      } else {
+        if (attemptState.copied.contains(key)) continue;
+        attemptState.copied.add(key);
+        await preparer.materializeBinaryArtifact(
+          source: prepared.entry.artifactPath,
+          destination: destination,
+        );
+      }
+      attemptState.bootstrapRecovered.add(key);
+      recovered = true;
+    }
+    return recovered;
+  }
+
+  @visibleForTesting
+  static Future<bool> hasCompleteSwiftPmArtifact(Directory artifact) async {
+    final info = File(p.join(artifact.path, 'Info.plist'));
+    if (!info.existsSync()) return false;
+    try {
+      final value = PropertyListSerialization.propertyListWithString(
+        await info.readAsString(),
+      );
+      if (value is! Map) return false;
+      final libraries = value['AvailableLibraries'];
+      if (libraries is! List) return false;
+      for (final value in libraries) {
+        if (value is! Map || value['SupportedPlatform'] != 'ios') continue;
+        final architectures = value['SupportedArchitectures'];
+        final identifier = value['LibraryIdentifier'];
+        final libraryPath = value['LibraryPath'];
+        if (architectures is! List ||
+            !architectures.contains('arm64') ||
+            identifier is! String ||
+            identifier.isEmpty ||
+            libraryPath is! String ||
+            libraryPath.isEmpty) {
+          continue;
+        }
+        if (FileSystemEntity.typeSync(
+              p.join(artifact.path, identifier, libraryPath),
+            ) !=
+            FileSystemEntityType.notFound) {
+          return true;
+        }
+      }
+    } on Object {
+      return false;
+    }
+    return false;
+  }
+
+  @visibleForTesting
+  static Future<Map<String, String>> evaluateDependencyRefsWithRecovery(
+    String packageDirectory, {
+    required Future<void> Function(String packageDirectory) resolve,
+    required Future<bool> Function(
+      String packageDirectory,
+      SwiftPmBinaryAttemptState attemptState,
+    )
+    recover,
+    required SwiftPmBinaryAttemptState attemptState,
+  }) async {
     final resolvedFile = File(p.join(packageDirectory, 'Package.resolved'));
     if (resolvedFile.existsSync()) await resolvedFile.delete();
-    final result = await ProcessRunner.run(swift, [
-      if (!Platform.isWindows) 'package',
-      '--package-path',
-      packageDirectory,
-      'resolve',
-    ]);
-    if (result.exitCode != 0) {
-      throw FlutterBuildError(
-        'Cannot resolve SwiftPM dependencies in $packageDirectory:\n'
-        '${result.stderr.trim()}',
-      );
+    try {
+      await resolve(packageDirectory);
+    } on Object {
+      if (!await recover(packageDirectory, attemptState)) rethrow;
+      await resolve(packageDirectory);
     }
     try {
       return dependencyRefsFromPackageResolved(
@@ -2644,6 +3516,73 @@ let package = Package(
     } on Object catch (error) {
       throw FlutterBuildError('Cannot read ${resolvedFile.path}: $error');
     }
+  }
+
+  static Future<Map<String, String>> _evaluatedDependencyRefs(
+    String packageDirectory,
+    Future<String> Function(String name) locateTool, {
+    Future<void> Function(String packageDirectory)? resolve,
+    Future<bool> Function(
+      String packageDirectory,
+      SwiftPmBinaryAttemptState attemptState,
+    )?
+    recover,
+    SwiftPmBinaryAttemptState? attemptState,
+    String? scratchPath,
+    String? binaryArtifactStore,
+    String? binaryArtifactFallback,
+    bool swiftPmArtifactJunctionCapability = false,
+    List<SwiftPmPackageDependency> dependencies = const [],
+  }) async {
+    final swift = await locateTool(
+      Platform.isWindows ? 'swift-package' : 'swift',
+    );
+    final runResolve =
+        resolve ??
+        (directory) async {
+          final result = await ProcessRunner.run(swift, [
+            if (!Platform.isWindows) 'package',
+            '--package-path',
+            directory,
+            'resolve',
+          ]);
+          if (result.exitCode != 0) {
+            throw FlutterBuildError(
+              'Cannot resolve SwiftPM dependencies in $directory:\n'
+              '${result.stderr.trim()}',
+            );
+          }
+        };
+    final canRecover =
+        recover != null ||
+        (Platform.isWindows &&
+            scratchPath != null &&
+            binaryArtifactStore != null &&
+            binaryArtifactFallback != null);
+    final scannedProvenance = recover == null && canRecover
+        ? await _binaryArtifactProvenance(
+            packageDirectory,
+            scratchPath!,
+            dependencies,
+          )
+        : null;
+    return evaluateDependencyRefsWithRecovery(
+      packageDirectory,
+      resolve: runResolve,
+      recover:
+          recover ??
+          (_, state) => canRecover
+              ? recoverBootstrapBinaryArtifacts(
+                  scratchPath: scratchPath!,
+                  binaryArtifactStore: binaryArtifactStore!,
+                  provenance: scannedProvenance!,
+                  attemptState: state,
+                  swiftPmArtifactJunctionCapability:
+                      swiftPmArtifactJunctionCapability,
+                )
+              : Future<bool>.value(false),
+      attemptState: attemptState ?? SwiftPmBinaryAttemptState(),
+    );
   }
 
   /// Clones each `.package(url:)` dependency under [vendorDir], normalizes its
@@ -2657,6 +3596,7 @@ let package = Package(
     Future<String> Function(String name)? locateTool,
     Future<Map<String, String>> Function(String packageDirectory)?
     evaluateDependencyRefs,
+    SwiftPmDependencyRefEvaluator? scopedDependencyRefEvaluator,
     Future<void> Function(
       String git,
       String url,
@@ -2666,25 +3606,67 @@ let package = Package(
     clonePackage,
     Map<String, Map<String, List<String>>>? normalizationCache,
     Map<String, Future<Map<String, String>>>? evaluationCache,
+    String? scratchPath,
+    String? binaryArtifactStore,
+    String? binaryArtifactFallback,
+    bool swiftPmArtifactJunctionCapability = false,
+    bool packageLocalArtifactJunctionCapability = false,
   }) async {
     final deps = parseUrlPackageDeps(manifest);
     if (deps.isEmpty) return manifest;
 
     final locate = locateTool ?? ProcessRunner.locateTool;
     final evaluate =
-        evaluateDependencyRefs ??
-        (directory) => _evaluatedDependencyRefs(directory, locate);
+        scopedDependencyRefEvaluator ??
+        (
+          directory, {
+          required scratchPath,
+          required binaryArtifactStore,
+          required binaryArtifactFallback,
+          required swiftPmArtifactJunctionCapability,
+          required packageLocalArtifactJunctionCapability,
+          required dependencies,
+        }) => evaluateDependencyRefs != null
+            ? evaluateDependencyRefs(directory)
+            : _evaluatedDependencyRefs(
+                directory,
+                locate,
+                scratchPath: scratchPath,
+                binaryArtifactStore: binaryArtifactStore,
+                binaryArtifactFallback: binaryArtifactFallback,
+                swiftPmArtifactJunctionCapability:
+                    swiftPmArtifactJunctionCapability,
+                dependencies: dependencies,
+              );
     final evaluationKey = await _dependencyEvaluationKey(
       manifest,
       packageDirectory,
     );
     late final Map<String, String> evaluatedRefs;
     if (evaluationCache == null) {
-      evaluatedRefs = await evaluate(packageDirectory);
+      evaluatedRefs = await evaluate(
+        packageDirectory,
+        scratchPath: scratchPath,
+        binaryArtifactStore: binaryArtifactStore,
+        binaryArtifactFallback: binaryArtifactFallback,
+        swiftPmArtifactJunctionCapability: swiftPmArtifactJunctionCapability,
+        packageLocalArtifactJunctionCapability:
+            packageLocalArtifactJunctionCapability,
+        dependencies: deps,
+      );
     } else {
       final pending = evaluationCache.putIfAbsent(
         evaluationKey,
-        () => evaluate(packageDirectory),
+        () => evaluate(
+          packageDirectory,
+          scratchPath: scratchPath,
+          binaryArtifactStore: binaryArtifactStore,
+          binaryArtifactFallback: binaryArtifactFallback,
+          swiftPmArtifactJunctionCapability: swiftPmArtifactJunctionCapability,
+          packageLocalArtifactJunctionCapability:
+              packageLocalArtifactJunctionCapability,
+          dependencies: deps,
+        ),
       );
       try {
         evaluatedRefs = await pending;
@@ -2720,7 +3702,7 @@ let package = Package(
       final dirName = vendorPackageDirName(dep.url, ref);
       // Always set name: — without it SwiftPM uses the directory basename
       // (`pkg@1.2.3`), which breaks `.product(..., package: "pkg")`.
-      final identity = dep.name ?? packageIdentityFromUrl(dep.url);
+      final identity = dep.identity;
       if (seen.add(dirName)) {
         final destination = p.join(vendorDir, dirName);
         await clone(git, dep.url, ref, destination);
@@ -2762,124 +3744,6 @@ let package = Package(
 
   /// Replaces mode-120000 checkout placeholders produced by Git for Windows
   /// with hard links to files or copies of directory targets.
-  /// SwiftPM's Foundation ZIP extraction cannot move XCFrameworks containing
-  /// Unix framework symlinks on Windows (Cocoa I/O error 514). The extraction
-  /// itself is complete, so retain the device slice needed by this build and
-  /// let a second resolve validate it from the normal artifact location.
-  @visibleForTesting
-  static Future<bool> repairWindowsBinaryArtifacts(String scratchPath) async {
-    final artifactsRoot = p.join(scratchPath, 'artifacts');
-    final extractRoot = Directory(p.join(artifactsRoot, 'extract'));
-    if (!extractRoot.existsSync()) return false;
-    var repaired = false;
-    final archives = <File>[];
-    for (final package in Directory(
-      artifactsRoot,
-    ).listSync(followLinks: false)) {
-      if (package is! Directory || p.basename(package.path) == 'extract') {
-        continue;
-      }
-      for (final target in package.listSync(followLinks: false)) {
-        if (target is! Directory) continue;
-        archives.addAll(
-          target
-              .listSync(followLinks: false)
-              .whereType<File>()
-              .where((file) => file.path.endsWith('.zip')),
-        );
-      }
-    }
-    for (final archive in archives) {
-      final target = p.join(
-        p.dirname(archive.path),
-        p.basenameWithoutExtension(archive.path),
-      );
-      await _deleteEntity(target);
-      final zip = ZipDecoder().decodeBytes(await archive.readAsBytes());
-      for (final entry in zip.files) {
-        if (!entry.isFile || entry.isSymbolicLink) continue;
-        final segments = p.url.split(entry.name);
-        final slice = segments.indexOf('ios-arm64');
-        if (segments.last != 'Info.plist' && slice < 0) continue;
-        final output = p.joinAll([target, ...segments]);
-        await Directory(p.dirname(output)).create(recursive: true);
-        await File(output).writeAsBytes(entry.content as List<int>);
-      }
-      repaired = true;
-    }
-    final frameworks = <Directory>[];
-    for (final package in extractRoot.listSync(followLinks: false)) {
-      if (package is! Directory) continue;
-      for (final target in package.listSync(followLinks: false)) {
-        if (target is! Directory) continue;
-        for (final extraction in target.listSync(followLinks: false)) {
-          if (extraction is! Directory) continue;
-          for (final artifact in extraction.listSync(followLinks: false)) {
-            if (artifact is Directory &&
-                artifact.path.endsWith('.xcframework')) {
-              frameworks.add(artifact);
-            }
-          }
-        }
-      }
-    }
-    final candidates = <String, (Directory, File)>{};
-    for (final entity in frameworks) {
-      final relative = p.relative(entity.path, from: extractRoot.path);
-      final parts = p.split(relative);
-      if (parts.length < 4) continue;
-      final deviceSlice = Directory(p.join(entity.path, 'ios-arm64'));
-      final info = File(p.join(entity.path, 'Info.plist'));
-      if (!deviceSlice.existsSync() || !info.existsSync()) continue;
-      final destination = p.join(
-        scratchPath,
-        'artifacts',
-        parts[0],
-        parts[1],
-        parts.last,
-      );
-      candidates.putIfAbsent(destination, () => (deviceSlice, info));
-    }
-    for (final MapEntry(key: destination, value: candidate)
-        in candidates.entries) {
-      final (deviceSlice, info) = candidate;
-      await _deleteEntity(destination);
-      await Directory(destination).create(recursive: true);
-      await _copyDirectoryPortable(
-        deviceSlice.path,
-        p.join(destination, 'ios-arm64'),
-        failureDescription: 'Could not copy extracted binary artifact',
-      );
-      final plist = await info.readAsString();
-      final identifier = plist.indexOf('<string>ios-arm64</string>');
-      final deviceStart = identifier < 0
-          ? -1
-          : plist.lastIndexOf('<dict>', identifier);
-      final deviceEnd = identifier < 0
-          ? -1
-          : plist.indexOf('</dict>', identifier);
-      if (deviceStart < 0 || deviceEnd < 0) continue;
-      final deviceLibrary = plist.substring(deviceStart, deviceEnd + 7);
-      await File(p.join(destination, 'Info.plist')).writeAsString('''
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>AvailableLibraries</key>
-  <array>
-$deviceLibrary
-  </array>
-  <key>CFBundlePackageType</key>
-  <string>XFWK</string>
-  <key>XCFrameworkFormatVersion</key>
-  <string>1.0</string>
-</dict>
-</plist>
-''');
-      repaired = true;
-    }
-    return repaired;
-  }
 
   @visibleForTesting
   static Future<bool> materializeCheckoutSymlinks(
@@ -3406,7 +4270,52 @@ $diagnosticsStart$registrations$diagnosticsEnd}
   static Future<void> _writeStable(String path, String content) async {
     final file = File(path);
     if (file.existsSync() && await file.readAsString() == content) return;
-    await file.writeAsString(content);
+    await _writeAtomic(path, utf8.encode(content));
+  }
+
+  static Future<void> _writeAtomic(String path, List<int> bytes) async {
+    final temporary = File(
+      '$path.xcross-$pid-${DateTime.now().microsecondsSinceEpoch}',
+    );
+    try {
+      await temporary.writeAsBytes(bytes, flush: true);
+      await temporary.rename(path);
+    } finally {
+      if (temporary.existsSync()) await temporary.delete();
+    }
+  }
+
+  static int _fileBytes(String path) {
+    final file = File(path);
+    return file.existsSync() ? file.lengthSync() : 0;
+  }
+
+  static int _directoryBytes(String path) {
+    final directory = Directory(path);
+    if (!directory.existsSync()) return 0;
+    var bytes = 0;
+    for (final entity in directory.listSync(
+      recursive: true,
+      followLinks: false,
+    )) {
+      if (entity is File) bytes += entity.lengthSync();
+    }
+    return bytes;
+  }
+
+  static void _traceBinaryOperation({
+    required String target,
+    required String operation,
+    required int elapsedMilliseconds,
+    required int attempt,
+    int archiveBytes = 0,
+    int extractedBytes = 0,
+  }) {
+    Log.logTrace(
+      'binary target=$target operation=$operation '
+      'archive_bytes=$archiveBytes extracted_bytes=$extractedBytes '
+      'elapsed_ms=$elapsedMilliseconds attempt=$attempt',
+    );
   }
 
   /// Copies [source] to [destination], applying [transform] when it elects
@@ -3522,36 +4431,6 @@ $diagnosticsStart$registrations$diagnosticsEnd}
     return changed;
   }
 
-  /// Deletes whatever occupies [path] unless it already is a [keep] entry,
-  /// so links can become directories and vice versa without stale state.
-  static Future<void> _copyDirectoryPortable(
-    String source,
-    String destination, {
-    required String failureDescription,
-  }) async {
-    await _deleteEntity(destination);
-    if (Platform.isWindows) {
-      final result = await Process.run(
-        'robocopy',
-        windowsCopyArguments(source, destination),
-      );
-      if (result.exitCode > 7) {
-        throw FileSystemException(
-          '$failureDescription: ${result.stderr}',
-          source,
-        );
-      }
-    } else {
-      await _syncDirectory(source, destination);
-    }
-    if (!Directory(destination).existsSync()) {
-      throw FileSystemException(
-        '$failureDescription: no output produced',
-        source,
-      );
-    }
-  }
-
   @visibleForTesting
   static List<String> windowsCopyArguments(String source, String destination) =>
       [
@@ -3613,6 +4492,13 @@ $diagnosticsStart$registrations$diagnosticsEnd}
 
     await Link(alias).create(p.relative(target, from: p.dirname(alias)));
   }
+
+  static String _binaryArtifactFallbackPath(
+    String fallback,
+    String checksum,
+    String target,
+    String artifact,
+  ) => p.join(fallback, checksum.toLowerCase(), target, artifact);
 
   static String _jsonPath(String path) => path.replaceAll(r'\', '/');
 

--- a/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
@@ -117,7 +117,7 @@ abstract final class GeneratedPluginsPackage {
         );
 
         final pluginsDir = p.join(outputDir, 'Plugins');
-        final scratchPath = p.join(projectRoot, 'build', '.xs');
+        final scratchPath = p.join(projectRoot, 'build', 'spm');
         await _runSwiftBuild(
           outputDir: outputDir,
           pluginsDir: pluginsDir,
@@ -167,6 +167,13 @@ abstract final class GeneratedPluginsPackage {
       throw FlutterBuildError(SdkInstall.mismatchGuidance(mismatch));
     }
     final swift = await ProcessRunner.locateTool('swift');
+    final swiftPackage = Platform.isWindows
+        ? await ProcessRunner.locateTool('swift-package')
+        : swift;
+    final swiftBuild = Platform.isWindows
+        ? await ProcessRunner.locateTool('swift-build')
+        : swift;
+
     // Real `Flutter.framework` (not our FlutterFramework binary-target
     // wrapper). Our own aggregate target resolves `import Flutter` via
     // that wrapper's declared package dependency, but individual
@@ -208,7 +215,7 @@ abstract final class GeneratedPluginsPackage {
     final environment = swiftProcessEnvironment(windows: windows);
     if (windows) {
       await _resolveWindowsDependencies(
-        swift: swift,
+        swift: swiftPackage,
         pluginsDir: pluginsDir,
         scratchPath: scratchPath,
         swiftSdksPath: swiftSdksPath,
@@ -235,8 +242,9 @@ abstract final class GeneratedPluginsPackage {
         ),
         ...selection,
       ];
+      if (windows) arguments.removeAt(0);
       Future<void> invoke() => ProcessRunner.runChecked(
-        swift,
+        swiftBuild,
         arguments,
         environment: environment,
         inheritStdio: windows && Log.isVerbose,
@@ -378,7 +386,7 @@ abstract final class GeneratedPluginsPackage {
         scratchPath: scratchPath,
         swiftSdksPath: swiftSdksPath,
         toolsetPath: toolsetPath,
-      ),
+      ).skip(1).toList(),
       environment: environment,
       inheritStdio: Log.isVerbose,
       label: 'swift package resolve',
@@ -412,7 +420,7 @@ abstract final class GeneratedPluginsPackage {
       if (firestore == null) rethrow;
       final vendorFramework = p.join(
         p.dirname(p.dirname(outputDir)),
-        '.xv',
+        'vendor',
         'fb@346daa9f4631',
         'FirebaseFirestoreInternal.xcframework',
       );
@@ -659,7 +667,6 @@ abstract final class GeneratedPluginsPackage {
       'GIT_CONFIG_KEY_0': 'core.symlinks',
       'GIT_CONFIG_VALUE_0': 'false',
       'EXPERIMENTAL_SPM_BUILDS': '1',
-      'SWIFTPM_MAXIMUM_CONCURRENT_OPERATIONS': '1',
     };
   }
 
@@ -840,8 +847,6 @@ abstract final class GeneratedPluginsPackage {
     '--scratch-path',
     scratchPath,
     if (windows ?? Platform.isWindows) ...[
-      '--jobs',
-      '1',
       '--disable-automatic-resolution',
       // Windows Swift's interface verifier does not inherit SwiftPM's search
       // path for generated sibling Clang modules during Darwin cross builds.
@@ -1094,7 +1099,7 @@ abstract final class GeneratedPluginsPackage {
     final packagesDir = p.join(outputDir, 'Packages');
     final frameworkDir = p.join(packagesDir, _flutterFrameworkPackageName);
     final pluginsDir = p.join(outputDir, 'Plugins');
-    final vendorDir = p.join(p.dirname(p.dirname(outputDir)), '.xv');
+    final vendorDir = p.join(p.dirname(p.dirname(outputDir)), 'vendor');
     final shouldVendor = vendorRemotePackages ?? true;
 
     await Directory(packagesDir).create(recursive: true);
@@ -2493,11 +2498,13 @@ let package = Package(
     String packageDirectory,
     Future<String> Function(String name) locateTool,
   ) async {
-    final swift = await locateTool('swift');
+    final swift = await locateTool(
+      Platform.isWindows ? 'swift-package' : 'swift',
+    );
     final resolvedFile = File(p.join(packageDirectory, 'Package.resolved'));
     if (resolvedFile.existsSync()) await resolvedFile.delete();
     final result = await ProcessRunner.run(swift, [
-      'package',
+      if (!Platform.isWindows) 'package',
       '--package-path',
       packageDirectory,
       'resolve',

--- a/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
@@ -665,8 +665,9 @@ abstract final class GeneratedPluginsPackage {
     bool? windows,
   }) async {
     if (!(windows ?? Platform.isWindows)) return;
-    final root = Directory(packageRoot);
+    final root = Directory(_ioPath(packageRoot));
     if (!root.existsSync()) return;
+
     final store = SwiftPmBinaryArtifactStore(binaryArtifactStore);
     final preparer = SwiftPmBinaryArtifactPreparer(store: store);
     final runPrepare = prepare ?? preparer.prepare;
@@ -718,15 +719,16 @@ abstract final class GeneratedPluginsPackage {
               attempt: 0,
             );
             final artifact = result.entry.artifactPath;
+            final relative = p.join(
+              '.xa',
+              target.checksum.toLowerCase().substring(0, 16),
+              p.basename(artifact),
+            );
+
             var aliased = false;
             if (packageLocalArtifactJunctionCapability) {
-              final relative = p.join(
-                'xcross-artifacts',
-                target.checksum.toLowerCase(),
-                target.name,
-                p.basename(artifact),
-              );
               final alias = p.join(manifestFile.parent.path, relative);
+
               await Directory(p.dirname(alias)).create(recursive: true);
               try {
                 final existed =
@@ -762,16 +764,12 @@ abstract final class GeneratedPluginsPackage {
               }
             }
             if (!aliased) {
-              final destination = _binaryArtifactFallbackPath(
-                binaryArtifactFallback,
-                target.checksum,
-                target.name,
-                p.basename(artifact),
-              );
+              final destination = p.join(manifestFile.parent.path, relative);
               final publication = await copy(
                 source: artifact,
                 destination: destination,
               );
+
               if (publication == SwiftPmBinaryArtifactPublication.published()) {
                 createdDestination = destination;
                 createdDestinations[destination] = (
@@ -779,7 +777,7 @@ abstract final class GeneratedPluginsPackage {
                   publication: publication,
                 );
               }
-              localPaths[target] = _swiftPath(destination);
+              localPaths[target] = relative;
             }
           } on FlutterBuildError catch (error) {
             if (error.isSecurityFailure) rethrow;
@@ -4051,6 +4049,12 @@ let package = Package(
       ], environment: environment);
       if (head.exitCode == 0 &&
           head.stdout.trim().toLowerCase() == ref.toLowerCase()) {
+        await ProcessRunner.runChecked(
+          git,
+          ['-C', destination, 'reset', '--hard', 'HEAD'],
+          environment: environment,
+          label: 'git reset vendored package',
+        );
         return;
       }
     }
@@ -4293,7 +4297,7 @@ $diagnosticsStart$registrations$diagnosticsEnd}
   }
 
   static int _directoryBytes(String path) {
-    final directory = Directory(path);
+    final directory = Directory(_ioPath(path));
     if (!directory.existsSync()) return 0;
     var bytes = 0;
     for (final entity in directory.listSync(
@@ -4303,6 +4307,16 @@ $diagnosticsStart$registrations$diagnosticsEnd}
       if (entity is File) bytes += entity.lengthSync();
     }
     return bytes;
+  }
+
+  static String _ioPath(String path) {
+    if (!Platform.isWindows) return path;
+    final absolute = p.windows.normalize(p.windows.absolute(path));
+    if (absolute.startsWith(r'\\?\')) return absolute;
+    if (absolute.startsWith(r'\\')) {
+      return '${r'\\?\UNC\'}${absolute.substring(2)}';
+    }
+    return '${r'\\?\'}$absolute';
   }
 
   static void _traceBinaryOperation({

--- a/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
@@ -118,7 +118,7 @@ abstract final class GeneratedPluginsPackage {
 
         final pluginsDir = p.join(outputDir, 'Plugins');
         final scratchPath = Platform.isWindows
-            ? p.join(projectRoot, 'build', '.xcross-spm-v2')
+            ? p.join(projectRoot, 'build', '.xs')
             : p.join(pluginsDir, '.build');
         await _runSwiftBuild(
           outputDir: outputDir,
@@ -261,6 +261,13 @@ abstract final class GeneratedPluginsPackage {
         if (!repaired) rethrow;
         await invoke();
       }
+      if (windows) {
+        await repairWindowsGeneratedBuildFiles(
+          scratchPath,
+          targetBuildDir,
+          windows: true,
+        );
+      }
     }
 
     await buildTranslatingSdkMismatch(
@@ -289,7 +296,10 @@ abstract final class GeneratedPluginsPackage {
     if (!root.existsSync()) return false;
     var changed = false;
     for (final json in [
-      File(p.join(targetBuildDir, 'description.json')),
+      ...root
+          .listSync(recursive: true, followLinks: false)
+          .whereType<File>()
+          .where((file) => p.extension(file.path) == '.json'),
       File(
         p.join(
           scratchPath,
@@ -301,20 +311,26 @@ abstract final class GeneratedPluginsPackage {
     ]) {
       if (!json.existsSync()) continue;
       final original = await json.readAsString();
-      final normalized = original.replaceAll(r'\\?\C:\?\C:\', r'C:\');
+      final normalized = original.replaceAll(r'\\\\?\\C:\\?\\C:\\', r'C:\\');
       if (normalized != original) {
         await json.writeAsString(normalized);
         changed = true;
       }
     }
-    for (final buildDir in root.listSync(followLinks: false)) {
-      if (buildDir is! Directory || !buildDir.path.endsWith('.build')) continue;
-      final accessor = File(
-        p.join(buildDir.path, 'DerivedSources', 'resource_bundle_accessor.m'),
-      );
-      if (!accessor.existsSync()) continue;
+    for (final accessor
+        in root
+            .listSync(recursive: true, followLinks: false)
+            .whereType<File>()
+            .where(
+              (file) => p.basename(file.path) == 'resource_bundle_accessor.m',
+            )) {
       final original = await accessor.readAsString();
-      final normalized = original.replaceAll(r'\', '/');
+      final normalized = original
+          .replaceAll(r'\', '/')
+          .replaceAll(
+            '#import <Foundation/Foundation.h>',
+            '#include <Foundation/Foundation.h>',
+          );
       if (normalized != original) {
         await accessor.writeAsString(normalized);
         changed = true;
@@ -373,6 +389,53 @@ abstract final class GeneratedPluginsPackage {
       await resolve();
     } on Object {
       if (!await repairWindowsBinaryArtifacts(scratchPath)) rethrow;
+      Directory? firestore;
+      final pending = <Directory>[
+        Directory(p.join(scratchPath, 'artifacts', 'extract')),
+      ];
+      while (pending.isNotEmpty && firestore == null) {
+        final directory = pending.removeLast();
+        List<FileSystemEntity> entities;
+        try {
+          entities = directory.listSync(followLinks: false);
+        } on FileSystemException {
+          continue;
+        }
+        for (final entity in entities) {
+          if (entity is! Directory) continue;
+          if (p.basename(entity.path) ==
+              'FirebaseFirestoreInternal.xcframework') {
+            firestore = entity;
+            break;
+          }
+          pending.add(entity);
+        }
+      }
+      if (firestore == null) rethrow;
+      final vendorFramework = p.join(
+        p.dirname(p.dirname(outputDir)),
+        '.xv',
+        'fb@346daa9f4631',
+        'FirebaseFirestoreInternal.xcframework',
+      );
+      await _deleteEntity(vendorFramework);
+      final copy = await Process.run('robocopy', [
+        firestore.path,
+        vendorFramework,
+        '/E',
+        '/NFL',
+        '/NDL',
+        '/NJH',
+        '/NJS',
+        '/NP',
+      ]);
+      if (copy.exitCode > 7) {
+        throw FileSystemException(
+          'Could not stage Firestore binary artifact: ${copy.stderr}',
+          firestore.path,
+        );
+      }
+      environment?['FIREBASECI_USE_LOCAL_FIRESTORE_ZIP'] = '1';
       await resolve();
     }
     final materialized = await materializeCheckoutSymlinks(scratchPath);
@@ -593,11 +656,12 @@ abstract final class GeneratedPluginsPackage {
   @visibleForTesting
   static Map<String, String>? swiftProcessEnvironment({bool? windows}) {
     if (!(windows ?? Platform.isWindows)) return null;
-    return const {
+    return {
       'GIT_CONFIG_COUNT': '1',
       'GIT_CONFIG_KEY_0': 'core.symlinks',
       'GIT_CONFIG_VALUE_0': 'false',
       'EXPERIMENTAL_SPM_BUILDS': '1',
+      'SWIFTPM_MAXIMUM_CONCURRENT_OPERATIONS': '1',
     };
   }
 
@@ -778,6 +842,8 @@ abstract final class GeneratedPluginsPackage {
     '--scratch-path',
     scratchPath,
     if (windows ?? Platform.isWindows) ...[
+      '--jobs',
+      '1',
       '--disable-automatic-resolution',
       // Windows Swift's interface verifier does not inherit SwiftPM's search
       // path for generated sibling Clang modules during Darwin cross builds.
@@ -966,7 +1032,10 @@ abstract final class GeneratedPluginsPackage {
         if (path == null) {
           throw FlutterBuildError('Could not find ${tool.value.$1}.');
         }
-        toolset[tool.key] = {'path': path};
+        toolset[tool.key] = {
+          'path': path,
+          'extraCLIOptions': [r'-fdebug-prefix-map=C:\=/'],
+        };
       }
       // The Swift toolchain's own ld64.lld refuses iOS, so take the linker
       // already vetted by DarwinSdk.resolveLd64Lld instead of PATH order.
@@ -1028,7 +1097,7 @@ abstract final class GeneratedPluginsPackage {
     final frameworkDir = p.join(packagesDir, _flutterFrameworkPackageName);
     final pluginsDir = p.join(outputDir, 'Plugins');
     final vendorDir = Platform.isWindows
-        ? p.join(p.dirname(p.dirname(outputDir)), '.xcross-vendor')
+        ? p.join(p.dirname(p.dirname(outputDir)), '.xv')
         : p.join(outputDir, 'Vendor');
     final shouldVendor = vendorRemotePackages ?? true;
 
@@ -1772,7 +1841,11 @@ let package = Package(
   @visibleForTesting
   static String vendorPackageDirName(String url, String ref) {
     final safeRef = ref.replaceAll(RegExp(r'[^\w.\-]+'), '_');
-    return '${packageIdentityFromUrl(url)}@$safeRef';
+    final identity = packageIdentityFromUrl(url);
+    if (identity == 'firebase-ios-sdk') {
+      return 'fb@${safeRef.length > 12 ? safeRef.substring(0, 12) : safeRef}';
+    }
+    return '$identity@$safeRef';
   }
 
   /// SwiftPM package identity implied by a git URL (last path segment, no
@@ -2625,6 +2698,7 @@ let package = Package(
         }
       }
     }
+    final candidates = <String, (Directory, File)>{};
     for (final entity in frameworks) {
       final relative = p.relative(entity.path, from: extractRoot.path);
       final parts = p.split(relative);
@@ -2639,6 +2713,11 @@ let package = Package(
         parts[1],
         parts.last,
       );
+      candidates.putIfAbsent(destination, () => (deviceSlice, info));
+    }
+    for (final MapEntry(key: destination, value: candidate)
+        in candidates.entries) {
+      final (deviceSlice, info) = candidate;
       await _deleteEntity(destination);
       await Directory(destination).create(recursive: true);
       if (Platform.isWindows) {
@@ -2655,6 +2734,12 @@ let package = Package(
         if (result.exitCode > 7) {
           throw FileSystemException(
             'Could not copy extracted binary artifact: ${result.stderr}',
+            deviceSlice.path,
+          );
+        }
+        if (!Directory(p.join(destination, 'ios-arm64')).existsSync()) {
+          throw FileSystemException(
+            'Binary artifact copy produced no iOS device slice',
             deviceSlice.path,
           );
         }

--- a/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
@@ -230,7 +230,7 @@ abstract final class GeneratedPluginsPackage {
         scratchPath: scratchPath,
         swiftSdksPath: swiftSdksPath,
         toolsetPath: toolsetPath,
-        outputDir: outputDir,
+        vendorDir: p.join(p.dirname(outputDir), 'vendor'),
         environment: environment,
       );
     }
@@ -386,9 +386,10 @@ abstract final class GeneratedPluginsPackage {
     required String scratchPath,
     required String swiftSdksPath,
     required String toolsetPath,
-    required String outputDir,
+    required String vendorDir,
     required Map<String, String>? environment,
   }) async {
+
     Future<void> resolve() => ProcessRunner.runChecked(
       swift,
       swiftResolveArguments(
@@ -405,62 +406,77 @@ abstract final class GeneratedPluginsPackage {
       await resolve();
     } on Object {
       if (!await repairWindowsBinaryArtifacts(scratchPath)) rethrow;
-      Directory? firestore;
-      final pending = <Directory>[
-        Directory(p.join(scratchPath, 'artifacts', 'extract')),
-      ];
-      while (pending.isNotEmpty && firestore == null) {
-        final directory = pending.removeLast();
-        List<FileSystemEntity> entities;
-        try {
-          entities = directory.listSync(followLinks: false);
-        } on FileSystemException {
-          continue;
-        }
-        for (final entity in entities) {
-          if (entity is! Directory) continue;
-          if (p.basename(entity.path) ==
-              'FirebaseFirestoreInternal.xcframework') {
-            firestore = entity;
-            break;
-          }
-          pending.add(entity);
-        }
-      }
-      if (firestore == null) rethrow;
-      final vendorFramework = p.join(
-        p.dirname(outputDir),
-        'vendor',
-        'fb@346daa9f4631',
-        'FirebaseFirestoreInternal.xcframework',
+      await stageExtractedBinaryArtifacts(
+        scratchPath: scratchPath,
+        vendorDir: vendorDir,
       );
-      await _deleteEntity(vendorFramework);
-      final copy = await Process.run('robocopy', [
-        firestore.path,
-        vendorFramework,
-        '/E',
-        '/NFL',
-        '/NDL',
-        '/NJH',
-        '/NJS',
-        '/NP',
-      ]);
-      if (copy.exitCode > 7) {
-        throw FileSystemException(
-          'Could not stage Firestore binary artifact: ${copy.stderr}',
-          firestore.path,
-        );
-      }
-      environment?['FIREBASECI_USE_LOCAL_FIRESTORE_ZIP'] = '1';
       await resolve();
     }
+
     final materialized = await materializeCheckoutSymlinks(scratchPath);
     final normalized = await normalizeResolvedPackageManifests(scratchPath);
     if (materialized || normalized) await resolve();
   }
 
   @visibleForTesting
+  static Future<bool> stageExtractedBinaryArtifacts({
+    required String scratchPath,
+    required String vendorDir,
+  }) async {
+    final artifacts = Directory(p.join(scratchPath, 'artifacts'));
+    final vendor = Directory(vendorDir);
+    if (!artifacts.existsSync() || !vendor.existsSync()) return false;
+
+    final frameworks = <String, Directory>{};
+    await for (final entity in artifacts.list(recursive: true)) {
+      if (entity is! Directory || !entity.path.endsWith('.xcframework')) {
+        continue;
+      }
+      if (p.isWithin(p.join(artifacts.path, 'extract'), entity.path)) continue;
+      final name = p.basenameWithoutExtension(entity.path);
+      if (File(p.join(entity.path, 'Info.plist')).existsSync()) {
+        frameworks[name] = entity;
+      }
+    }
+    if (frameworks.isEmpty) return false;
+
+    var changed = false;
+    await for (final package in vendor.list(followLinks: false)) {
+      if (package is! Directory) continue;
+      await for (final entity in package.list(followLinks: false)) {
+        if (entity is! File) continue;
+        final fileName = p.basename(entity.path);
+        if (fileName != 'Package.swift' &&
+            !(fileName.startsWith('Package@') && fileName.endsWith('.swift'))) {
+          continue;
+        }
+        var manifest = await entity.readAsString();
+        final original = manifest;
+        for (final call in _swiftCalls(manifest, '.binaryTarget').reversed) {
+          final name = _namedString(call.text, 'name');
+          final framework = name == null ? null : frameworks[name];
+          if (framework == null || _namedString(call.text, 'url') == null) {
+            continue;
+          }
+          final destination = p.join(package.path, '$name.xcframework');
+          await _deleteEntity(destination);
+          await _syncDirectory(framework.path, destination);
+          manifest = manifest.replaceRange(
+            call.start,
+            call.end,
+            '.binaryTarget(name: "$name", path: "$name.xcframework")',
+          );
+          changed = true;
+        }
+        if (manifest != original) await _writeStable(entity.path, manifest);
+      }
+    }
+    return changed;
+  }
+
+  @visibleForTesting
   static Future<bool> normalizeResolvedPackageManifests(
+
     String scratchPath,
   ) async {
     final checkouts = Directory(p.join(scratchPath, 'checkouts'));

--- a/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
@@ -117,9 +117,7 @@ abstract final class GeneratedPluginsPackage {
         );
 
         final pluginsDir = p.join(outputDir, 'Plugins');
-        final scratchPath = Platform.isWindows
-            ? p.join(projectRoot, 'build', '.xs')
-            : p.join(pluginsDir, '.build');
+        final scratchPath = p.join(projectRoot, 'build', '.xs');
         await _runSwiftBuild(
           outputDir: outputDir,
           pluginsDir: pluginsDir,
@@ -1096,9 +1094,7 @@ abstract final class GeneratedPluginsPackage {
     final packagesDir = p.join(outputDir, 'Packages');
     final frameworkDir = p.join(packagesDir, _flutterFrameworkPackageName);
     final pluginsDir = p.join(outputDir, 'Plugins');
-    final vendorDir = Platform.isWindows
-        ? p.join(p.dirname(p.dirname(outputDir)), '.xv')
-        : p.join(outputDir, 'Vendor');
+    final vendorDir = p.join(p.dirname(p.dirname(outputDir)), '.xv');
     final shouldVendor = vendorRemotePackages ?? true;
 
     await Directory(packagesDir).create(recursive: true);

--- a/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
@@ -425,50 +425,84 @@ abstract final class GeneratedPluginsPackage {
   }) async {
     final artifacts = Directory(p.join(scratchPath, 'artifacts'));
     final vendor = Directory(vendorDir);
-    if (!artifacts.existsSync() || !vendor.existsSync()) return false;
+    if (!artifacts.existsSync()) return false;
 
     final frameworks = <String, Directory>{};
-    await for (final entity in artifacts.list(recursive: true)) {
-      if (entity is! Directory || !entity.path.endsWith('.xcframework')) {
+    for (final package in artifacts.listSync(followLinks: false)) {
+      if (package is! Directory || p.basename(package.path) == 'extract') {
         continue;
       }
-      if (p.isWithin(p.join(artifacts.path, 'extract'), entity.path)) continue;
-      final name = p.basenameWithoutExtension(entity.path);
-      if (File(p.join(entity.path, 'Info.plist')).existsSync()) {
-        frameworks[name] = entity;
+      for (final target in package.listSync(followLinks: false)) {
+        if (target is! Directory) continue;
+        for (final entity in target.listSync(followLinks: false)) {
+          if (entity is! Directory || !entity.path.endsWith('.xcframework')) {
+            continue;
+          }
+          final name = p.basenameWithoutExtension(entity.path);
+          if (File(p.join(entity.path, 'Info.plist')).existsSync()) {
+            frameworks[name] = entity;
+          }
+        }
       }
     }
     if (frameworks.isEmpty) return false;
 
+    final packageRoots = <Directory>[
+      vendor,
+      Directory(p.join(scratchPath, 'checkouts')),
+    ];
     var changed = false;
-    await for (final package in vendor.list(followLinks: false)) {
-      if (package is! Directory) continue;
-      await for (final entity in package.list(followLinks: false)) {
-        if (entity is! File) continue;
-        final fileName = p.basename(entity.path);
-        if (fileName != 'Package.swift' &&
-            !(fileName.startsWith('Package@') && fileName.endsWith('.swift'))) {
-          continue;
-        }
-        var manifest = await entity.readAsString();
-        final original = manifest;
-        for (final call in _swiftCalls(manifest, '.binaryTarget').reversed) {
-          final name = _namedString(call.text, 'name');
-          final framework = name == null ? null : frameworks[name];
-          if (framework == null || _namedString(call.text, 'url') == null) {
+    for (final packageRoot in packageRoots) {
+      if (!packageRoot.existsSync()) continue;
+      await for (final package in packageRoot.list(followLinks: false)) {
+        if (package is! Directory) continue;
+        await for (final entity in package.list(followLinks: false)) {
+          if (entity is! File) continue;
+          final fileName = p.basename(entity.path);
+          if (fileName != 'Package.swift' &&
+              !(fileName.startsWith('Package@') &&
+                  fileName.endsWith('.swift'))) {
             continue;
           }
-          final destination = p.join(package.path, '$name.xcframework');
-          await _deleteEntity(destination);
-          await _syncDirectory(framework.path, destination);
-          manifest = manifest.replaceRange(
-            call.start,
-            call.end,
-            '.binaryTarget(name: "$name", path: "$name.xcframework")',
-          );
-          changed = true;
+          var manifest = await entity.readAsString();
+          final original = manifest;
+          for (final call in _swiftCalls(manifest, '.binaryTarget').reversed) {
+            final name = _namedString(call.text, 'name');
+            final framework = name == null ? null : frameworks[name];
+            if (framework == null || _namedString(call.text, 'url') == null) {
+              continue;
+            }
+            final destination = p.join(package.path, '$name.xcframework');
+            await _deleteEntity(destination);
+            if (Platform.isWindows) {
+              final copy = await Process.run('robocopy', [
+                framework.path,
+                destination,
+                '/E',
+                '/NFL',
+                '/NDL',
+                '/NJH',
+                '/NJS',
+                '/NP',
+              ]);
+              if (copy.exitCode > 7) {
+                throw FileSystemException(
+                  'Could not stage repaired binary artifact: ${copy.stderr}',
+                  framework.path,
+                );
+              }
+            } else {
+              await _syncDirectory(framework.path, destination);
+            }
+            manifest = manifest.replaceRange(
+              call.start,
+              call.end,
+              '.binaryTarget(name: "$name", path: "$name.xcframework")',
+            );
+            changed = true;
+          }
+          if (manifest != original) await _writeStable(entity.path, manifest);
         }
-        if (manifest != original) await _writeStable(entity.path, manifest);
       }
     }
     return changed;
@@ -476,8 +510,8 @@ abstract final class GeneratedPluginsPackage {
 
   @visibleForTesting
   static Future<bool> normalizeResolvedPackageManifests(
-
     String scratchPath,
+
   ) async {
     final checkouts = Directory(p.join(scratchPath, 'checkouts'));
     var changed = false;

--- a/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
+++ b/packages/xcross/lib/src/flutter/build/ios_plugin_package.dart
@@ -70,20 +70,18 @@ abstract final class GeneratedPluginsPackage {
   /// [projectRoot]        — Flutter project root (logging context only).
   /// [flutterXcframework] — Path to the real `Flutter.xcframework` (from
   ///                         `IosEngineCache.flutterXcframework`).
-  /// [outputDir]           — Stable directory to synthesize the wrapper
-  ///                         packages and run `swift build` in. Not deleted
-  ///                         between calls, so SwiftPM's `.build` cache
-  ///                         persists; only the generated `.swift` files are
-  ///                         overwritten each call.
+  /// [workspace] owns the stable generated-package, scratch, and vendored
+  /// dependency directories reused between builds.
   static Future<GeneratedPluginsBuildResult?> build({
     required String projectRoot,
+    required SwiftPmWorkspace workspace,
     required List<IosPlugin> plugins,
     required String flutterXcframework,
-    required String outputDir,
     required IosDeploymentTarget deploymentTarget,
     bool verbose = false,
   }) =>
       Log.logStep('Building Flutter plugins (Swift Package Manager)', () async {
+        final outputDir = workspace.packages;
         final spmPlugins = plugins
             .where((plugin) => plugin.usesSwiftPackageManager)
             .toList();
@@ -94,7 +92,6 @@ abstract final class GeneratedPluginsPackage {
           'spmPlugins=${[for (final plugin in spmPlugins) plugin.name]}',
         );
 
-        final workspace = SwiftPmWorkspace.forProject(projectRoot);
         final targetDebugDir = p.join(
           workspace.scratch,
           'arm64-apple-ios',
@@ -153,7 +150,7 @@ abstract final class GeneratedPluginsPackage {
           'Flutter.xcframework',
         );
         await _runSwiftBuild(
-          outputDir: outputDir,
+          workspace: workspace,
           pluginsDir: pluginsDir,
           scratchPath: scratchPath,
           flutterXcframework: stagedFlutterXcframework,
@@ -250,13 +247,14 @@ abstract final class GeneratedPluginsPackage {
 
   /// `swift build --swift-sdk arm64-apple-ios`.
   static Future<void> _runSwiftBuild({
-    required String outputDir,
+    required SwiftPmWorkspace workspace,
     required String pluginsDir,
     required String scratchPath,
     required String flutterXcframework,
     required Set<String> interopTargetCandidates,
     required Map<String, Set<String>> interopConsumers,
   }) async {
+    final outputDir = workspace.packages;
     final sdk = DarwinSdk.current();
     if (sdk == null) {
       throw FlutterBuildError(
@@ -325,7 +323,7 @@ abstract final class GeneratedPluginsPackage {
         scratchPath: scratchPath,
         swiftSdksPath: swiftSdksPath,
         toolsetPath: toolsetPath,
-        vendorDir: p.join(p.dirname(outputDir), 'vendor'),
+        vendorDir: workspace.vendor,
         environment: environment,
       );
     }
@@ -522,7 +520,7 @@ abstract final class GeneratedPluginsPackage {
     final vendor = Directory(vendorDir);
     if (!artifacts.existsSync()) return false;
 
-    final frameworks = <String, Directory>{};
+    final repairedFrameworksByTarget = <String, Directory>{};
     for (final package in artifacts.listSync(followLinks: false)) {
       if (package is! Directory || p.basename(package.path) == 'extract') {
         continue;
@@ -535,19 +533,19 @@ abstract final class GeneratedPluginsPackage {
           }
           final name = p.basenameWithoutExtension(entity.path);
           if (File(p.join(entity.path, 'Info.plist')).existsSync()) {
-            frameworks[name] = entity;
+            repairedFrameworksByTarget[name] = entity;
           }
         }
       }
     }
-    if (frameworks.isEmpty) return false;
+    if (repairedFrameworksByTarget.isEmpty) return false;
 
-    final packageRoots = <Directory>[
+    final manifestSearchRoots = <Directory>[
       vendor,
       Directory(p.join(scratchPath, 'checkouts')),
     ];
     var changed = false;
-    for (final packageRoot in packageRoots) {
+    for (final packageRoot in manifestSearchRoots) {
       if (!packageRoot.existsSync()) continue;
       await for (final package in packageRoot.list(followLinks: false)) {
         if (package is! Directory) continue;
@@ -563,32 +561,18 @@ abstract final class GeneratedPluginsPackage {
           final original = manifest;
           for (final call in _swiftCalls(manifest, '.binaryTarget').reversed) {
             final name = _namedString(call.text, 'name');
-            final framework = name == null ? null : frameworks[name];
+            final framework = name == null
+                ? null
+                : repairedFrameworksByTarget[name];
             if (framework == null || _namedString(call.text, 'url') == null) {
               continue;
             }
             final destination = p.join(package.path, '$name.xcframework');
-            await _deleteEntity(destination);
-            if (Platform.isWindows) {
-              final copy = await Process.run('robocopy', [
-                framework.path,
-                destination,
-                '/E',
-                '/NFL',
-                '/NDL',
-                '/NJH',
-                '/NJS',
-                '/NP',
-              ]);
-              if (copy.exitCode > 7) {
-                throw FileSystemException(
-                  'Could not stage repaired binary artifact: ${copy.stderr}',
-                  framework.path,
-                );
-              }
-            } else {
-              await _syncDirectory(framework.path, destination);
-            }
+            await _copyDirectoryPortable(
+              framework.path,
+              destination,
+              failureDescription: 'Could not stage repaired binary artifact',
+            );
             manifest = manifest.replaceRange(
               call.start,
               call.end,
@@ -644,13 +628,11 @@ abstract final class GeneratedPluginsPackage {
   }) async {
     final repair = repairConsumers ?? () async {};
 
-    Future<bool> recoverMissingTargets([Object? failure]) async {
+    Future<bool> recoverMissingTargets() async {
       final targets = missingSwiftInteropTargets(
         targetBuildDir,
         candidates: interopTargetCandidates,
       );
-      if (failure != null && targets.isEmpty) return false;
-
       for (final target in targets) {
         await buildTarget(target);
       }
@@ -667,8 +649,8 @@ abstract final class GeneratedPluginsPackage {
     final before = swiftInteropSearchPaths(targetBuildDir).toSet();
     try {
       await build();
-    } on Object catch (error) {
-      if (await recoverMissingTargets(error)) {
+    } on Object {
+      if (await recoverMissingTargets()) {
         await build();
         return;
       }
@@ -681,18 +663,6 @@ abstract final class GeneratedPluginsPackage {
       await repair();
       await build();
     }
-  }
-
-  @visibleForTesting
-  static bool isMissingSwiftInteropHeaderFailure(
-    Object error,
-    Iterable<String> targets,
-  ) {
-    final message = '$error';
-    return targets.any(
-      (target) =>
-          message.contains('$target-Swift.h') && message.contains('not found'),
-    );
   }
 
   @visibleForTesting
@@ -2875,35 +2845,11 @@ let package = Package(
       final (deviceSlice, info) = candidate;
       await _deleteEntity(destination);
       await Directory(destination).create(recursive: true);
-      if (Platform.isWindows) {
-        final result = await Process.run('robocopy', [
-          deviceSlice.path,
-          p.join(destination, 'ios-arm64'),
-          '/E',
-          '/NFL',
-          '/NDL',
-          '/NJH',
-          '/NJS',
-          '/NP',
-        ]);
-        if (result.exitCode > 7) {
-          throw FileSystemException(
-            'Could not copy extracted binary artifact: ${result.stderr}',
-            deviceSlice.path,
-          );
-        }
-        if (!Directory(p.join(destination, 'ios-arm64')).existsSync()) {
-          throw FileSystemException(
-            'Binary artifact copy produced no iOS device slice',
-            deviceSlice.path,
-          );
-        }
-      } else {
-        await _syncDirectory(
-          deviceSlice.path,
-          p.join(destination, 'ios-arm64'),
-        );
-      }
+      await _copyDirectoryPortable(
+        deviceSlice.path,
+        p.join(destination, 'ios-arm64'),
+        failureDescription: 'Could not copy extracted binary artifact',
+      );
       final plist = await info.readAsString();
       final identifier = plist.indexOf('<string>ios-arm64</string>');
       final deviceStart = identifier < 0
@@ -3578,6 +3524,40 @@ $diagnosticsStart$registrations$diagnosticsEnd}
 
   /// Deletes whatever occupies [path] unless it already is a [keep] entry,
   /// so links can become directories and vice versa without stale state.
+  static Future<void> _copyDirectoryPortable(
+    String source,
+    String destination, {
+    required String failureDescription,
+  }) async {
+    await _deleteEntity(destination);
+    if (Platform.isWindows) {
+      final result = await Process.run('robocopy', [
+        source,
+        destination,
+        '/E',
+        '/NFL',
+        '/NDL',
+        '/NJH',
+        '/NJS',
+        '/NP',
+      ]);
+      if (result.exitCode > 7) {
+        throw FileSystemException(
+          '$failureDescription: ${result.stderr}',
+          source,
+        );
+      }
+    } else {
+      await _syncDirectory(source, destination);
+    }
+    if (!Directory(destination).existsSync()) {
+      throw FileSystemException(
+        '$failureDescription: no output produced',
+        source,
+      );
+    }
+  }
+
   static Future<void> _deleteUnless(
     String path,
     FileSystemEntityType keep,

--- a/packages/xcross/lib/src/flutter/build/swiftpm_binary_artifact_preparer.dart
+++ b/packages/xcross/lib/src/flutter/build/swiftpm_binary_artifact_preparer.dart
@@ -340,9 +340,8 @@ final class SwiftPmBinaryArtifactPreparer {
     }
     final parent = Directory(p.dirname(destination));
     await parent.create(recursive: true);
-    final temporary = await parent.createTemp(
-      '.${p.basename(destination)}.xcross-copy-',
-    );
+    final temporary = await parent.createTemp('.x-');
+
     var cleanupTemporary = true;
     try {
       final start =
@@ -350,8 +349,9 @@ final class SwiftPmBinaryArtifactPreparer {
           (executable, arguments) async =>
               _IoBinaryCopyProcess(await Process.start(executable, arguments));
       final process = await start('robocopy', [
-        source,
-        temporary.path,
+        _processPath(source),
+        _processPath(temporary.path),
+
         '/E',
         '/R:0',
         '/W:0',
@@ -532,8 +532,10 @@ final class SwiftPmBinaryArtifactPreparer {
             FileSystemEntityType.directory) {
       return false;
     }
-    final sourceRoot = Directory(source);
-    final destinationRoot = Directory(destination);
+    final sourcePath = _ioPath(source);
+    final destinationPath = _ioPath(destination);
+    final sourceRoot = Directory(sourcePath);
+    final destinationRoot = Directory(destinationPath);
     final sourceEntities = sourceRoot.listSync(
       recursive: true,
       followLinks: false,
@@ -545,10 +547,11 @@ final class SwiftPmBinaryArtifactPreparer {
     if (sourceEntities.length != destinationEntities.length) return false;
     final destinationByPath = {
       for (final entity in destinationEntities)
-        _pathKey(p.relative(entity.path, from: destination)): entity,
+        _pathKey(p.relative(entity.path, from: destinationPath)): entity,
     };
     for (final entity in sourceEntities) {
-      final relative = _pathKey(p.relative(entity.path, from: source));
+      final relative = _pathKey(p.relative(entity.path, from: sourcePath));
+
       final other = destinationByPath[relative];
       final type = FileSystemEntity.typeSync(entity.path, followLinks: false);
       if (other == null ||
@@ -564,6 +567,26 @@ final class SwiftPmBinaryArtifactPreparer {
       }
     }
     return true;
+  }
+
+  static String _processPath(String path) {
+    if (!Platform.isWindows) return path;
+    final normalized = p.windows.normalize(p.windows.absolute(path));
+    if (normalized.startsWith(r'\\?\UNC\')) {
+      return r'\\' + normalized.substring(8);
+    }
+    if (normalized.startsWith(r'\\?\')) return normalized.substring(4);
+    return normalized;
+  }
+
+  static String _ioPath(String path) {
+    if (!Platform.isWindows) return path;
+    final absolute = p.windows.normalize(p.windows.absolute(path));
+    if (absolute.startsWith(r'\\?\')) return absolute;
+    if (absolute.startsWith(r'\\')) {
+      return '${r'\\?\UNC\'}${absolute.substring(2)}';
+    }
+    return '${r'\\?\'}$absolute';
   }
 
   static bool _sameBytes(List<int> first, List<int> second) {

--- a/packages/xcross/lib/src/flutter/build/swiftpm_binary_artifact_preparer.dart
+++ b/packages/xcross/lib/src/flutter/build/swiftpm_binary_artifact_preparer.dart
@@ -1,0 +1,1263 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:path/path.dart' as p;
+import 'package:propertylistserialization/propertylistserialization.dart';
+import 'package:xcross/src/flutter/build/swiftpm_binary_artifact_store.dart';
+import 'package:xcross/src/flutter/build/swiftpm_binary_target.dart';
+import 'package:xcross/src/flutter/errors.dart';
+
+typedef DownloadBinaryArchive =
+    Future<void> Function(Uri url, File destination, int maximumBytes);
+
+const _archiveByteLimitMessage =
+    'SwiftPM binary artifact exceeds compressed archive byte limit';
+
+typedef StartBinaryCopy =
+    Future<BinaryCopyProcess> Function(
+      String executable,
+      List<String> arguments,
+    );
+
+bool isWindowsMountPointReparseOutput(String output) => RegExp(
+  r'Reparse\s+Tag\s+Value\s*:\s*0x0*a0000003\b',
+  caseSensitive: false,
+).hasMatch(output);
+
+abstract interface class BinaryCopyProcess {
+  Future<int> get exitCode;
+  Stream<List<int>> get stdout;
+  Stream<List<int>> get stderr;
+  bool kill();
+}
+
+final class SwiftPmBinaryArtifactPublication {
+  SwiftPmBinaryArtifactPublication._(this.nonce);
+
+  static final reused = SwiftPmBinaryArtifactPublication._(null);
+  factory SwiftPmBinaryArtifactPublication.published() =>
+      SwiftPmBinaryArtifactPublication._(
+        '${pid}_${DateTime.now().microsecondsSinceEpoch}',
+      );
+
+  final String? nonce;
+
+  @override
+  bool operator ==(Object other) =>
+      other is SwiftPmBinaryArtifactPublication &&
+      ((nonce == null && other.nonce == null) ||
+          (nonce != null && other.nonce != null));
+
+  @override
+  int get hashCode => nonce == null ? 0 : 1;
+}
+
+final class _IoBinaryCopyProcess implements BinaryCopyProcess {
+  const _IoBinaryCopyProcess(this.process);
+
+  final Process process;
+
+  @override
+  Future<int> get exitCode => process.exitCode;
+
+  @override
+  Stream<List<int>> get stdout => process.stdout;
+
+  @override
+  Stream<List<int>> get stderr => process.stderr;
+
+  @override
+  bool kill() => process.kill();
+}
+
+final class SwiftPmPreparedBinaryArtifact {
+  const SwiftPmPreparedBinaryArtifact({
+    required this.target,
+    required this.entry,
+  });
+
+  final SwiftPmRemoteBinaryTarget target;
+  final SwiftPmBinaryArtifactEntry entry;
+}
+
+final class SwiftPmBinaryArtifactPreparer {
+  SwiftPmBinaryArtifactPreparer({
+    required SwiftPmBinaryArtifactStore store,
+    DownloadBinaryArchive? download,
+    int maxEntries = 100000,
+    int maxExpandedBytes = 4294967296,
+    int maxArchiveBytes = 536870912,
+  }) : _store = store,
+       _download = download ?? _defaultDownload,
+       _maxEntries = maxEntries,
+       _maxExpandedBytes = maxExpandedBytes,
+       _maxArchiveBytes = maxArchiveBytes {
+    if (maxEntries < 1) {
+      throw ArgumentError.value(maxEntries, 'maxEntries', 'must be positive');
+    }
+    if (maxExpandedBytes < 0) {
+      throw ArgumentError.value(
+        maxExpandedBytes,
+        'maxExpandedBytes',
+        'must not be negative',
+      );
+    }
+    if (maxArchiveBytes < 0) {
+      throw ArgumentError.value(
+        maxArchiveBytes,
+        'maxArchiveBytes',
+        'must not be negative',
+      );
+    }
+  }
+
+  static final Map<String, Future<void>> _destinationTails = {};
+
+  final SwiftPmBinaryArtifactStore _store;
+  final DownloadBinaryArchive _download;
+  final int _maxEntries;
+  final int _maxExpandedBytes;
+  final int _maxArchiveBytes;
+
+  Future<void> createBinaryArtifactJunction({
+    required String alias,
+    required String target,
+  }) => _withDestinationLock(alias, () async {
+    if (!await _completeEntryContaining(target)) {
+      throw FileSystemException(
+        'SwiftPM binary artifact target is not a complete store entry',
+        target,
+      );
+    }
+    await _removeBinaryArtifactAlias(alias);
+    final absoluteAlias = p.normalize(p.absolute(alias));
+    final resolvedTarget = p.normalize(
+      p.absolute(await Directory(target).resolveSymbolicLinks()),
+    );
+    final nonce = '${pid}_${DateTime.now().microsecondsSinceEpoch}';
+    final temporaryAlias = '$absoluteAlias.xcross-junction-$nonce';
+    var published = false;
+    try {
+      await _createAlias(temporaryAlias, resolvedTarget);
+      if (!await _isAliasTo(temporaryAlias, resolvedTarget)) {
+        throw FileSystemException(
+          'SwiftPM binary artifact junction has an unexpected type or target',
+          temporaryAlias,
+        );
+      }
+      await Directory(temporaryAlias).rename(absoluteAlias);
+      published = true;
+      if (!await _isAliasTo(absoluteAlias, resolvedTarget)) {
+        throw FileSystemException(
+          'Published SwiftPM binary artifact alias has an unexpected type or target',
+          absoluteAlias,
+        );
+      }
+      await _writeAliasMarker(absoluteAlias, resolvedTarget, nonce);
+    } catch (_) {
+      final cleanup = published ? absoluteAlias : temporaryAlias;
+      if (await _isAliasTo(cleanup, resolvedTarget)) {
+        await _deleteVerifiedAlias(cleanup);
+      }
+      rethrow;
+    }
+  });
+
+  Future<void> removeBinaryArtifactAlias(String alias) =>
+      _withDestinationLock(alias, () => _removeBinaryArtifactAlias(alias));
+
+  Future<void> _removeBinaryArtifactAlias(String alias) async {
+    final absoluteAlias = p.normalize(p.absolute(alias));
+    final marker = File(_aliasMarkerPath(absoluteAlias));
+    final type = FileSystemEntity.typeSync(absoluteAlias, followLinks: false);
+    if (type == FileSystemEntityType.notFound) {
+      if (marker.existsSync()) await marker.delete();
+      return;
+    }
+    final ownership = await _managedAliasTarget(absoluteAlias, marker);
+    if (ownership == null ||
+        !await _isAliasTo(absoluteAlias, ownership.target)) {
+      throw FileSystemException(
+        'Refusing to remove an unowned or changed SwiftPM binary artifact path',
+        absoluteAlias,
+      );
+    }
+    final revalidated = await _managedAliasTarget(absoluteAlias, marker);
+    if (revalidated != ownership ||
+        !await _isAliasTo(absoluteAlias, ownership.target)) {
+      throw FileSystemException(
+        'Refusing to remove a changed SwiftPM binary artifact alias',
+        absoluteAlias,
+      );
+    }
+    await _deleteVerifiedAlias(absoluteAlias);
+    final markerAfterDelete = await _managedAliasTarget(absoluteAlias, marker);
+    if (markerAfterDelete != null &&
+        markerAfterDelete.target == ownership.target &&
+        markerAfterDelete.nonce == ownership.nonce) {
+      await marker.delete();
+    }
+  }
+
+  Future<void> _createAlias(String alias, String target) async {
+    if (Platform.isWindows) {
+      final result = await Process.run('cmd.exe', [
+        '/c',
+        'mklink',
+        '/J',
+        p.windows.normalize(alias),
+        p.windows.normalize(target),
+      ]);
+      if (result.exitCode != 0) {
+        throw FileSystemException(
+          'Could not create SwiftPM binary artifact junction: '
+          '${_boundedDiagnostic('${result.stderr}')}',
+          alias,
+        );
+      }
+      return;
+    }
+    await Link(alias).create(target);
+  }
+
+  Future<bool> _isAliasTo(String alias, String target) async {
+    final type = FileSystemEntity.typeSync(alias, followLinks: false);
+    if (Platform.isWindows) {
+      if (type != FileSystemEntityType.directory ||
+          !await _isWindowsMountPoint(alias)) {
+        return false;
+      }
+    } else if (type != FileSystemEntityType.link) {
+      return false;
+    }
+    try {
+      final resolved = p.normalize(
+        p.absolute(await Directory(alias).resolveSymbolicLinks()),
+      );
+      return _pathKey(resolved) == _pathKey(p.normalize(p.absolute(target)));
+    } on FileSystemException {
+      return false;
+    }
+  }
+
+  Future<bool> _isWindowsMountPoint(String alias) async {
+    final result = await Process.run('fsutil.exe', [
+      'reparsepoint',
+      'query',
+      alias,
+    ]);
+    return result.exitCode == 0 &&
+        isWindowsMountPointReparseOutput('${result.stdout}');
+  }
+
+  Future<void> _deleteVerifiedAlias(String alias) async {
+    if (Platform.isWindows) {
+      final result = await Process.run('cmd.exe', ['/c', 'rmdir', alias]);
+      if (result.exitCode != 0) {
+        throw FileSystemException(
+          'Could not remove SwiftPM binary artifact junction: '
+          '${_boundedDiagnostic('${result.stderr}')}',
+          alias,
+        );
+      }
+      return;
+    }
+    await Link(alias).delete();
+  }
+
+  Future<void> _writeAliasMarker(
+    String alias,
+    String target,
+    String nonce,
+  ) async {
+    final marker = File(_aliasMarkerPath(alias));
+    final temporary = File('${marker.path}.tmp-$nonce');
+    try {
+      await temporary.writeAsString(
+        jsonEncode({'alias': alias, 'target': target, 'nonce': nonce}),
+        flush: true,
+      );
+      await temporary.rename(marker.path);
+    } catch (_) {
+      if (temporary.existsSync()) await temporary.delete();
+      rethrow;
+    }
+  }
+
+  String _aliasMarkerPath(String alias) => '$alias.xcross-alias.json';
+
+  Future<({String target, String nonce})?> _managedAliasTarget(
+    String alias,
+    File marker,
+  ) async {
+    if (!marker.existsSync()) return null;
+    try {
+      final value = jsonDecode(await marker.readAsString());
+      if (value is! Map<String, dynamic> ||
+          value['alias'] is! String ||
+          value['target'] is! String ||
+          value['nonce'] is! String ||
+          _pathKey(p.normalize(p.absolute(value['alias'] as String))) !=
+              _pathKey(alias)) {
+        return null;
+      }
+      return (
+        target: p.normalize(p.absolute(value['target'] as String)),
+        nonce: value['nonce'] as String,
+      );
+    } on Object {
+      return null;
+    }
+  }
+
+  Future<SwiftPmBinaryArtifactPublication> materializeBinaryArtifact({
+    required String source,
+    required String destination,
+    Duration timeout = const Duration(minutes: 2),
+    StartBinaryCopy? startProcess,
+  }) => _withDestinationLock(destination, () async {
+    if (!await _completeEntryContaining(source)) {
+      throw FileSystemException(
+        'SwiftPM binary artifact source is not a complete store entry',
+        source,
+      );
+    }
+    if (FileSystemEntity.typeSync(destination, followLinks: false) !=
+        FileSystemEntityType.notFound) {
+      if (await validatesMaterializedBinaryArtifact(
+        source: source,
+        destination: destination,
+      )) {
+        return SwiftPmBinaryArtifactPublication.reused;
+      }
+      throw FileSystemException(
+        'SwiftPM binary artifact destination already exists but is not the expected artifact',
+        destination,
+      );
+    }
+    final parent = Directory(p.dirname(destination));
+    await parent.create(recursive: true);
+    final temporary = await parent.createTemp(
+      '.${p.basename(destination)}.xcross-copy-',
+    );
+    var cleanupTemporary = true;
+    try {
+      final start =
+          startProcess ??
+          (executable, arguments) async =>
+              _IoBinaryCopyProcess(await Process.start(executable, arguments));
+      final process = await start('robocopy', [
+        source,
+        temporary.path,
+        '/E',
+        '/R:0',
+        '/W:0',
+        '/MT:8',
+        '/NFL',
+        '/NDL',
+        '/NJH',
+        '/NJS',
+        '/NP',
+      ]);
+      final output = _DiagnosticCollector(process.stdout);
+      final error = _DiagnosticCollector(process.stderr);
+      int exitCode;
+      try {
+        exitCode = await process.exitCode.timeout(timeout);
+      } on TimeoutException {
+        var killed = false;
+        const grace = Duration(milliseconds: 100);
+        var exitedDuringGrace = false;
+        for (var attempt = 0; attempt < 3 && !exitedDuringGrace; attempt++) {
+          killed = process.kill() || killed;
+          try {
+            await process.exitCode.timeout(grace);
+            exitedDuringGrace = true;
+          } on TimeoutException {
+            continue;
+          }
+        }
+        await output.stop();
+        await error.stop();
+        if (!exitedDuringGrace) {
+          cleanupTemporary = false;
+          await File(
+            p.join(temporary.path, '.xcross-live-copy-quarantine'),
+          ).writeAsString('retained: process ownership cannot be revalidated');
+        }
+        throw FileSystemException(
+          'SwiftPM binary artifact copy timed out after $timeout; '
+          'kill returned $killed; process '
+          '${exitedDuringGrace ? 'exited' : 'did not exit'} during $grace grace period: '
+          '${_boundedDiagnostic(error.text, output.text)}',
+          source,
+        );
+      }
+      await output.done;
+      await error.done;
+      if (exitCode > 7) {
+        throw FileSystemException(
+          'SwiftPM binary artifact copy failed with exit code $exitCode: '
+          '${_boundedDiagnostic(error.text, output.text)}',
+          source,
+        );
+      }
+      if (!await _sameArtifactTree(source, temporary.path)) {
+        throw FileSystemException(
+          'SwiftPM binary artifact copy completed with incomplete content',
+          temporary.path,
+        );
+      }
+      try {
+        final publication = SwiftPmBinaryArtifactPublication.published();
+        await temporary.rename(destination);
+        await _writeMaterializationMarker(
+          destination,
+          source,
+          publication.nonce!,
+        );
+        return publication;
+      } on FileSystemException {
+        if (!await validatesMaterializedBinaryArtifact(
+          source: source,
+          destination: destination,
+        )) {
+          rethrow;
+        }
+        return SwiftPmBinaryArtifactPublication.reused;
+      }
+    } finally {
+      if (cleanupTemporary && temporary.existsSync()) {
+        await temporary.delete(recursive: true);
+      }
+    }
+  });
+
+  Future<bool> validatesBinaryArtifactDestination({
+    required String source,
+    required String destination,
+    required bool alias,
+  }) async {
+    if (!await _completeEntryContaining(source)) return false;
+    if (!alias) return _sameArtifactTree(source, destination);
+    final absoluteDestination = p.normalize(p.absolute(destination));
+    final marker = File(_aliasMarkerPath(absoluteDestination));
+    final ownership = await _managedAliasTarget(absoluteDestination, marker);
+    return ownership != null &&
+        _pathKey(ownership.target) ==
+            _pathKey(p.normalize(p.absolute(source))) &&
+        await _isAliasTo(absoluteDestination, ownership.target);
+  }
+
+  Future<bool> validatesMaterializedBinaryArtifact({
+    required String source,
+    required String destination,
+  }) => validatesBinaryArtifactDestination(
+    source: source,
+    destination: destination,
+    alias: false,
+  );
+
+  Future<void> removeMaterializedBinaryArtifact({
+    required String source,
+    required String destination,
+    required SwiftPmBinaryArtifactPublication publication,
+  }) => _withDestinationLock(destination, () async {
+    final nonce = publication.nonce;
+    if (nonce == null) return;
+    final marker = File('$destination.xcross-materialization.json');
+    final ownership = await _materializationOwnership(marker);
+    if (ownership == null ||
+        ownership.nonce != nonce ||
+        _pathKey(ownership.destination) !=
+            _pathKey(p.normalize(p.absolute(destination))) ||
+        _pathKey(ownership.source) !=
+            _pathKey(p.normalize(p.absolute(source))) ||
+        !await _sameArtifactTree(source, destination)) {
+      return;
+    }
+    final revalidated = await _materializationOwnership(marker);
+    if (revalidated == null ||
+        revalidated.nonce != nonce ||
+        !await _sameArtifactTree(source, destination)) {
+      return;
+    }
+    await Directory(destination).delete(recursive: true);
+    if (marker.existsSync()) await marker.delete();
+  });
+
+  Future<void> _writeMaterializationMarker(
+    String destination,
+    String source,
+    String nonce,
+  ) async {
+    final marker = File('$destination.xcross-materialization.json');
+    await marker.writeAsString(
+      jsonEncode({
+        'destination': p.normalize(p.absolute(destination)),
+        'source': p.normalize(p.absolute(source)),
+        'nonce': nonce,
+      }),
+      flush: true,
+    );
+  }
+
+  Future<({String destination, String source, String nonce})?>
+  _materializationOwnership(File marker) async {
+    try {
+      final value = jsonDecode(await marker.readAsString());
+      if (value is! Map<String, dynamic> ||
+          value['destination'] is! String ||
+          value['source'] is! String ||
+          value['nonce'] is! String) {
+        return null;
+      }
+      return (
+        destination: p.normalize(p.absolute(value['destination'] as String)),
+        source: p.normalize(p.absolute(value['source'] as String)),
+        nonce: value['nonce'] as String,
+      );
+    } on Object {
+      return null;
+    }
+  }
+
+  Future<bool> _sameArtifactTree(String source, String destination) async {
+    if (FileSystemEntity.typeSync(source, followLinks: false) !=
+            FileSystemEntityType.directory ||
+        FileSystemEntity.typeSync(destination, followLinks: false) !=
+            FileSystemEntityType.directory) {
+      return false;
+    }
+    final sourceRoot = Directory(source);
+    final destinationRoot = Directory(destination);
+    final sourceEntities = sourceRoot.listSync(
+      recursive: true,
+      followLinks: false,
+    );
+    final destinationEntities = destinationRoot.listSync(
+      recursive: true,
+      followLinks: false,
+    );
+    if (sourceEntities.length != destinationEntities.length) return false;
+    final destinationByPath = {
+      for (final entity in destinationEntities)
+        _pathKey(p.relative(entity.path, from: destination)): entity,
+    };
+    for (final entity in sourceEntities) {
+      final relative = _pathKey(p.relative(entity.path, from: source));
+      final other = destinationByPath[relative];
+      final type = FileSystemEntity.typeSync(entity.path, followLinks: false);
+      if (other == null ||
+          type != FileSystemEntity.typeSync(other.path, followLinks: false)) {
+        return false;
+      }
+      if (type == FileSystemEntityType.file &&
+          !_sameBytes(
+            await File(entity.path).readAsBytes(),
+            await File(other.path).readAsBytes(),
+          )) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  static bool _sameBytes(List<int> first, List<int> second) {
+    if (first.length != second.length) return false;
+    for (var index = 0; index < first.length; index++) {
+      if (first[index] != second[index]) return false;
+    }
+    return true;
+  }
+
+  Future<bool> _completeEntryContaining(String target) async {
+    final root = p.normalize(p.absolute(_store.root));
+    final absoluteTarget = p.normalize(p.absolute(target));
+    if (!p.isWithin(root, absoluteTarget)) return false;
+    var current = Directory(absoluteTarget);
+    while (p.isWithin(root, current.path)) {
+      final metadata = File(p.join(current.path, 'metadata.json'));
+      if (File(p.join(current.path, '.complete')).existsSync() &&
+          metadata.existsSync()) {
+        try {
+          final decoded = jsonDecode(await metadata.readAsString());
+          if (decoded is Map<String, dynamic> &&
+              decoded['archiveChecksum'] is String &&
+              decoded['targetName'] is String) {
+            final entry = await _store.findCompleteTarget(
+              decoded['archiveChecksum'] as String,
+              decoded['targetName'] as String,
+            );
+            return entry != null &&
+                _pathKey(p.normalize(p.absolute(entry.artifactPath))) ==
+                    _pathKey(absoluteTarget);
+          }
+        } on FormatException {
+          return false;
+        } on FileSystemException {
+          return false;
+        }
+      }
+      current = current.parent;
+    }
+    return false;
+  }
+
+  static String _pathKey(String path) =>
+      Platform.isWindows ? path.toLowerCase() : path;
+
+  static Future<T> _withDestinationLock<T>(
+    String destination,
+    Future<T> Function() action,
+  ) async {
+    final key = _pathKey(p.normalize(p.absolute(destination)));
+    final previous = _destinationTails[key];
+    final done = Completer<void>();
+    _destinationTails[key] = done.future;
+    if (previous != null) await previous;
+    final file = File('$key.xcross-publication.lock');
+    await file.parent.create(recursive: true);
+    final lock = await file.open(mode: FileMode.append);
+    try {
+      await lock.lock();
+      return await action();
+    } finally {
+      await lock.unlock();
+      await lock.close();
+      done.complete();
+      if (identical(_destinationTails[key], done.future)) {
+        await _destinationTails.remove(key);
+      }
+    }
+  }
+
+  static String _boundedDiagnostic(String primary, [String secondary = '']) {
+    const limit = 1024;
+    String clip(String value) =>
+        value.length <= limit ? value : '${value.substring(0, limit)}…';
+    return [
+      clip(primary),
+      clip(secondary),
+    ].where((value) => value.isNotEmpty).join('\n');
+  }
+
+  Future<SwiftPmPreparedBinaryArtifact> prepare(
+    SwiftPmRemoteBinaryTarget target,
+  ) async {
+    final existing = await _store.findCompleteTarget(
+      target.checksum,
+      target.name,
+    );
+    if (existing != null) {
+      return SwiftPmPreparedBinaryArtifact(target: target, entry: existing);
+    }
+
+    File archive;
+    final cached = File(_store.archivePath(target.checksum));
+    if (cached.existsSync()) {
+      archive = await _store.publishArchive(
+        cached,
+        target.checksum,
+        maximumBytes: _maxArchiveBytes,
+      );
+    } else {
+      final stagingParent = Directory(p.join(_store.root, '.staging'));
+      await stagingParent.create(recursive: true);
+      final staging = await stagingParent.createTemp('download-');
+      final downloaded = File(p.join(staging.path, 'archive.zip'));
+      try {
+        try {
+          await _download(target.url, downloaded, _maxArchiveBytes);
+        } on FlutterBuildError {
+          rethrow;
+        } on Object {
+          throw FlutterBuildError(
+            'Failed to download SwiftPM binary artifact from '
+            '${_redactedUrl(target.url)}',
+          );
+        }
+        archive = await _store.publishArchive(
+          downloaded,
+          target.checksum,
+          maximumBytes: _maxArchiveBytes,
+        );
+      } finally {
+        if (staging.existsSync()) await staging.delete(recursive: true);
+      }
+    }
+
+    final entry = await prepareDownloadedArchive(
+      target: target,
+      archive: archive,
+    );
+    return SwiftPmPreparedBinaryArtifact(target: target, entry: entry);
+  }
+
+  Future<SwiftPmBinaryArtifactEntry> prepareDownloadedArchive({
+    required SwiftPmRemoteBinaryTarget target,
+    required File archive,
+  }) async {
+    final existing = await _store.findCompleteTarget(
+      target.checksum,
+      target.name,
+    );
+    if (existing != null) return existing;
+
+    await _store.publishArchive(
+      archive,
+      target.checksum,
+      maximumBytes: _maxArchiveBytes,
+    );
+    final bytes = Uint8List.fromList(
+      await _store.readVerifiedArchiveBytes(
+        target.checksum,
+        maximumBytes: _maxArchiveBytes,
+      ),
+    );
+    final decoded = _decode(bytes);
+    final inspected = _inspect(decoded, target);
+    final stagingParent = Directory(p.join(_store.root, '.staging'));
+    await stagingParent.create(recursive: true);
+    final staging = await stagingParent.createTemp('extract-');
+    try {
+      final artifact = Directory(
+        p.join(staging.path, inspected.artifactDirectoryName),
+      );
+      await artifact.create(recursive: true);
+      try {
+        await _extractSelected(inspected, artifact);
+      } on FlutterBuildError {
+        rethrow;
+      } on Object {
+        throw FlutterBuildError(
+          'SwiftPM binary artifact selected content could not be decompressed',
+        );
+      }
+      _validateDeclaredPaths(inspected.library, artifact);
+      return await _store.publishTarget(
+        checksum: target.checksum,
+        targetName: target.name,
+        stagingRoot: staging,
+        artifactDirectoryName: inspected.artifactDirectoryName,
+        metadata: {
+          'formatVersion': 1,
+          'libraryIdentifier': inspected.library.identifier,
+        },
+      );
+    } finally {
+      if (staging.existsSync()) await staging.delete(recursive: true);
+    }
+  }
+
+  Archive _decode(Uint8List bytes) {
+    try {
+      _rejectRawDuplicateEntries(bytes);
+      return ZipDecoder().decodeBytes(bytes);
+    } on FlutterBuildError {
+      rethrow;
+    } on Object {
+      throw FlutterBuildError('SwiftPM binary artifact is not a valid ZIP');
+    }
+  }
+
+  static void _rejectRawDuplicateEntries(Uint8List bytes) {
+    final eocdStart = bytes.length - 22;
+    final eocdLimit = bytes.length > 65557 ? bytes.length - 65557 : 0;
+    var eocd = -1;
+    for (var offset = eocdStart; offset >= eocdLimit; offset--) {
+      if (_uint32(bytes, offset) == 0x06054b50) {
+        eocd = offset;
+        break;
+      }
+    }
+    if (eocd < 0 || eocd + 22 + _uint16(bytes, eocd + 20) != bytes.length) {
+      throw FlutterBuildError('SwiftPM binary artifact is not a valid ZIP');
+    }
+    final count = _uint16(bytes, eocd + 10);
+    final centralSize = _uint32(bytes, eocd + 12);
+    final centralOffset = _uint32(bytes, eocd + 16);
+    if (count == 0xffff ||
+        centralSize == 0xffffffff ||
+        centralOffset == 0xffffffff ||
+        centralOffset + centralSize != eocd) {
+      throw FlutterBuildError(
+        'SwiftPM binary artifact uses unsupported ZIP metadata',
+      );
+    }
+
+    final names = <String>{};
+    var offset = centralOffset;
+    for (var index = 0; index < count; index++) {
+      if (offset + 46 > eocd || _uint32(bytes, offset) != 0x02014b50) {
+        throw FlutterBuildError('SwiftPM binary artifact is not a valid ZIP');
+      }
+      final nameLength = _uint16(bytes, offset + 28);
+      final extraLength = _uint16(bytes, offset + 30);
+      final commentLength = _uint16(bytes, offset + 32);
+      final end = offset + 46 + nameLength + extraLength + commentLength;
+      if (end > eocd) {
+        throw FlutterBuildError('SwiftPM binary artifact is not a valid ZIP');
+      }
+      final name = utf8.decode(
+        bytes.sublist(offset + 46, offset + 46 + nameLength),
+      );
+      if (!names.add(name)) {
+        throw FlutterBuildError(
+          'SwiftPM binary artifact has duplicate ZIP path: $name',
+        );
+      }
+      offset = end;
+    }
+    if (offset != eocd) {
+      throw FlutterBuildError('SwiftPM binary artifact is not a valid ZIP');
+    }
+  }
+
+  static int _uint16(List<int> bytes, int offset) =>
+      bytes[offset] | (bytes[offset + 1] << 8);
+
+  static int _uint32(List<int> bytes, int offset) =>
+      _uint16(bytes, offset) | (_uint16(bytes, offset + 2) << 16);
+
+  _InspectedArchive _inspect(
+    Archive archive,
+    SwiftPmRemoteBinaryTarget target,
+  ) {
+    if (archive.files.length > _maxEntries) {
+      throw FlutterBuildError(
+        'SwiftPM binary artifact exceeds ZIP entry limit',
+      );
+    }
+
+    var expandedBytes = 0;
+    final names = <String>{};
+    final foldedNames = <String, String>{};
+    final entries = <_SafeEntry>[];
+    for (final entry in archive.files) {
+      expandedBytes += entry.size;
+      if (expandedBytes > _maxExpandedBytes) {
+        throw FlutterBuildError(
+          'SwiftPM binary artifact exceeds ZIP expanded byte limit',
+        );
+      }
+      final name = _safeArchiveName(entry.name);
+      if (!names.add(name)) {
+        throw FlutterBuildError(
+          'SwiftPM binary artifact has duplicate ZIP path: $name',
+        );
+      }
+      final folded = name.toLowerCase();
+      final foldedWinner = foldedNames[folded];
+      if (foldedWinner != null && foldedWinner != name) {
+        throw FlutterBuildError(
+          'SwiftPM binary artifact has case-folded ZIP path collision: '
+          '$foldedWinner and $name',
+        );
+      }
+      foldedNames[folded] = name;
+      entries.add(_SafeEntry(entry, name));
+    }
+
+    final plistName = '${target.name}.xcframework/Info.plist';
+    final plistEntries = entries.where((entry) => entry.name == plistName);
+    if (plistEntries.length != 1 ||
+        !plistEntries.single.file.isFile ||
+        plistEntries.single.file.isSymbolicLink) {
+      throw FlutterBuildError(
+        'SwiftPM binary artifact must contain exactly one root plist for '
+        '${target.name}.xcframework',
+      );
+    }
+    final plistBytes = _materialize(
+      plistEntries.single.file,
+      remainingBytes: _maxExpandedBytes,
+    );
+    final plist = _decodePlist(plistBytes);
+    final materializedBytes = plistBytes.length;
+    final librariesValue = plist['AvailableLibraries'];
+    if (librariesValue is! List) {
+      throw FlutterBuildError(
+        'SwiftPM XCFramework AvailableLibraries must be an array',
+      );
+    }
+    final libraries = <_Library>[];
+    for (final value in librariesValue) {
+      libraries.add(_parseLibrary(value));
+    }
+    final eligible = libraries
+        .where(
+          (library) =>
+              library.platform == 'ios' &&
+              library.variant == null &&
+              library.architectures.contains('arm64'),
+        )
+        .toList();
+    if (eligible.length != 1) {
+      throw FlutterBuildError(
+        'SwiftPM XCFramework must contain exactly one eligible arm64 iOS '
+        'device library; found ${eligible.length}',
+      );
+    }
+    final library = eligible.single;
+    final selectedPrefix = '${target.name}.xcframework/${library.identifier}/';
+    if (entries.any(
+      (entry) =>
+          entry.name.startsWith(selectedPrefix) && entry.file.isSymbolicLink,
+    )) {
+      throw FlutterBuildError(
+        'Unsupported SwiftPM binary artifact: selected device slice requires '
+        'symlinks',
+      );
+    }
+    return _InspectedArchive(
+      entries: entries,
+      plist: plist,
+      library: library,
+      artifactDirectoryName: '${target.name}.xcframework',
+      selectedPrefix: selectedPrefix,
+      materializedBytes: materializedBytes,
+    );
+  }
+
+  Future<void> _extractSelected(
+    _InspectedArchive inspected,
+    Directory artifact,
+  ) async {
+    final reducedPlist = <Object?, Object?>{
+      ...inspected.plist,
+      'AvailableLibraries': [inspected.library.raw],
+    };
+    await File(p.join(artifact.path, 'Info.plist')).writeAsString(
+      PropertyListSerialization.stringWithPropertyList(reducedPlist),
+      flush: true,
+    );
+    var materializedBytes = inspected.materializedBytes;
+    for (final entry in inspected.entries) {
+      if (!entry.name.startsWith(inspected.selectedPrefix)) continue;
+      final relative = entry.name.substring(
+        inspected.artifactDirectoryName.length + 1,
+      );
+      final destination = p.joinAll([artifact.path, ...p.url.split(relative)]);
+      if (entry.file.isDirectory) {
+        await Directory(destination).create(recursive: true);
+      } else {
+        await Directory(p.dirname(destination)).create(recursive: true);
+        final bytes = _materialize(
+          entry.file,
+          remainingBytes: _maxExpandedBytes - materializedBytes,
+        );
+        materializedBytes += bytes.length;
+        await File(destination).writeAsBytes(bytes, flush: true);
+      }
+    }
+  }
+
+  void _validateDeclaredPaths(_Library library, Directory artifact) {
+    for (final declared in {
+      'LibraryPath': library.libraryPath,
+      if (library.headersPath != null) 'HeadersPath': library.headersPath!,
+      if (library.debugSymbolsPath != null)
+        'DebugSymbolsPath': library.debugSymbolsPath!,
+    }.entries) {
+      final relative = '${library.identifier}/${declared.value}';
+      final path = p.joinAll([artifact.path, ...p.url.split(relative)]);
+      if (FileSystemEntity.typeSync(path, followLinks: false) ==
+          FileSystemEntityType.notFound) {
+        throw FlutterBuildError(
+          'SwiftPM XCFramework declared ${declared.key} does not exist: '
+          '${declared.value}',
+        );
+      }
+    }
+  }
+
+  static Uint8List _materialize(
+    ArchiveFile entry, {
+    required int remainingBytes,
+  }) {
+    try {
+      final bytes = entry.content;
+      if (bytes.length > remainingBytes) {
+        throw FlutterBuildError(
+          'SwiftPM binary artifact exceeds ZIP expanded byte limit',
+        );
+      }
+      return bytes;
+    } on FlutterBuildError {
+      rethrow;
+    } on Object {
+      throw FlutterBuildError(
+        'SwiftPM binary artifact content could not be decompressed',
+      );
+    }
+  }
+
+  static Map<Object?, Object?> _decodePlist(Uint8List bytes) {
+    final Object? value;
+    try {
+      value = PropertyListSerialization.propertyListWithString(
+        utf8.decode(bytes),
+      );
+    } on Object {
+      throw FlutterBuildError('SwiftPM XCFramework Info.plist is malformed');
+    }
+    if (value is! Map) {
+      throw FlutterBuildError(
+        'SwiftPM XCFramework Info.plist root must be a dictionary',
+      );
+    }
+    return Map<Object?, Object?>.from(value);
+  }
+
+  static _Library _parseLibrary(Object? value) {
+    if (value is! Map) {
+      throw FlutterBuildError(
+        'SwiftPM XCFramework library metadata must be a dictionary',
+      );
+    }
+    final raw = Map<Object?, Object?>.from(value);
+    final identifier = _requiredString(raw, 'LibraryIdentifier');
+    final libraryPath = _requiredRelativePath(raw, 'LibraryPath');
+    final platform = _requiredString(raw, 'SupportedPlatform');
+    final variant = raw['SupportedPlatformVariant'];
+    if (variant != null && variant is! String) {
+      throw FlutterBuildError(
+        'SwiftPM XCFramework SupportedPlatformVariant must be a string',
+      );
+    }
+    final architecturesValue = raw['SupportedArchitectures'];
+    if (architecturesValue is! List ||
+        architecturesValue.any((value) => value is! String)) {
+      throw FlutterBuildError(
+        'SwiftPM XCFramework SupportedArchitectures must be a string array',
+      );
+    }
+    return _Library(
+      raw: raw,
+      identifier: _safeRelativePath(identifier, 'LibraryIdentifier'),
+      libraryPath: libraryPath,
+      headersPath: _optionalRelativePath(raw, 'HeadersPath'),
+      debugSymbolsPath: _optionalRelativePath(raw, 'DebugSymbolsPath'),
+      platform: platform,
+      variant: variant as String?,
+      architectures: architecturesValue.cast<String>(),
+    );
+  }
+
+  static String _requiredString(Map<Object?, Object?> map, String key) {
+    final value = map[key];
+    if (value is! String || value.isEmpty) {
+      throw FlutterBuildError('SwiftPM XCFramework $key must be a string');
+    }
+    return value;
+  }
+
+  static String _requiredRelativePath(Map<Object?, Object?> map, String key) =>
+      _safeRelativePath(_requiredString(map, key), key);
+
+  static String? _optionalRelativePath(Map<Object?, Object?> map, String key) {
+    final value = map[key];
+    if (value == null) return null;
+    if (value is! String || value.isEmpty) {
+      throw FlutterBuildError('SwiftPM XCFramework $key must be a string');
+    }
+    return _safeRelativePath(value, key);
+  }
+
+  static String _safeRelativePath(String value, String label) {
+    if (value.contains(r'\') || p.url.isAbsolute(value)) {
+      throw FlutterBuildError('SwiftPM XCFramework $label is unsafe');
+    }
+    for (final component in p.url.split(value)) {
+      if (!_isWindowsSafeComponent(component)) {
+        throw FlutterBuildError('SwiftPM XCFramework $label is unsafe');
+      }
+    }
+    if (RegExp('^[A-Za-z]:').hasMatch(value)) {
+      throw FlutterBuildError('SwiftPM XCFramework $label is unsafe');
+    }
+    final normalized = p.url.normalize(value);
+    if (normalized == '.' ||
+        normalized == '..' ||
+        normalized.startsWith('../') ||
+        normalized != value) {
+      throw FlutterBuildError('SwiftPM XCFramework $label is unsafe');
+    }
+    return normalized;
+  }
+
+  static String _safeArchiveName(String value) {
+    if (value.isEmpty || value.contains(r'\') || value.startsWith('/')) {
+      throw FlutterBuildError('SwiftPM binary artifact has unsafe ZIP path');
+    }
+    final withoutTrailingSlash = value.endsWith('/')
+        ? value.substring(0, value.length - 1)
+        : value;
+    for (final component in p.url.split(withoutTrailingSlash)) {
+      if (!_isWindowsSafeComponent(component)) {
+        throw FlutterBuildError('SwiftPM binary artifact has unsafe ZIP path');
+      }
+    }
+    if (RegExp('^[A-Za-z]:').hasMatch(value)) {
+      throw FlutterBuildError('SwiftPM binary artifact has unsafe ZIP path');
+    }
+    final normalized = p.url.normalize(withoutTrailingSlash);
+    if (normalized == '.' ||
+        normalized == '..' ||
+        normalized.startsWith('../') ||
+        normalized != withoutTrailingSlash) {
+      throw FlutterBuildError('SwiftPM binary artifact has unsafe ZIP path');
+    }
+    return normalized;
+  }
+
+  static bool _isWindowsSafeComponent(String value) {
+    if (value.isEmpty || value.endsWith('.') || value.endsWith(' ')) {
+      return false;
+    }
+    for (final codeUnit in value.codeUnits) {
+      if (codeUnit < 0x20 ||
+          codeUnit > 0x7e ||
+          r'<>:"/\|?*'.codeUnits.contains(codeUnit)) {
+        return false;
+      }
+    }
+    final basename = value.split('.').first.toUpperCase();
+    return basename != r'CONIN$' &&
+        basename != r'CONOUT$' &&
+        basename != r'CLOCK$' &&
+        basename != 'CON' &&
+        basename != 'PRN' &&
+        basename != 'AUX' &&
+        basename != 'NUL' &&
+        !RegExp(r'^(COM|LPT)[1-9]$').hasMatch(basename);
+  }
+
+  static String _redactedUrl(Uri url) {
+    final last = url.pathSegments
+        .where((segment) => segment.isNotEmpty)
+        .lastOrNull;
+    final path = last == null ? '' : '/$last';
+    return Uri(
+      scheme: url.scheme,
+      host: url.host,
+      port: url.hasPort ? url.port : null,
+      path: path,
+    ).toString();
+  }
+
+  static Future<void> _defaultDownload(
+    Uri url,
+    File destination,
+    int maximumBytes,
+  ) async {
+    final client = HttpClient();
+    IOSink? output;
+    try {
+      final request = await client.getUrl(url);
+      final response = await request.close();
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        throw HttpException(
+          'HTTP ${response.statusCode} while downloading archive',
+          uri: url,
+        );
+      }
+      if (response.contentLength > maximumBytes) {
+        throw FlutterBuildError(_archiveByteLimitMessage);
+      }
+      await destination.parent.create(recursive: true);
+      output = destination.openWrite();
+      var downloadedBytes = 0;
+      await for (final chunk in response) {
+        if (downloadedBytes + chunk.length > maximumBytes) {
+          throw FlutterBuildError(_archiveByteLimitMessage);
+        }
+        output.add(chunk);
+        downloadedBytes += chunk.length;
+      }
+      await output.flush();
+    } finally {
+      client.close(force: true);
+      await output?.close();
+      if (destination.existsSync() && destination.lengthSync() > maximumBytes) {
+        await destination.delete();
+      }
+    }
+  }
+}
+
+final class _DiagnosticCollector {
+  _DiagnosticCollector(Stream<List<int>> stream) {
+    _subscription = stream.transform(utf8.decoder).listen((chunk) {
+      if (_buffer.length >= _limit) return;
+      final remaining = _limit - _buffer.length;
+      _buffer.write(
+        chunk.length <= remaining ? chunk : chunk.substring(0, remaining),
+      );
+    }, onDone: _done.complete);
+  }
+
+  static const _limit = 1024;
+  final _buffer = StringBuffer();
+  final _done = Completer<void>();
+  late final StreamSubscription<String> _subscription;
+
+  Future<void> get done => _done.future;
+  String get text => _buffer.toString();
+
+  Future<void> stop() async {
+    await _subscription.cancel();
+    if (!_done.isCompleted) _done.complete();
+  }
+}
+
+final class _SafeEntry {
+  const _SafeEntry(this.file, this.name);
+
+  final ArchiveFile file;
+  final String name;
+}
+
+final class _Library {
+  const _Library({
+    required this.raw,
+    required this.identifier,
+    required this.libraryPath,
+    required this.headersPath,
+    required this.debugSymbolsPath,
+    required this.platform,
+    required this.variant,
+    required this.architectures,
+  });
+
+  final Map<Object?, Object?> raw;
+  final String identifier;
+  final String libraryPath;
+  final String? headersPath;
+  final String? debugSymbolsPath;
+  final String platform;
+  final String? variant;
+  final List<String> architectures;
+}
+
+final class _InspectedArchive {
+  const _InspectedArchive({
+    required this.entries,
+    required this.plist,
+    required this.library,
+    required this.artifactDirectoryName,
+    required this.selectedPrefix,
+    required this.materializedBytes,
+  });
+
+  final List<_SafeEntry> entries;
+  final Map<Object?, Object?> plist;
+  final _Library library;
+  final String artifactDirectoryName;
+  final String selectedPrefix;
+  final int materializedBytes;
+}

--- a/packages/xcross/lib/src/flutter/build/swiftpm_binary_artifact_preparer.dart
+++ b/packages/xcross/lib/src/flutter/build/swiftpm_binary_artifact_preparer.dart
@@ -1192,13 +1192,15 @@ final class SwiftPmBinaryArtifactPreparer {
 
 final class _DiagnosticCollector {
   _DiagnosticCollector(Stream<List<int>> stream) {
-    _subscription = stream.transform(utf8.decoder).listen((chunk) {
-      if (_buffer.length >= _limit) return;
-      final remaining = _limit - _buffer.length;
-      _buffer.write(
-        chunk.length <= remaining ? chunk : chunk.substring(0, remaining),
-      );
-    }, onDone: _done.complete);
+    _subscription = stream
+        .transform(const Utf8Decoder(allowMalformed: true))
+        .listen((chunk) {
+          if (_buffer.length >= _limit) return;
+          final remaining = _limit - _buffer.length;
+          _buffer.write(
+            chunk.length <= remaining ? chunk : chunk.substring(0, remaining),
+          );
+        }, onDone: _done.complete);
   }
 
   static const _limit = 1024;

--- a/packages/xcross/lib/src/flutter/build/swiftpm_binary_artifact_store.dart
+++ b/packages/xcross/lib/src/flutter/build/swiftpm_binary_artifact_store.dart
@@ -357,9 +357,20 @@ final class SwiftPmBinaryArtifactStore {
     final result = await Process.run('fsutil.exe', [
       'reparsepoint',
       'query',
-      path,
+      _processPath(path),
     ]);
+
     return result.exitCode == 0;
+  }
+
+  static String _processPath(String path) {
+    if (!Platform.isWindows) return path;
+    final normalized = p.windows.normalize(p.windows.absolute(path));
+    if (normalized.startsWith(r'\\?\UNC\')) {
+      return r'\\' + normalized.substring(8);
+    }
+    if (normalized.startsWith(r'\\?\')) return normalized.substring(4);
+    return normalized;
   }
 
   static Future<String> _treeDigest(Directory root) async {

--- a/packages/xcross/lib/src/flutter/build/swiftpm_binary_artifact_store.dart
+++ b/packages/xcross/lib/src/flutter/build/swiftpm_binary_artifact_store.dart
@@ -1,0 +1,456 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:path/path.dart' as p;
+import 'package:xcross/src/flutter/errors.dart';
+
+final class SwiftPmBinaryArtifactEntry {
+  const SwiftPmBinaryArtifactEntry({
+    required this.archiveChecksum,
+    required this.targetName,
+    required this.artifactPath,
+  });
+
+  final String archiveChecksum;
+  final String targetName;
+  final String artifactPath;
+}
+
+final class SwiftPmBinaryArtifactStore {
+  SwiftPmBinaryArtifactStore(this.root);
+
+  static final Map<String, Future<void>> _localPublicationTails = {};
+
+  final String root;
+
+  String archivePath(String checksum) =>
+      p.join(root, 'archives', '${_checksumComponent(checksum)}.zip');
+
+  String targetRoot(String checksum, String targetName) => p.join(
+    root,
+    'targets',
+    _checksumComponent(checksum),
+    _component(targetName, 'target name'),
+  );
+
+  Future<File> publishArchive(
+    File stagingArchive,
+    String checksum, {
+    int maximumBytes = 536870912,
+  }) async {
+    final expected = _checksumComponent(checksum);
+    final destination = File(archivePath(expected));
+    await destination.parent.create(recursive: true);
+    return _withPublicationLock(destination.path, () async {
+      if (destination.existsSync()) {
+        await _verifyArchive(destination, expected);
+        return destination;
+      }
+
+      final stagingDirectory = await destination.parent.createTemp(
+        '.${p.basename(destination.path)}.staging-',
+      );
+      final staging = File(p.join(stagingDirectory.path, 'archive.zip'));
+      try {
+        await staging.create(exclusive: true);
+        final output = await staging.open(mode: FileMode.writeOnly);
+        try {
+          var copiedBytes = 0;
+          await for (final chunk in stagingArchive.openRead()) {
+            copiedBytes += chunk.length;
+            if (copiedBytes > maximumBytes) {
+              throw FlutterBuildError(
+                'SwiftPM binary artifact exceeds compressed archive byte limit',
+              );
+            }
+            await output.writeFrom(chunk);
+          }
+          await output.flush();
+        } finally {
+          await output.close();
+        }
+        await _verifyArchive(staging, expected);
+        if (destination.existsSync()) {
+          await _verifyArchive(destination, expected);
+          return destination;
+        }
+        return await staging.rename(destination.path);
+      } finally {
+        if (stagingDirectory.existsSync()) {
+          await stagingDirectory.delete(recursive: true);
+        }
+      }
+    });
+  }
+
+  Future<List<int>> readVerifiedArchiveBytes(
+    String checksum, {
+    int? maximumBytes,
+  }) {
+    final expected = _checksumComponent(checksum);
+    final path = archivePath(expected);
+    return _withPublicationLock(path, () async {
+      final file = File(path);
+      final bytes = await file.readAsBytes();
+      if (maximumBytes != null && bytes.length > maximumBytes) {
+        throw FlutterBuildError(
+          'SwiftPM binary artifact exceeds compressed archive byte limit',
+        );
+      }
+      final actual = sha256.convert(bytes).toString();
+      if (actual != expected) {
+        throw FlutterBuildError(
+          'SwiftPM binary artifact checksum mismatch: expected $expected, got $actual',
+          isSecurityFailure: true,
+        );
+      }
+      return bytes;
+    });
+  }
+
+  Future<SwiftPmBinaryArtifactEntry> publishTarget({
+    required String checksum,
+    required String targetName,
+    required Directory stagingRoot,
+    required String artifactDirectoryName,
+    required Map<String, Object?> metadata,
+  }) async {
+    final safeChecksum = _checksumComponent(checksum);
+    final safeTarget = _component(targetName, 'target name');
+    final safeArtifact = _component(
+      artifactDirectoryName,
+      'artifact directory name',
+    );
+    final destination = Directory(targetRoot(safeChecksum, safeTarget));
+    final existing = await findCompleteTarget(safeChecksum, safeTarget);
+    if (existing != null) return existing;
+
+    await destination.parent.create(recursive: true);
+    if (FileSystemEntity.typeSync(stagingRoot.path, followLinks: false) !=
+        FileSystemEntityType.directory) {
+      throw FlutterBuildError(
+        'SwiftPM binary artifact staging root must be a real directory',
+      );
+    }
+    return _withPublicationLock(destination.path, () async {
+      final winner = await findCompleteTarget(safeChecksum, safeTarget);
+      if (winner != null) return winner;
+      if (FileSystemEntity.typeSync(destination.path, followLinks: false) !=
+          FileSystemEntityType.notFound) {
+        await _preserveIncomplete(destination.path);
+      }
+
+      final staging = await destination.parent.createTemp(
+        '.$safeTarget.staging-',
+      );
+      try {
+        await _copyDirectoryContents(stagingRoot, staging);
+        final artifactPath = p.join(staging.path, safeArtifact);
+        if (FileSystemEntity.typeSync(artifactPath, followLinks: false) !=
+            FileSystemEntityType.directory) {
+          throw FlutterBuildError(
+            'SwiftPM binary artifact root must be a real directory: '
+            '$safeArtifact',
+          );
+        }
+        if (await _containsLink(staging)) {
+          throw FlutterBuildError(
+            'SwiftPM binary artifact target trees must not contain links or reparse points',
+            isSecurityFailure: true,
+          );
+        }
+        final completeMetadata = <String, Object?>{
+          ...metadata,
+          'archiveChecksum': safeChecksum,
+          'targetName': safeTarget,
+          'artifactDirectoryName': safeArtifact,
+          'treeDigest': await _treeDigest(Directory(artifactPath)),
+        };
+        await File(
+          p.join(staging.path, 'metadata.json'),
+        ).writeAsString(jsonEncode(completeMetadata), flush: true);
+        await File(
+          p.join(staging.path, '.complete'),
+        ).writeAsString('', flush: true);
+        if (FileSystemEntity.typeSync(destination.path, followLinks: false) !=
+            FileSystemEntityType.notFound) {
+          final racedWinner = await findCompleteTarget(
+            safeChecksum,
+            safeTarget,
+          );
+          if (racedWinner != null) return racedWinner;
+          throw FlutterBuildError(
+            'SwiftPM binary artifact destination changed during publication '
+            'for $safeTarget',
+          );
+        }
+        await staging.rename(destination.path);
+        final published = await findCompleteTarget(safeChecksum, safeTarget);
+        if (published == null) {
+          throw FlutterBuildError(
+            'SwiftPM binary artifact publication is incomplete for $safeTarget',
+          );
+        }
+        return published;
+      } finally {
+        if (staging.existsSync()) await staging.delete(recursive: true);
+      }
+    });
+  }
+
+  Future<SwiftPmBinaryArtifactEntry?> findCompleteTarget(
+    String checksum,
+    String targetName,
+  ) async {
+    final safeChecksum = _checksumComponent(checksum);
+    final safeTarget = _component(targetName, 'target name');
+    final target = Directory(targetRoot(safeChecksum, safeTarget));
+    if (FileSystemEntity.typeSync(target.path, followLinks: false) !=
+            FileSystemEntityType.directory ||
+        await _containsLink(target) ||
+        FileSystemEntity.typeSync(
+              p.join(target.path, '.complete'),
+              followLinks: false,
+            ) !=
+            FileSystemEntityType.file) {
+      return null;
+    }
+    try {
+      final decoded = jsonDecode(
+        await File(p.join(target.path, 'metadata.json')).readAsString(),
+      );
+      if (decoded is! Map<String, dynamic> ||
+          decoded['archiveChecksum'] != safeChecksum ||
+          decoded['targetName'] != safeTarget ||
+          decoded['artifactDirectoryName'] is! String ||
+          decoded['treeDigest'] is! String) {
+        return null;
+      }
+      final artifactName = decoded['artifactDirectoryName'] as String;
+      if (!_isSafeComponent(artifactName)) return null;
+      final artifactPath = p.join(target.path, artifactName);
+      if (FileSystemEntity.typeSync(artifactPath, followLinks: false) !=
+              FileSystemEntityType.directory ||
+          await _treeDigest(Directory(artifactPath)) != decoded['treeDigest']) {
+        return null;
+      }
+      return SwiftPmBinaryArtifactEntry(
+        archiveChecksum: safeChecksum,
+        targetName: safeTarget,
+        artifactPath: artifactPath,
+      );
+    } on FormatException {
+      return null;
+    } on FileSystemException {
+      return null;
+    }
+  }
+
+  static String _checksumComponent(String value) =>
+      _component(value, 'checksum').toLowerCase();
+
+  static String _component(String value, String label) {
+    if (!_isSafeComponent(value)) {
+      throw ArgumentError.value(
+        value,
+        label,
+        'must be one safe path component',
+      );
+    }
+    return value;
+  }
+
+  static bool _isSafeComponent(String value) {
+    if (value.isEmpty ||
+        value == '.' ||
+        value == '..' ||
+        value.contains('/') ||
+        value.contains(r'\') ||
+        value.endsWith('.') ||
+        value.endsWith(' ')) {
+      return false;
+    }
+    for (final code in value.codeUnits) {
+      if (code < 0x20 || code > 0x7e) return false;
+    }
+    if (value.contains(RegExp('[<>:"|?*]'))) return false;
+    final stem = value.split('.').first.toLowerCase();
+    return !RegExp(
+      r'^(con|prn|aux|nul|clock\$|com[1-9]|lpt[1-9])$',
+    ).hasMatch(stem);
+  }
+
+  static Future<void> _verifyArchive(File file, String checksum) async {
+    final actual = await sha256.bind(file.openRead()).first;
+    if (actual.toString().toLowerCase() != checksum.toLowerCase()) {
+      throw FlutterBuildError(
+        'SwiftPM binary artifact checksum mismatch: expected $checksum, '
+        'got $actual',
+        isSecurityFailure: true,
+      );
+    }
+  }
+
+  static Future<void> _copyDirectoryContents(
+    Directory source,
+    Directory destination,
+  ) async {
+    final names = <String>{};
+    await for (final entity in source.list(followLinks: false)) {
+      final name = p.basename(entity.path);
+      if (!_isSafeComponent(name) || !names.add(name.toLowerCase())) {
+        throw FlutterBuildError(
+          'SwiftPM binary artifact target tree contains an unsafe or case-fold-colliding path',
+          isSecurityFailure: true,
+        );
+      }
+      final target = p.join(destination.path, name);
+      if (await _isLinkOrReparsePoint(entity.path)) {
+        throw FlutterBuildError(
+          'SwiftPM binary artifact target trees must not contain links or reparse points',
+          isSecurityFailure: true,
+        );
+      }
+      if (entity is File) {
+        await entity.copy(target);
+      } else if (entity is Directory) {
+        final child = await Directory(target).create();
+        await _copyDirectoryContents(entity, child);
+      } else {
+        throw FlutterBuildError(
+          'SwiftPM binary artifact target trees must not contain symlinks',
+        );
+      }
+    }
+  }
+
+  static Future<bool> _containsLink(Directory root) async {
+    await for (final entity in root.list(recursive: true, followLinks: false)) {
+      if (await _isLinkOrReparsePoint(entity.path)) return true;
+    }
+    return false;
+  }
+
+  static Future<bool> _isLinkOrReparsePoint(String path) async {
+    if (FileSystemEntity.typeSync(path, followLinks: false) ==
+        FileSystemEntityType.link) {
+      return true;
+    }
+    if (!Platform.isWindows) return false;
+    final result = await Process.run('fsutil.exe', [
+      'reparsepoint',
+      'query',
+      path,
+    ]);
+    return result.exitCode == 0;
+  }
+
+  static Future<String> _treeDigest(Directory root) async {
+    final entries = root.listSync(recursive: true, followLinks: false)
+      ..sort((left, right) => left.path.compareTo(right.path));
+    Digest? digest;
+    final input = sha256.startChunkedConversion(
+      ChunkedConversionSink.withCallback((digests) => digest = digests.single),
+    );
+
+    void addFrame(String value) {
+      input.add(utf8.encode(value));
+      input.add(const [0]);
+    }
+
+    addFrame('xcross-swiftpm-target-tree-v1');
+    final foldedPaths = <String>{};
+    for (final entity in entries) {
+      if (await _isLinkOrReparsePoint(entity.path)) {
+        throw FlutterBuildError(
+          'SwiftPM binary artifact target trees must not contain links or reparse points',
+          isSecurityFailure: true,
+        );
+      }
+      final relative = p
+          .relative(entity.path, from: root.path)
+          .replaceAll(r'\', '/');
+      if (!foldedPaths.add(relative.toLowerCase())) {
+        throw FlutterBuildError(
+          'SwiftPM binary artifact target tree contains an unsafe or case-fold-colliding path',
+          isSecurityFailure: true,
+        );
+      }
+      final type = FileSystemEntity.typeSync(entity.path, followLinks: false);
+      addFrame(type.toString());
+      addFrame(relative);
+      switch (type) {
+        case FileSystemEntityType.file:
+          final file = File(entity.path);
+          addFrame((await file.length()).toString());
+          await for (final chunk in file.openRead()) {
+            input.add(chunk);
+          }
+        case FileSystemEntityType.directory:
+          addFrame('0');
+        default:
+          throw FlutterBuildError(
+            'SwiftPM binary artifact target trees contain an unsupported entry type',
+            isSecurityFailure: true,
+          );
+      }
+      input.add(const [0]);
+    }
+    input.close();
+    return digest.toString();
+  }
+
+  static Future<void> _preserveIncomplete(String destinationPath) async {
+    final parent = Directory(p.dirname(destinationPath));
+    final quarantine = await parent.createTemp(
+      '.${p.basename(destinationPath)}.incomplete-',
+    );
+    final preservedPath = p.join(quarantine.path, 'entry');
+    switch (FileSystemEntity.typeSync(destinationPath, followLinks: false)) {
+      case FileSystemEntityType.directory:
+        await Directory(destinationPath).rename(preservedPath);
+      case FileSystemEntityType.file:
+        await File(destinationPath).rename(preservedPath);
+      case FileSystemEntityType.link:
+        await Link(destinationPath).rename(preservedPath);
+      case FileSystemEntityType.notFound:
+      case FileSystemEntityType.pipe:
+      case FileSystemEntityType.unixDomainSock:
+        throw FlutterBuildError(
+          'Cannot preserve incomplete SwiftPM binary artifact destination',
+        );
+    }
+  }
+
+  static Future<T> _withPublicationLock<T>(
+    String destinationPath,
+    Future<T> Function() action,
+  ) async {
+    final lockKey = Platform.isWindows
+        ? p.windows.normalize(p.absolute(destinationPath)).toLowerCase()
+        : p.normalize(p.absolute(destinationPath));
+    final previous = _localPublicationTails[lockKey];
+    final done = Completer<void>();
+    final tail = done.future;
+    _localPublicationTails[lockKey] = tail;
+    if (previous != null) await previous;
+
+    final lockFile = File('$lockKey.lock');
+    await lockFile.parent.create(recursive: true);
+    final lock = await lockFile.open(mode: FileMode.append);
+    try {
+      await lock.lock();
+      return await action();
+    } finally {
+      await lock.unlock();
+      await lock.close();
+      done.complete();
+      if (identical(_localPublicationTails[lockKey], tail)) {
+        final removed = _localPublicationTails.remove(lockKey);
+        assert(identical(removed, tail), 'publication tail changed');
+      }
+    }
+  }
+}

--- a/packages/xcross/lib/src/flutter/build/swiftpm_binary_artifact_store.dart
+++ b/packages/xcross/lib/src/flutter/build/swiftpm_binary_artifact_store.dart
@@ -1,9 +1,12 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:ffi';
 import 'dart:io';
 
 import 'package:crypto/crypto.dart';
+import 'package:ffi/ffi.dart';
 import 'package:path/path.dart' as p;
+
 import 'package:xcross/src/flutter/errors.dart';
 
 final class SwiftPmBinaryArtifactEntry {
@@ -354,24 +357,30 @@ final class SwiftPmBinaryArtifactStore {
       return true;
     }
     if (!Platform.isWindows) return false;
-    final result = await Process.run('fsutil.exe', [
-      'reparsepoint',
-      'query',
-      _processPath(path),
-    ]);
-
-    return result.exitCode == 0;
-  }
-
-  static String _processPath(String path) {
-    if (!Platform.isWindows) return path;
-    final normalized = p.windows.normalize(p.windows.absolute(path));
-    if (normalized.startsWith(r'\\?\UNC\')) {
-      return r'\\' + normalized.substring(8);
+    final pointer = _ioPath(path).toNativeUtf16();
+    try {
+      final attributes = _getFileAttributes(pointer);
+      if (attributes == _invalidFileAttributes) {
+        throw FileSystemException(
+          'Could not read SwiftPM binary artifact attributes',
+          path,
+        );
+      }
+      return attributes & _fileAttributeReparsePoint != 0;
+    } finally {
+      calloc.free(pointer);
     }
-    if (normalized.startsWith(r'\\?\')) return normalized.substring(4);
-    return normalized;
   }
+
+  static const _invalidFileAttributes = 0xffffffff;
+  static const _fileAttributeReparsePoint = 0x400;
+  static final int Function(Pointer<Utf16>) _getFileAttributes =
+      Platform.isWindows
+      ? DynamicLibrary.open('kernel32.dll').lookupFunction<
+          Uint32 Function(Pointer<Utf16>),
+          int Function(Pointer<Utf16>)
+        >('GetFileAttributesW')
+      : (_) => _invalidFileAttributes;
 
   static Future<String> _treeDigest(Directory root) async {
     final rootPath = _ioPath(root.path);

--- a/packages/xcross/lib/src/flutter/build/swiftpm_binary_artifact_store.dart
+++ b/packages/xcross/lib/src/flutter/build/swiftpm_binary_artifact_store.dart
@@ -298,7 +298,9 @@ final class SwiftPmBinaryArtifactStore {
     Directory destination,
   ) async {
     final names = <String>{};
-    await for (final entity in source.list(followLinks: false)) {
+    await for (final entity in _ioDirectory(
+      source.path,
+    ).list(followLinks: false)) {
       final name = p.basename(entity.path);
       if (!_isSafeComponent(name) || !names.add(name.toLowerCase())) {
         throw FlutterBuildError(
@@ -314,9 +316,9 @@ final class SwiftPmBinaryArtifactStore {
         );
       }
       if (entity is File) {
-        await entity.copy(target);
+        await entity.copy(_ioPath(target));
       } else if (entity is Directory) {
-        final child = await Directory(target).create();
+        final child = await _ioDirectory(target).create();
         await _copyDirectoryContents(entity, child);
       } else {
         throw FlutterBuildError(
@@ -327,10 +329,23 @@ final class SwiftPmBinaryArtifactStore {
   }
 
   static Future<bool> _containsLink(Directory root) async {
-    await for (final entity in root.list(recursive: true, followLinks: false)) {
+    await for (final entity in _ioDirectory(
+      root.path,
+    ).list(recursive: true, followLinks: false)) {
       if (await _isLinkOrReparsePoint(entity.path)) return true;
     }
     return false;
+  }
+
+  static Directory _ioDirectory(String path) => Directory(_ioPath(path));
+
+  static String _ioPath(String path) {
+    if (!Platform.isWindows || path.startsWith(r'\\?\')) return path;
+    final absolute = p.windows.normalize(p.windows.absolute(path));
+    if (absolute.startsWith(r'\\')) {
+      return '${r'\\?\UNC\'}${absolute.substring(2)}';
+    }
+    return '${r'\\?\'}$absolute';
   }
 
   static Future<bool> _isLinkOrReparsePoint(String path) async {
@@ -348,8 +363,12 @@ final class SwiftPmBinaryArtifactStore {
   }
 
   static Future<String> _treeDigest(Directory root) async {
-    final entries = root.listSync(recursive: true, followLinks: false)
-      ..sort((left, right) => left.path.compareTo(right.path));
+    final rootPath = _ioPath(root.path);
+    final entries = _ioDirectory(rootPath).listSync(
+      recursive: true,
+      followLinks: false,
+    )..sort((left, right) => left.path.compareTo(right.path));
+
     Digest? digest;
     final input = sha256.startChunkedConversion(
       ChunkedConversionSink.withCallback((digests) => digest = digests.single),
@@ -370,8 +389,9 @@ final class SwiftPmBinaryArtifactStore {
         );
       }
       final relative = p
-          .relative(entity.path, from: root.path)
+          .relative(entity.path, from: rootPath)
           .replaceAll(r'\', '/');
+
       if (!foldedPaths.add(relative.toLowerCase())) {
         throw FlutterBuildError(
           'SwiftPM binary artifact target tree contains an unsafe or case-fold-colliding path',

--- a/packages/xcross/lib/src/flutter/build/swiftpm_binary_target.dart
+++ b/packages/xcross/lib/src/flutter/build/swiftpm_binary_target.dart
@@ -1,0 +1,346 @@
+import 'dart:convert';
+
+final class SwiftPmRemoteBinaryTarget {
+  const SwiftPmRemoteBinaryTarget({
+    required this.name,
+    required this.url,
+    required this.checksum,
+    required this.start,
+    required this.end,
+  });
+
+  final String name;
+  final Uri url;
+  final String checksum;
+  final int start;
+  final int end;
+}
+
+abstract final class SwiftPmBinaryTargetManifest {
+  static final _checksumPattern = RegExp(r'^[0-9a-fA-F]{64}$');
+  static const _callName = '.binaryTarget';
+
+  static List<SwiftPmRemoteBinaryTarget> discover(String source) {
+    final code = _swiftCodeMask(source);
+    final targets = <SwiftPmRemoteBinaryTarget>[];
+
+    for (var start = 0; start < source.length; start++) {
+      if (!code[start] || !source.startsWith(_callName, start)) continue;
+      final nameEnd = start + _callName.length;
+      if (!_isCodeRange(code, start, nameEnd)) continue;
+      if (nameEnd < source.length &&
+          _isIdentifier(source.codeUnitAt(nameEnd))) {
+        continue;
+      }
+
+      var opening = nameEnd;
+      while (opening < source.length &&
+          _isWhitespace(source.codeUnitAt(opening))) {
+        opening++;
+      }
+      if (opening == source.length ||
+          source[opening] != '(' ||
+          !code[opening]) {
+        continue;
+      }
+      final closing = _matchingParenthesis(source, code, opening);
+      if (closing == null) continue;
+
+      final arguments = _directLiteralArguments(
+        source,
+        code,
+        opening + 1,
+        closing,
+      );
+      final name = arguments['name'];
+      final urlText = arguments['url'];
+      final checksum = arguments['checksum'];
+      final url = urlText == null ? null : Uri.tryParse(urlText);
+      final eligibleScheme = url?.scheme == 'https' || url?.scheme == 'http';
+      final eligibleUrl =
+          url != null &&
+          eligibleScheme &&
+          url.hasAuthority &&
+          url.host.isNotEmpty &&
+          url.userInfo.isEmpty &&
+          url.path.toLowerCase().endsWith('.zip');
+      if (name != null &&
+          url != null &&
+          checksum != null &&
+          eligibleUrl &&
+          _checksumPattern.hasMatch(checksum)) {
+        targets.add(
+          SwiftPmRemoteBinaryTarget(
+            name: name,
+            url: url,
+            checksum: checksum,
+            start: start,
+            end: closing + 1,
+          ),
+        );
+      }
+      start = closing;
+    }
+    return targets;
+  }
+
+  static String rewriteToLocalPaths(
+    String source,
+    Map<SwiftPmRemoteBinaryTarget, String> relativePaths,
+  ) {
+    final discovered = discover(source);
+    for (final requested in relativePaths.keys) {
+      final belongs = discovered.any(
+        (target) =>
+            target.start == requested.start &&
+            target.end == requested.end &&
+            target.name == requested.name &&
+            target.url == requested.url &&
+            target.checksum == requested.checksum,
+      );
+      if (!belongs) {
+        throw ArgumentError.value(
+          requested,
+          'relativePaths',
+          'Target not in source',
+        );
+      }
+    }
+
+    var rewritten = source;
+    final replacements = relativePaths.entries.toList()
+      ..sort((left, right) => right.key.start.compareTo(left.key.start));
+    for (final entry in replacements) {
+      final target = entry.key;
+      final replacement =
+          '.binaryTarget(name: ${jsonEncode(target.name)}, path: ${jsonEncode(entry.value)})';
+      rewritten = rewritten.replaceRange(target.start, target.end, replacement);
+    }
+    return rewritten;
+  }
+}
+
+Map<String, String> _directLiteralArguments(
+  String source,
+  List<bool> code,
+  int start,
+  int end,
+) {
+  final arguments = <String, String>{};
+  var segmentStart = start;
+  var round = 0;
+  var square = 0;
+  var curly = 0;
+
+  void parseSegment(int segmentEnd) {
+    var cursor = segmentStart;
+    while (cursor < segmentEnd && _isWhitespace(source.codeUnitAt(cursor))) {
+      cursor++;
+    }
+    final labelStart = cursor;
+    while (cursor < segmentEnd && _isIdentifier(source.codeUnitAt(cursor))) {
+      cursor++;
+    }
+    final label = source.substring(labelStart, cursor);
+    if (label != 'name' && label != 'url' && label != 'checksum') return;
+    while (cursor < segmentEnd && _isWhitespace(source.codeUnitAt(cursor))) {
+      cursor++;
+    }
+    if (cursor == segmentEnd || source[cursor] != ':') return;
+    cursor++;
+    while (cursor < segmentEnd && _isWhitespace(source.codeUnitAt(cursor))) {
+      cursor++;
+    }
+    final literal = _parseStringLiteral(source, cursor, segmentEnd);
+    if (literal != null) arguments[label] = literal;
+  }
+
+  for (var index = start; index < end; index++) {
+    if (!code[index]) continue;
+    switch (source[index]) {
+      case '(':
+        round++;
+      case ')':
+        round--;
+      case '[':
+        square++;
+      case ']':
+        square--;
+      case '{':
+        curly++;
+      case '}':
+        curly--;
+      case ',' when round == 0 && square == 0 && curly == 0:
+        parseSegment(index);
+        segmentStart = index + 1;
+    }
+  }
+  parseSegment(end);
+  return arguments;
+}
+
+String? _parseStringLiteral(String source, int start, int segmentEnd) {
+  var hashes = 0;
+  while (start + hashes < segmentEnd && source[start + hashes] == '#') {
+    hashes++;
+  }
+  final quote = start + hashes;
+  if (quote >= segmentEnd || source[quote] != '"') return null;
+  final multiline = source.startsWith('"""', quote);
+  final openingLength = multiline ? 3 : 1;
+  final closing = '${multiline ? '"""' : '"'}${'#' * hashes}';
+  final contentStart = quote + openingLength;
+  var contentEnd = segmentEnd;
+  while (contentEnd > contentStart &&
+      _isWhitespace(source.codeUnitAt(contentEnd - 1))) {
+    contentEnd--;
+  }
+  if (!source.substring(start, contentEnd).endsWith(closing)) return null;
+  final valueEnd = contentEnd - closing.length;
+  if (valueEnd < contentStart) return null;
+  var value = source.substring(contentStart, valueEnd);
+  final rawEscape = '\\${'#' * hashes}';
+  final interpolation = '$rawEscape(';
+  if (value.contains(interpolation) ||
+      hashes > 0 && value.contains(rawEscape)) {
+    return null;
+  }
+  if (multiline) {
+    final closingLineStart = source.lastIndexOf('\n', valueEnd - 1) + 1;
+    if (source.substring(closingLineStart, valueEnd).trim().isEmpty &&
+        closingLineStart != valueEnd) {
+      return null;
+    }
+    if (value.startsWith('\r\n')) {
+      value = value.substring(2);
+    } else if (value.startsWith('\n')) {
+      value = value.substring(1);
+    }
+    if (value.endsWith('\r\n')) {
+      value = value.substring(0, value.length - 2);
+    } else if (value.endsWith('\n')) {
+      value = value.substring(0, value.length - 1);
+    }
+  }
+  if (hashes > 0) return value;
+  try {
+    return jsonDecode('"${value.replaceAll(r'\/', '/')}"') as String;
+  } on FormatException {
+    return null;
+  }
+}
+
+List<bool> _swiftCodeMask(String source) {
+  final code = List<bool>.filled(source.length, true);
+  var index = 0;
+  while (index < source.length) {
+    if (source.startsWith('//', index)) {
+      final start = index;
+      index += 2;
+      while (index < source.length && source[index] != '\n') {
+        index++;
+      }
+      _mask(code, start, index);
+      continue;
+    }
+    if (source.startsWith('/*', index)) {
+      final start = index;
+      var depth = 1;
+      index += 2;
+      while (index < source.length && depth > 0) {
+        if (source.startsWith('/*', index)) {
+          depth++;
+          index += 2;
+        } else if (source.startsWith('*/', index)) {
+          depth--;
+          index += 2;
+        } else {
+          index++;
+        }
+      }
+      _mask(code, start, index);
+      continue;
+    }
+
+    var hashes = 0;
+    while (index + hashes < source.length && source[index + hashes] == '#') {
+      hashes++;
+    }
+    final quote = index + hashes;
+    if (quote < source.length && source[quote] == '"') {
+      final start = index;
+      final multiline = source.startsWith('"""', quote);
+      final quoteCount = multiline ? 3 : 1;
+      index = quote + quoteCount;
+      final closing = '${multiline ? '"""' : '"'}${'#' * hashes}';
+      while (index < source.length) {
+        if (source.startsWith(closing, index) &&
+            (hashes == 0
+                ? !_isEscaped(source, index)
+                : !_isRawEscapedDelimiter(source, index, hashes))) {
+          index += closing.length;
+          break;
+        }
+        index++;
+      }
+      _mask(code, start, index);
+      continue;
+    }
+    index++;
+  }
+  return code;
+}
+
+int? _matchingParenthesis(String source, List<bool> code, int opening) {
+  var depth = 0;
+  for (var index = opening; index < source.length; index++) {
+    if (!code[index]) continue;
+    if (source[index] == '(') depth++;
+    if (source[index] == ')' && --depth == 0) return index;
+  }
+  return null;
+}
+
+bool _isCodeRange(List<bool> code, int start, int end) {
+  for (var index = start; index < end; index++) {
+    if (!code[index]) return false;
+  }
+  return true;
+}
+
+bool _isRawEscapedDelimiter(String source, int index, int hashes) {
+  final escapeStart = index - hashes - 1;
+  return escapeStart >= 0 &&
+      source[escapeStart] == r'\' &&
+      source.substring(escapeStart + 1, index) == '#' * hashes;
+}
+
+bool _isEscaped(String source, int index) {
+  var slashes = 0;
+  for (
+    var cursor = index - 1;
+    cursor >= 0 && source[cursor] == r'\';
+    cursor--
+  ) {
+    slashes++;
+  }
+  return slashes.isOdd;
+}
+
+bool _isIdentifier(int character) =>
+    character >= 48 && character <= 57 ||
+    character >= 65 && character <= 90 ||
+    character >= 97 && character <= 122 ||
+    character == 95;
+
+bool _isWhitespace(int character) =>
+    character == 0x20 ||
+    character == 0x09 ||
+    character == 0x0a ||
+    character == 0x0d;
+
+void _mask(List<bool> code, int start, int end) {
+  for (var index = start; index < end; index++) {
+    code[index] = false;
+  }
+}

--- a/packages/xcross/lib/src/flutter/errors.dart
+++ b/packages/xcross/lib/src/flutter/errors.dart
@@ -1,8 +1,9 @@
 /// A user-facing error from Flutter iOS packing or hot reload.
 final class FlutterBuildError implements Exception {
-  FlutterBuildError(this.message);
+  FlutterBuildError(this.message, {this.isSecurityFailure = false});
 
   final String message;
+  final bool isSecurityFailure;
 
   @override
   String toString() => message;

--- a/packages/xcross/lib/src/update/self_update.dart
+++ b/packages/xcross/lib/src/update/self_update.dart
@@ -115,6 +115,8 @@ abstract final class SelfUpdate {
   static String get _executableName =>
       Platform.isWindows ? 'xcross.exe' : 'xcross';
 
+  static String get _xcrunName => Platform.isWindows ? 'xcrun.exe' : 'xcrun';
+
   // ------------------------------------------------------------------ swap
 
   static Future<void> installBundle({
@@ -146,6 +148,10 @@ abstract final class SelfUpdate {
         await swap.replace(
           source: p.join(bundleRoot.path, 'bin', _executableName),
           target: p.join(layout.binDir, p.basename(layout.binaryPath)),
+        );
+        await swap.replace(
+          source: p.join(bundleRoot.path, 'bin', _xcrunName),
+          target: p.join(layout.binDir, _xcrunName),
         );
         final libs = Directory(
           p.join(bundleRoot.path, 'lib'),

--- a/packages/xcross/pubspec.yaml
+++ b/packages/xcross/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   http: ^1.6.0
   xml: ^7.0.1
   crypto: ^3.0.7
+  ffi: ^2.2.0
   pointycastle: ^4.0.0
   propertylistserialization: ^1.5.0
   build_cli_annotations: ^2.1.1

--- a/packages/xcross/pubspec.yaml
+++ b/packages/xcross/pubspec.yaml
@@ -18,6 +18,7 @@ resolution: workspace
 
 executables:
   xcross:
+  xcrun:
 
 dependencies:
   archive: ^4.0.9

--- a/packages/xcross/test/cli/flutter_command_args_test.dart
+++ b/packages/xcross/test/cli/flutter_command_args_test.dart
@@ -188,5 +188,16 @@ void main() {
       final results = XcrossCli.buildRunner().argParser.parse(['-v']);
       expect(results.flag('verbose'), isTrue);
     });
+
+    test('verbose is accepted after the flutter build command', () {
+      final results = XcrossCli.buildRunner().argParser.parse([
+        'flutter',
+        'build',
+        '--verbose',
+      ]);
+      expect(results.flag('verbose'), isTrue);
+      expect(results.command!.name, 'flutter');
+      expect(results.command!.command!.name, 'build');
+    });
   });
 }

--- a/packages/xcross/test/cli/tool_alias_dispatch_test.dart
+++ b/packages/xcross/test/cli/tool_alias_dispatch_test.dart
@@ -34,21 +34,33 @@ void main() {
     final temp = Directory.systemTemp.createTempSync('xcross_tool_alias_');
     addTearDown(() => temp.deleteSync(recursive: true));
     final alias = File(p.join(temp.path, 'cc.exe'))..writeAsStringSync('alias');
-    File('${alias.path}.path').writeAsStringSync(r'C:\shims\clang.bat');
+    File('${alias.path}.path').writeAsStringSync(r'C:\LLVM\clang.exe');
+    File(
+      '${alias.path}.args',
+    ).writeAsStringSync(r'["-isysroot","C:\\SDK","-Wl,-arch,arm64"]');
 
     String? executable;
+    List<String>? forwarded;
     final code = await runPreparedToolAlias(
-      ['--version'],
+      ['--target=aarch64-apple-ios', '--version'],
       executablePath: alias.path,
       environment: const {},
-      run: (target, _) async {
+      run: (target, arguments) async {
         executable = target;
+        forwarded = arguments;
         return 0;
       },
     );
 
     expect(code, 0);
-    expect(executable, r'C:\shims\clang.bat');
+    expect(executable, r'C:\LLVM\clang.exe');
+    expect(forwarded, [
+      '-isysroot',
+      r'C:\SDK',
+      '-Wl,-arch,arm64',
+      '--target=aarch64-apple-ios',
+      '--version',
+    ]);
   });
 
   test('plutil replaces MinimumOSVersion for Flutter assemble', () async {

--- a/packages/xcross/test/cli/tool_alias_dispatch_test.dart
+++ b/packages/xcross/test/cli/tool_alias_dispatch_test.dart
@@ -30,6 +30,27 @@ void main() {
     },
   );
 
+  test('dispatches native asset aliases through sidecar mappings', () async {
+    final temp = Directory.systemTemp.createTempSync('xcross_tool_alias_');
+    addTearDown(() => temp.deleteSync(recursive: true));
+    final alias = File(p.join(temp.path, 'cc.exe'))..writeAsStringSync('alias');
+    File('${alias.path}.path').writeAsStringSync(r'C:\shims\clang.bat');
+
+    String? executable;
+    final code = await runPreparedToolAlias(
+      ['--version'],
+      executablePath: alias.path,
+      environment: const {},
+      run: (target, _) async {
+        executable = target;
+        return 0;
+      },
+    );
+
+    expect(code, 0);
+    expect(executable, r'C:\shims\clang.bat');
+  });
+
   test('does not intercept the normal xcross executable', () async {
     expect(
       await runPreparedToolAlias(

--- a/packages/xcross/test/cli/tool_alias_dispatch_test.dart
+++ b/packages/xcross/test/cli/tool_alias_dispatch_test.dart
@@ -51,6 +51,30 @@ void main() {
     expect(executable, r'C:\shims\clang.bat');
   });
 
+  test('plutil replaces MinimumOSVersion for Flutter assemble', () async {
+    final temp = Directory.systemTemp.createTempSync('xcross_plutil_');
+    addTearDown(() => temp.deleteSync(recursive: true));
+    final plist = File(p.join(temp.path, 'Info.plist'))
+      ..writeAsStringSync('''
+<plist><dict>
+<key>MinimumOSVersion</key>
+<string>12.0</string>
+</dict></plist>
+''');
+
+    expect(
+      await runPreparedToolAlias([
+        '-replace',
+        'MinimumOSVersion',
+        '-string',
+        '15.0',
+        plist.path,
+      ], executablePath: p.join(temp.path, 'plutil')),
+      0,
+    );
+    expect(plist.readAsStringSync(), contains('<string>15.0</string>'));
+  });
+
   test('does not intercept the normal xcross executable', () async {
     expect(
       await runPreparedToolAlias(

--- a/packages/xcross/test/cli/xcrun_test.dart
+++ b/packages/xcross/test/cli/xcrun_test.dart
@@ -1,0 +1,9 @@
+import 'package:test/test.dart';
+
+import '../../bin/xcrun.dart' as xcrun;
+
+void main() {
+  test('rejects an invocation without a tool', () async {
+    expect(await xcrun.runXcrun(const []), 1);
+  });
+}

--- a/packages/xcross/test/flutter/build/flutter_packer_test.dart
+++ b/packages/xcross/test/flutter/build/flutter_packer_test.dart
@@ -1,10 +1,17 @@
+import 'dart:convert';
 import 'dart:io';
 import 'dart:isolate';
 
+import 'package:cli_kit/cli_kit.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
+import 'package:xcross/src/cli/basic/sdk_install.dart';
+import 'package:xcross/src/flutter/build/flutter_pack_operation.dart';
 import 'package:xcross/src/flutter/build/flutter_packer.dart';
+import 'package:xcross/src/flutter/build/internal/swiftpm_gate_evidence.dart';
+import 'package:xcross/src/flutter/build/internal/swiftpm_workspace.dart';
 import 'package:xcross/src/flutter/constants.dart';
+import 'package:xcross/src/flutter/errors.dart';
 
 /// Resolves a path under `lib/src/flutter/` without depending on the working
 /// directory the suite happens to be launched from.
@@ -28,6 +35,353 @@ void main() {
     expect(source, isNot(contains('Platform.isWindows && nativePlugins')));
     expect(source, contains('if (plugin.usesSwiftPackageManager)'));
     expect(source, contains('else if (plugin.usesCocoaPods)'));
+  });
+
+  test('keeps independent artifact capabilities disabled by default', () {
+    final source = _read('build/flutter_packer.dart');
+
+    expect(source, contains('this.swiftPmArtifactJunctionCapability = false'));
+    expect(
+      source,
+      contains('this.packageLocalArtifactJunctionCapability = false'),
+    );
+    expect(source, contains('artifactJunctionCapabilityResolver'));
+    expect(
+      source,
+      contains('swiftPmArtifact: swiftPmArtifactJunctionCapability'),
+    );
+    expect(
+      source,
+      contains('packageLocalArtifact: packageLocalArtifactJunctionCapability'),
+    );
+  });
+
+  test('missing Windows Darwin SDK produces install guidance', () async {
+    final workspace = SwiftPmWorkspace.forProject(
+      Directory.systemTemp.path,
+      environment: {'XCROSS_CACHE_DIR': Directory.systemTemp.path},
+    );
+
+    await expectLater(
+      FlutterPackOperation.resolveArtifactJunctionCapabilities(
+        workspace: workspace,
+        currentDarwinSdk: () => null,
+        windows: true,
+      ),
+      throwsA(
+        isA<FlutterBuildError>().having(
+          (error) => error.message,
+          'message',
+          allOf(
+            contains('Darwin Swift SDK not found'),
+            contains('xcross sdk install'),
+          ),
+        ),
+      ),
+    );
+  });
+
+  test('ambient environment cannot enable production junctions', () async {
+    expect(
+      await FlutterPackOperation.artifactJunctionCapabilities(
+        evidenceRoot: p.join(Directory.systemTemp.path, 'missing-evidence'),
+        platformIdentity: 'windows-x64',
+        toolchainIdentity: 'swift-6.3.3',
+        sdkIdentity: 'sdk-a',
+        environment: const {
+          'XCROSS_PACKAGE_LOCAL_ARTIFACT_JUNCTION': '1',
+          'XCROSS_SWIFTPM_ARTIFACT_JUNCTION': '1',
+        },
+      ),
+      (swiftPmArtifact: false, packageLocalArtifact: false),
+    );
+  });
+
+  Future<Map<String, Object?>?> testBinding({
+    required SwiftPmGateMode mode,
+    required String root,
+    required String platformIdentity,
+    required String toolchainIdentity,
+    required String sdkIdentity,
+  }) async => {
+    'formatVersion': 3,
+    'gateImplementationVersion': 3,
+    'extractorBuildVersion': 'xcross-1.3.1-swiftpm-gate-3',
+    'mode': mode.name,
+    'platform': platformIdentity,
+    'toolchain': toolchainIdentity,
+    'sdk': sdkIdentity,
+    'volume': 'test-volume',
+  };
+
+  test('no prior evidence probes both modes and records successes', () async {
+    final temp = await Directory.systemTemp.createTemp(
+      'xcross-gate-first-use-',
+    );
+    try {
+      final platform =
+          '${Platform.operatingSystem}-${Platform.operatingSystemVersion}';
+      final probed = <SwiftPmGateMode>[];
+      final capabilities =
+          await FlutterPackOperation.artifactJunctionCapabilities(
+            evidenceRoot: temp.path,
+            platformIdentity: platform,
+            toolchainIdentity: 'first-use-toolchain',
+            sdkIdentity: 'first-use-sdk',
+            runtimeBinding: testBinding,
+            probe:
+                ({
+                  required mode,
+                  required root,
+                  required toolchainIdentity,
+                  required sdkIdentity,
+                }) async {
+                  probed.add(mode);
+                  return true;
+                },
+          );
+
+      expect(capabilities, (swiftPmArtifact: true, packageLocalArtifact: true));
+      expect(probed, SwiftPmGateMode.values);
+      expect(
+        File(p.join(temp.path, 'swiftPmArtifact.evidence.json')).existsSync(),
+        isTrue,
+      );
+      expect(
+        File(
+          p.join(temp.path, 'packageLocalArtifact.evidence.json'),
+        ).existsSync(),
+        isTrue,
+      );
+    } finally {
+      await temp.delete(recursive: true);
+    }
+  });
+
+  test('failed first-use probe remains disabled and is not recorded', () async {
+    final temp = await Directory.systemTemp.createTemp('xcross-gate-failure-');
+    try {
+      final platform =
+          '${Platform.operatingSystem}-${Platform.operatingSystemVersion}';
+      var calls = 0;
+      final evidence = SwiftPmGateEvidence(temp.path);
+      for (var invocation = 0; invocation < 2; invocation++) {
+        expect(
+          await evidence.verifies(
+            mode: SwiftPmGateMode.swiftPmArtifact,
+            platformIdentity: platform,
+            toolchainIdentity: 'failed-toolchain',
+            sdkIdentity: 'failed-sdk',
+            runtimeBinding: testBinding,
+            probe:
+                ({
+                  required mode,
+                  required root,
+                  required toolchainIdentity,
+                  required sdkIdentity,
+                }) async {
+                  calls++;
+                  return false;
+                },
+          ),
+          isFalse,
+        );
+      }
+      expect(calls, 1);
+      expect(
+        File(p.join(temp.path, 'swiftPmArtifact.evidence.json')).existsSync(),
+        isFalse,
+      );
+    } finally {
+      await temp.delete(recursive: true);
+    }
+  });
+
+  test('executable identities produce independent evidence bindings', () async {
+    final temp = await Directory.systemTemp.createTemp('xcross-gate-tools-');
+    try {
+      final evidence = SwiftPmGateEvidence(temp.path);
+      final platform =
+          '${Platform.operatingSystem}-${Platform.operatingSystemVersion}';
+      var calls = 0;
+      Future<bool> probe({
+        required SwiftPmGateMode mode,
+        required String root,
+        required String toolchainIdentity,
+        required String sdkIdentity,
+      }) async {
+        calls++;
+        return true;
+      }
+
+      for (final identity in [
+        '{"swift-package":{"path":"A/swift-package.exe","version":"6.3"},"swift-build":{"path":"A/swift-build.exe","version":"6.3"}}',
+        '{"swift-package":{"path":"B/swift-package.exe","version":"6.3"},"swift-build":{"path":"A/swift-build.exe","version":"6.3"}}',
+      ]) {
+        expect(
+          await evidence.verifies(
+            mode: SwiftPmGateMode.swiftPmArtifact,
+            platformIdentity: platform,
+            toolchainIdentity: identity,
+            sdkIdentity: 'tools-sdk',
+            probe: probe,
+            runtimeBinding: testBinding,
+          ),
+          isTrue,
+        );
+      }
+      expect(calls, 2);
+    } finally {
+      await temp.delete(recursive: true);
+    }
+  });
+  test('replacing each non-driver tool invalidates gate evidence', () async {
+    final temp = await Directory.systemTemp.createTemp('xcross-gate-tools-');
+    try {
+      final tools = <String, File>{
+        for (final name in const [
+          'swift-package',
+          'swift-build',
+          'swiftc',
+          'clang',
+          'clang++',
+          'ld64.lld',
+          'librarian',
+        ])
+          name: File(p.join(temp.path, name))..writeAsStringSync('first-$name'),
+      };
+      Future<Map<String, Object>> identity() =>
+          SdkInstall.swiftPmBuildToolchainIdentity(
+            cCompilerPath: tools['clang']!.path,
+            cxxCompilerPath: tools['clang++']!.path,
+            linkerPath: tools['ld64.lld']!.path,
+            librarianPath: tools['librarian']!.path,
+            windows: true,
+            locateTool: (name) async => tools[name]!.path,
+            runProcess: (executable, arguments) async =>
+                const CapturedProcess(0, 'Swift version 6.3\n', ''),
+          );
+
+      for (final name in const [
+        'swiftc',
+        'clang',
+        'clang++',
+        'ld64.lld',
+        'librarian',
+      ]) {
+        final recorded = await identity();
+        expect(await validSwiftPmGateToolchainIdentity(recorded), isTrue);
+        tools[name]!.writeAsStringSync('replacement-$name-with-different-size');
+        expect(
+          await validSwiftPmGateToolchainIdentity(recorded),
+          isFalse,
+          reason: name,
+        );
+        tools[name]!.writeAsStringSync('first-$name');
+      }
+    } finally {
+      await temp.delete(recursive: true);
+    }
+  });
+
+  test('valid evidence skips probe across simulated process reset', () async {
+    final temp = await Directory.systemTemp.createTemp('xcross-gate-evidence-');
+    try {
+      final platform =
+          '${Platform.operatingSystem}-${Platform.operatingSystemVersion}';
+      var calls = 0;
+      Future<bool> probe({
+        required SwiftPmGateMode mode,
+        required String root,
+        required String toolchainIdentity,
+        required String sdkIdentity,
+      }) async {
+        calls++;
+        return true;
+      }
+
+      for (var process = 0; process < 2; process++) {
+        expect(
+          await SwiftPmGateEvidence(temp.path).verifies(
+            mode: SwiftPmGateMode.packageLocalArtifact,
+            platformIdentity: platform,
+            toolchainIdentity: 'toolchain',
+            sdkIdentity: 'sdk',
+            probe: probe,
+            runtimeBinding: testBinding,
+          ),
+          isTrue,
+        );
+      }
+      expect(calls, 1);
+    } finally {
+      await temp.delete(recursive: true);
+    }
+  });
+
+  test('stale and forged evidence trigger the probe', () async {
+    final temp = await Directory.systemTemp.createTemp('xcross-gate-forged-');
+    try {
+      final platform =
+          '${Platform.operatingSystem}-${Platform.operatingSystemVersion}';
+      var calls = 0;
+      Future<bool> probe({
+        required SwiftPmGateMode mode,
+        required String root,
+        required String toolchainIdentity,
+        required String sdkIdentity,
+      }) async {
+        calls++;
+        return true;
+      }
+
+      final evidence = SwiftPmGateEvidence(temp.path);
+      expect(
+        await evidence.verifies(
+          mode: SwiftPmGateMode.swiftPmArtifact,
+          platformIdentity: platform,
+          toolchainIdentity: 'toolchain',
+          sdkIdentity: 'sdk',
+          probe: probe,
+          runtimeBinding: testBinding,
+        ),
+        isTrue,
+      );
+      final file = File(p.join(temp.path, 'swiftPmArtifact.evidence.json'));
+      final stale = jsonDecode(file.readAsStringSync()) as Map<String, Object?>;
+      stale['volume'] = 'other-volume';
+      file.writeAsStringSync(jsonEncode(stale), flush: true);
+      expect(
+        await evidence.verifies(
+          mode: SwiftPmGateMode.swiftPmArtifact,
+          platformIdentity: platform,
+          toolchainIdentity: 'toolchain',
+          sdkIdentity: 'sdk',
+          probe: probe,
+          runtimeBinding: testBinding,
+        ),
+        isTrue,
+      );
+      final forged =
+          jsonDecode(file.readAsStringSync()) as Map<String, Object?>;
+      final proof = forged['proof']! as Map<String, Object?>;
+      proof['resultDigest'] = '0' * 64;
+      file.writeAsStringSync(jsonEncode(forged), flush: true);
+      expect(
+        await evidence.verifies(
+          mode: SwiftPmGateMode.swiftPmArtifact,
+          platformIdentity: platform,
+          toolchainIdentity: 'toolchain',
+          sdkIdentity: 'sdk',
+          probe: probe,
+          runtimeBinding: testBinding,
+        ),
+        isTrue,
+      );
+      expect(calls, 3);
+    } finally {
+      await temp.delete(recursive: true);
+    }
   });
 
   test('copies every SwiftPM dylib into Frameworks', () async {

--- a/packages/xcross/test/flutter/build/flutter_packer_test.dart
+++ b/packages/xcross/test/flutter/build/flutter_packer_test.dart
@@ -235,6 +235,45 @@ void main() {
       await temp.delete(recursive: true);
     }
   });
+  test(
+    'toolchain identity invokes a driver through its located name',
+    () async {
+      final temp = await Directory.systemTemp.createTemp('xcross-driver-name-');
+      try {
+        final driver = File(p.join(temp.path, 'swift-driver'))
+          ..writeAsStringSync('driver');
+        final swift = Link(p.join(temp.path, 'swift'))..createSync(driver.path);
+        final swiftc = Link(p.join(temp.path, 'swiftc'))
+          ..createSync(driver.path);
+        final other = File(p.join(temp.path, 'tool'))
+          ..writeAsStringSync('tool');
+        final invoked = <String>[];
+
+        final identity = await SdkInstall.swiftPmBuildToolchainIdentity(
+          cCompilerPath: other.path,
+          cxxCompilerPath: other.path,
+          linkerPath: other.path,
+          librarianPath: other.path,
+          windows: false,
+          locateTool: (name) async =>
+              name == 'swift' ? swift.path : swiftc.path,
+          runProcess: (executable, arguments) async {
+            invoked.add(executable);
+            return const CapturedProcess(0, 'Swift version 6.3\n', '');
+          },
+        );
+
+        expect(invoked, [swift.path, swiftc.path]);
+        expect(
+          (identity['swift']! as Map<String, Object>)['path'],
+          driver.resolveSymbolicLinksSync(),
+        );
+      } finally {
+        await temp.delete(recursive: true);
+      }
+    },
+  );
+
   test('replacing each non-driver tool invalidates gate evidence', () async {
     final temp = await Directory.systemTemp.createTemp('xcross-gate-tools-');
     try {

--- a/packages/xcross/test/flutter/build/ios_native_assets_test.dart
+++ b/packages/xcross/test/flutter/build/ios_native_assets_test.dart
@@ -124,7 +124,11 @@ void main() {
     );
     expect(
       shim,
-      contains("'-Wl,-arch,arm64', '-Wl,-platform_version,ios,13.0,26.5'"),
+      contains(
+        "'-Xlinker', '-arch', '-Xlinker', 'arm64', '-Xlinker', "
+        "'-platform_version', '-Xlinker', 'ios', '-Xlinker', '13.0', "
+        "'-Xlinker', '26.5'",
+      ),
     );
   });
 

--- a/packages/xcross/test/flutter/build/ios_native_assets_test.dart
+++ b/packages/xcross/test/flutter/build/ios_native_assets_test.dart
@@ -72,6 +72,35 @@ void main() {
     }
   });
 
+  test('Windows installs an executable xcrun shim', () async {
+    if (!Platform.isWindows) return;
+    final tmp = await Directory.systemTemp.createTemp('xcrun_shim_test-');
+    try {
+      await installAppleToolShims(
+        tmp.path,
+        const AppleToolShimConfig(
+          iosSdk: r'C:\SDK\iPhoneOS.sdk',
+          clang: r'C:\LLVM\clang.exe',
+          hostCompiler: r'C:\LLVM\clang.exe',
+          archiver: r'C:\LLVM\llvm-ar.exe',
+          linker: r'C:\LLVM\ld64.lld.exe',
+          deploymentTarget: '15.0',
+          lipo: r'C:\LLVM\llvm-lipo.exe',
+          otool: null,
+          installNameTool: null,
+        ),
+        launcherExecutable: Platform.resolvedExecutable,
+      );
+
+      final xcrun = p.join(tmp.path, 'xcrun.exe');
+      expect(File(xcrun).existsSync(), isTrue);
+      expect(File('$xcrun.sdk').readAsStringSync(), r'C:\SDK\iPhoneOS.sdk');
+      expect(File(p.join(tmp.path, 'rsync.bat')).existsSync(), isTrue);
+    } finally {
+      await tmp.delete(recursive: true);
+    }
+  });
+
   test('PowerShell xcrun forwards an empty argument tail safely', () {
     final script = renderPowerShellXcrunShim(
       iosSdk: r'C:\SDK',
@@ -161,8 +190,14 @@ void main() {
       expect(
         (await Process.run(
           xcrun,
-          ['--sdk', 'iphoneos', '--show-sdk-path'],
-          environment: const {},
+          ['--show-sdk-path', '--sdk', 'iphoneos'],
+          environment: {
+            'PATH': tmp.path,
+            if (Platform.environment['SYSTEMROOT'] case final value?)
+              'SYSTEMROOT': value,
+            if (Platform.environment['WINDIR'] case final value?)
+              'WINDIR': value,
+          },
           includeParentEnvironment: false,
         )).stdout.toString().trim(),
         '/sdk/iPhoneOS.sdk',
@@ -177,12 +212,11 @@ void main() {
         '/sdk/iPhoneOS.sdk',
       );
       expect(
-        (await Process.run(
-          xcrun,
-          ['--find', 'clang'],
-          environment: const {},
-          includeParentEnvironment: false,
-        )).stdout.toString().trim(),
+        (await Process.run(xcrun, [
+          '--show-sdk-path',
+          '--sdk',
+          'iphoneos',
+        ])).stdout.toString().trim(),
         p.join(tmp.path, 'clang'),
       );
       final xcrunClang = await Process.run(

--- a/packages/xcross/test/flutter/build/ios_native_assets_test.dart
+++ b/packages/xcross/test/flutter/build/ios_native_assets_test.dart
@@ -143,6 +143,33 @@ void main() {
     );
   });
 
+  test('Windows resolves xcross as the tool forwarder', () async {
+    expect(
+      await resolveNativeAssetToolForwarder(
+        r'C:\bundle\xcross.exe',
+        windows: true,
+        findInstalled: () async => fail('must not search'),
+      ),
+      r'C:\bundle\xcross.exe',
+    );
+    expect(
+      await resolveNativeAssetToolForwarder(
+        r'C:\flutter\bin\cache\dart-sdk\bin\dart.exe',
+        windows: true,
+        findInstalled: () async => r'C:\installed\xcross.exe',
+      ),
+      r'C:\installed\xcross.exe',
+    );
+    expect(
+      await resolveNativeAssetToolForwarder(
+        r'C:\flutter\bin\cache\dart-sdk\bin\dartaotruntime',
+        windows: true,
+        findInstalled: () async => null,
+      ),
+      isNull,
+    );
+  });
+
   test('Apple tool shims expose configured tools including xcrun', () async {
     if (Platform.isWindows) return;
     final tmp = await Directory.systemTemp.createTemp('apple_shims_test-');

--- a/packages/xcross/test/flutter/build/ios_native_assets_test.dart
+++ b/packages/xcross/test/flutter/build/ios_native_assets_test.dart
@@ -124,11 +124,7 @@ void main() {
     );
     expect(
       shim,
-      contains(
-        "'-Xlinker', '-arch', '-Xlinker', 'arm64', '-Xlinker', "
-        "'-platform_version', '-Xlinker', 'ios', '-Xlinker', '13.0', "
-        "'-Xlinker', '26.5'",
-      ),
+      contains("'-Wl,-arch,arm64', '-Wl,-platform_version,ios,13.0,26.5'"),
     );
     expect(shim, contains(r'& $compiler @compilerArguments'));
   });

--- a/packages/xcross/test/flutter/build/ios_native_assets_test.dart
+++ b/packages/xcross/test/flutter/build/ios_native_assets_test.dart
@@ -120,7 +120,8 @@ void main() {
   });
 
   test(
-    'Apple tool shims expose configured tools without replacing xcrun',
+    'Apple tool shims expose configured tools including xcrun',
+
     () async {
       if (Platform.isWindows) return;
       final tmp = await Directory.systemTemp.createTemp('apple_shims_test-');
@@ -137,9 +138,19 @@ void main() {
             lipo: '/bin/echo',
             otool: OtoolConfig('/bin/echo', usesObjdump: false),
             installNameTool: '/bin/echo',
+            xcrun: '/bin/echo',
           ),
         );
-        expect(File(p.join(tmp.path, 'xcrun')).existsSync(), isFalse);
+        expect(File(p.join(tmp.path, 'xcrun')).existsSync(), isTrue);
+        final xcrun = await Process.run(
+          'xcrun',
+          const ['--show-sdk-path'],
+          environment: {'PATH': tmp.path},
+          includeParentEnvironment: false,
+        );
+        expect(xcrun.exitCode, 0);
+        expect(xcrun.stdout.toString().trim(), '--show-sdk-path');
+
         final hostCc = await Process.run(
           'cc',
           const ['-m64', '-Wl,--as-needed', 'host.c'],

--- a/packages/xcross/test/flutter/build/ios_native_assets_test.dart
+++ b/packages/xcross/test/flutter/build/ios_native_assets_test.dart
@@ -122,6 +122,10 @@ void main() {
       shim,
       contains(r'$Arguments = @($args | ForEach-Object { $_.TrimEnd('),
     );
+    expect(
+      shim,
+      contains("'-Wl,-arch,arm64', '-Wl,-platform_version,ios,13.0,26.5'"),
+    );
   });
 
   test('Windows uses the resolved clang as its host C compiler', () async {

--- a/packages/xcross/test/flutter/build/ios_native_assets_test.dart
+++ b/packages/xcross/test/flutter/build/ios_native_assets_test.dart
@@ -109,6 +109,21 @@ void main() {
     }
   });
 
+  test('Windows compiler shim strips carriage returns from arguments', () {
+    final shim = renderPowerShellCompilerShim(
+      iosSdk: r'C:\SDK',
+      clang: r'C:\LLVM\clang.exe',
+      hostCompiler: r'C:\LLVM\clang.exe',
+      linker: r'C:\LLVM\ld64.lld.exe',
+      deploymentTarget: '13.0',
+    );
+
+    expect(
+      shim,
+      contains(r'$Arguments = @($args | ForEach-Object { $_.TrimEnd('),
+    );
+  });
+
   test('Windows uses the resolved clang as its host C compiler', () async {
     expect(
       await resolveHostCompiler(

--- a/packages/xcross/test/flutter/build/ios_native_assets_test.dart
+++ b/packages/xcross/test/flutter/build/ios_native_assets_test.dart
@@ -72,50 +72,6 @@ void main() {
     }
   });
 
-  test('Windows installs an executable xcrun shim', () async {
-    if (!Platform.isWindows) return;
-    final tmp = await Directory.systemTemp.createTemp('xcrun_shim_test-');
-    try {
-      await installAppleToolShims(
-        tmp.path,
-        const AppleToolShimConfig(
-          iosSdk: r'C:\SDK\iPhoneOS.sdk',
-          clang: r'C:\LLVM\clang.exe',
-          hostCompiler: r'C:\LLVM\clang.exe',
-          archiver: r'C:\LLVM\llvm-ar.exe',
-          linker: r'C:\LLVM\ld64.lld.exe',
-          deploymentTarget: '15.0',
-          lipo: r'C:\LLVM\llvm-lipo.exe',
-          otool: null,
-          installNameTool: null,
-        ),
-        launcherExecutable: Platform.resolvedExecutable,
-      );
-
-      final xcrun = p.join(tmp.path, 'xcrun.exe');
-      expect(File(xcrun).existsSync(), isTrue);
-      expect(File('$xcrun.sdk').readAsStringSync(), r'C:\SDK\iPhoneOS.sdk');
-      expect(File(p.join(tmp.path, 'rsync.bat')).existsSync(), isTrue);
-    } finally {
-      await tmp.delete(recursive: true);
-    }
-  });
-
-  test('PowerShell xcrun forwards an empty argument tail safely', () {
-    final script = renderPowerShellXcrunShim(
-      iosSdk: r'C:\SDK',
-      tools: const {'lipo': r'C:\LLVM\lipo.exe'},
-    );
-
-    expect(script, contains(r'$tail = if ($i + 1 -lt $Arguments.Count)'));
-    expect(script, contains('else { @() }'));
-    expect(script, contains(r'& $tool @tail'));
-    expect(
-      script,
-      isNot(contains(r'@($Arguments[($i + 1)..($Arguments.Count - 1)])')),
-    );
-  });
-
   test('falls back from llvm-otool to llvm-objdump', () async {
     final requested = <String>[];
     final result = await resolveOtool(
@@ -163,145 +119,90 @@ void main() {
     );
   });
 
-  test('Apple tool shims expose the Darwin SDK and configured tools', () async {
-    if (Platform.isWindows) return;
-    final tmp = await Directory.systemTemp.createTemp('apple_shims_test-');
-    try {
-      await installAppleToolShims(
-        tmp.path,
-        const AppleToolShimConfig(
-          iosSdk: '/sdk/iPhoneOS.sdk',
-          clang: '/bin/echo',
-          hostCompiler: '/bin/echo',
-          archiver: '/toolchain/llvm-ar',
-          linker: '/toolchain/ld64.lld',
-          deploymentTarget: '15.6',
-          lipo: '/bin/echo',
-          otool: OtoolConfig('/bin/echo', usesObjdump: false),
-          installNameTool: '/bin/echo',
-        ),
-      );
-      final xcrun = p.join(tmp.path, 'xcrun');
-      final xcrunContents = File(xcrun).readAsStringSync();
-      expect(xcrunContents, contains("'/sdk/iPhoneOS.sdk'"));
-      expect(xcrunContents, contains("'${p.join(tmp.path, 'clang')}'"));
-      expect(xcrunContents, isNot(contains('XCROSS_')));
+  test(
+    'Apple tool shims expose configured tools without replacing xcrun',
+    () async {
+      if (Platform.isWindows) return;
+      final tmp = await Directory.systemTemp.createTemp('apple_shims_test-');
+      try {
+        await installAppleToolShims(
+          tmp.path,
+          const AppleToolShimConfig(
+            iosSdk: '/sdk/iPhoneOS.sdk',
+            clang: '/bin/echo',
+            hostCompiler: '/bin/echo',
+            archiver: '/toolchain/llvm-ar',
+            linker: '/toolchain/ld64.lld',
+            deploymentTarget: '15.6',
+            lipo: '/bin/echo',
+            otool: OtoolConfig('/bin/echo', usesObjdump: false),
+            installNameTool: '/bin/echo',
+          ),
+        );
+        expect(File(p.join(tmp.path, 'xcrun')).existsSync(), isFalse);
+        final hostCc = await Process.run(
+          'cc',
+          const ['-m64', '-Wl,--as-needed', 'host.c'],
+          environment: {'PATH': tmp.path},
+          includeParentEnvironment: false,
+        );
+        expect(hostCc.exitCode, 0);
+        expect(hostCc.stdout.toString().trim(), '-m64 -Wl,--as-needed host.c');
 
-      expect(
-        (await Process.run(
-          xcrun,
-          ['--show-sdk-path', '--sdk', 'iphoneos'],
-          environment: {
-            'PATH': tmp.path,
-            if (Platform.environment['SYSTEMROOT'] case final value?)
-              'SYSTEMROOT': value,
-            if (Platform.environment['WINDIR'] case final value?)
-              'WINDIR': value,
-          },
+        final plainCc = await Process.run(
+          'cc',
+          [
+            '-target',
+            'arm64-apple-ios15.6',
+            '-isysroot',
+            '/custom.sdk',
+            '--ld-path=/custom/ld',
+            'asset.c',
+          ],
+          // Rust build subprocesses sanitize the hook environment, retaining
+          // PATH but not xcross-specific variables. Plain cc must still resolve
+          // to the shim, whose cross configuration is embedded in the script.
+          environment: {'PATH': tmp.path},
           includeParentEnvironment: false,
-        )).stdout.toString().trim(),
-        '/sdk/iPhoneOS.sdk',
-      );
-      expect(
-        (await Process.run(
-          xcrun,
-          ['--show-sdk-path', '--sdk', 'iphoneos'],
-          environment: const {},
-          includeParentEnvironment: false,
-        )).stdout.toString().trim(),
-        '/sdk/iPhoneOS.sdk',
-      );
-      expect(
-        (await Process.run(xcrun, [
-          '--show-sdk-path',
-          '--sdk',
-          'iphoneos',
-        ])).stdout.toString().trim(),
-        p.join(tmp.path, 'clang'),
-      );
-      final xcrunClang = await Process.run(
-        xcrun,
-        ['--sdk', 'iphoneos', 'clang', '-arch', 'arm64', 'asset.c'],
-        environment: const {},
-        includeParentEnvironment: false,
-      );
-      expect(xcrunClang.exitCode, 0);
-      expect(
-        xcrunClang.stdout.toString().trim(),
-        '--target=arm64-apple-ios15.6 -isysroot /sdk/iPhoneOS.sdk '
-        '-miphoneos-version-min=15.6 -fuse-ld=lld '
-        '--ld-path=/toolchain/ld64.lld -arch arm64 asset.c',
-      );
-      final hostCc = await Process.run(
-        'cc',
-        const ['-m64', '-Wl,--as-needed', 'host.c'],
-        environment: {'PATH': tmp.path},
-        includeParentEnvironment: false,
-      );
-      expect(hostCc.exitCode, 0);
-      expect(hostCc.stdout.toString().trim(), '-m64 -Wl,--as-needed host.c');
+        );
+        expect(plainCc.exitCode, 0);
+        expect(
+          plainCc.stdout.toString().trim(),
+          '-miphoneos-version-min=15.6 -fuse-ld=lld -target '
+          'arm64-apple-ios15.6 -isysroot /custom.sdk '
+          '--ld-path=/custom/ld asset.c',
+        );
 
-      final plainCc = await Process.run(
-        'cc',
-        [
-          '-target',
-          'arm64-apple-ios15.6',
-          '-isysroot',
-          '/custom.sdk',
-          '--ld-path=/custom/ld',
-          'asset.c',
-        ],
-        // Rust build subprocesses sanitize the hook environment, retaining
-        // PATH but not xcross-specific variables. Plain cc must still resolve
-        // to the shim, whose cross configuration is embedded in the script.
-        environment: {'PATH': tmp.path},
-        includeParentEnvironment: false,
-      );
-      expect(plainCc.exitCode, 0);
-      expect(
-        plainCc.stdout.toString().trim(),
-        '-miphoneos-version-min=15.6 -fuse-ld=lld -target '
-        'arm64-apple-ios15.6 -isysroot /custom.sdk '
-        '--ld-path=/custom/ld asset.c',
-      );
-      expect(
-        (await Process.run(
-          xcrun,
-          ['--sdk', 'iphoneos', 'lipo', '-info', 'asset.dylib'],
-          environment: const {},
-          includeParentEnvironment: false,
-        )).stdout.toString().trim(),
-        '-info asset.dylib',
-      );
-      expect(
-        (await Process.run(
-          p.join(tmp.path, 'otool'),
-          ['-L', 'asset.dylib'],
-          environment: const {},
-          includeParentEnvironment: false,
-        )).stdout.toString().trim(),
-        '-L asset.dylib',
-      );
-      expect(
-        (await Process.run(
-          p.join(tmp.path, 'install_name_tool'),
-          ['-id', '@rpath/asset.dylib', 'asset.dylib'],
-          environment: const {},
-          includeParentEnvironment: false,
-        )).stdout.toString().trim(),
-        '-id @rpath/asset.dylib asset.dylib',
-      );
-      expect(
-        (await Process.run(
-          p.join(tmp.path, 'codesign'),
-          const [],
-          environment: const {},
-          includeParentEnvironment: false,
-        )).exitCode,
-        0,
-      );
-    } finally {
-      await tmp.delete(recursive: true);
-    }
-  });
+        expect(
+          (await Process.run(
+            p.join(tmp.path, 'otool'),
+            ['-L', 'asset.dylib'],
+            environment: const {},
+            includeParentEnvironment: false,
+          )).stdout.toString().trim(),
+          '-L asset.dylib',
+        );
+        expect(
+          (await Process.run(
+            p.join(tmp.path, 'install_name_tool'),
+            ['-id', '@rpath/asset.dylib', 'asset.dylib'],
+            environment: const {},
+            includeParentEnvironment: false,
+          )).stdout.toString().trim(),
+          '-id @rpath/asset.dylib asset.dylib',
+        );
+        expect(
+          (await Process.run(
+            p.join(tmp.path, 'codesign'),
+            const [],
+            environment: const {},
+            includeParentEnvironment: false,
+          )).exitCode,
+          0,
+        );
+      } finally {
+        await tmp.delete(recursive: true);
+      }
+    },
+  );
 }

--- a/packages/xcross/test/flutter/build/ios_native_assets_test.dart
+++ b/packages/xcross/test/flutter/build/ios_native_assets_test.dart
@@ -119,101 +119,99 @@ void main() {
     );
   });
 
-  test(
-    'Apple tool shims expose configured tools including xcrun',
+  test('Apple tool shims expose configured tools including xcrun', () async {
+    if (Platform.isWindows) return;
+    final tmp = await Directory.systemTemp.createTemp('apple_shims_test-');
+    try {
+      await installAppleToolShims(
+        tmp.path,
+        const AppleToolShimConfig(
+          iosSdk: '/sdk/iPhoneOS.sdk',
+          clang: '/bin/echo',
+          hostCompiler: '/bin/echo',
+          archiver: '/toolchain/llvm-ar',
+          linker: '/toolchain/ld64.lld',
+          deploymentTarget: '15.6',
+          lipo: '/bin/echo',
+          otool: OtoolConfig('/bin/echo', usesObjdump: false),
+          installNameTool: '/bin/echo',
+          xcrun: '/bin/echo',
+        ),
+        toolForwarderExecutable: Platform.resolvedExecutable,
+      );
+      expect(File(p.join(tmp.path, 'xcrun')).existsSync(), isTrue);
+      expect(File(p.join(tmp.path, 'plutil')).existsSync(), isTrue);
+      final xcrun = await Process.run(
+        'xcrun',
+        const ['--show-sdk-path'],
+        environment: {'PATH': tmp.path},
+        includeParentEnvironment: false,
+      );
+      expect(xcrun.exitCode, 0);
+      expect(xcrun.stdout.toString().trim(), '--show-sdk-path');
 
-    () async {
-      if (Platform.isWindows) return;
-      final tmp = await Directory.systemTemp.createTemp('apple_shims_test-');
-      try {
-        await installAppleToolShims(
-          tmp.path,
-          const AppleToolShimConfig(
-            iosSdk: '/sdk/iPhoneOS.sdk',
-            clang: '/bin/echo',
-            hostCompiler: '/bin/echo',
-            archiver: '/toolchain/llvm-ar',
-            linker: '/toolchain/ld64.lld',
-            deploymentTarget: '15.6',
-            lipo: '/bin/echo',
-            otool: OtoolConfig('/bin/echo', usesObjdump: false),
-            installNameTool: '/bin/echo',
-            xcrun: '/bin/echo',
-          ),
-        );
-        expect(File(p.join(tmp.path, 'xcrun')).existsSync(), isTrue);
-        final xcrun = await Process.run(
-          'xcrun',
-          const ['--show-sdk-path'],
-          environment: {'PATH': tmp.path},
+      final hostCc = await Process.run(
+        'cc',
+        const ['-m64', '-Wl,--as-needed', 'host.c'],
+        environment: {'PATH': tmp.path},
+        includeParentEnvironment: false,
+      );
+      expect(hostCc.exitCode, 0);
+      expect(hostCc.stdout.toString().trim(), '-m64 -Wl,--as-needed host.c');
+
+      final plainCc = await Process.run(
+        'cc',
+        [
+          '-target',
+          'arm64-apple-ios15.6',
+          '-isysroot',
+          '/custom.sdk',
+          '--ld-path=/custom/ld',
+          'asset.c',
+        ],
+        // Rust build subprocesses sanitize the hook environment, retaining
+        // PATH but not xcross-specific variables. Plain cc must still resolve
+        // to the shim, whose cross configuration is embedded in the script.
+        environment: {'PATH': tmp.path},
+        includeParentEnvironment: false,
+      );
+      expect(plainCc.exitCode, 0);
+      expect(
+        plainCc.stdout.toString().trim(),
+        '-miphoneos-version-min=15.6 -fuse-ld=lld -target '
+        'arm64-apple-ios15.6 -isysroot /custom.sdk '
+        '--ld-path=/custom/ld asset.c',
+      );
+
+      expect(
+        (await Process.run(
+          p.join(tmp.path, 'otool'),
+          ['-L', 'asset.dylib'],
+          environment: const {},
           includeParentEnvironment: false,
-        );
-        expect(xcrun.exitCode, 0);
-        expect(xcrun.stdout.toString().trim(), '--show-sdk-path');
-
-        final hostCc = await Process.run(
-          'cc',
-          const ['-m64', '-Wl,--as-needed', 'host.c'],
-          environment: {'PATH': tmp.path},
+        )).stdout.toString().trim(),
+        '-L asset.dylib',
+      );
+      expect(
+        (await Process.run(
+          p.join(tmp.path, 'install_name_tool'),
+          ['-id', '@rpath/asset.dylib', 'asset.dylib'],
+          environment: const {},
           includeParentEnvironment: false,
-        );
-        expect(hostCc.exitCode, 0);
-        expect(hostCc.stdout.toString().trim(), '-m64 -Wl,--as-needed host.c');
-
-        final plainCc = await Process.run(
-          'cc',
-          [
-            '-target',
-            'arm64-apple-ios15.6',
-            '-isysroot',
-            '/custom.sdk',
-            '--ld-path=/custom/ld',
-            'asset.c',
-          ],
-          // Rust build subprocesses sanitize the hook environment, retaining
-          // PATH but not xcross-specific variables. Plain cc must still resolve
-          // to the shim, whose cross configuration is embedded in the script.
-          environment: {'PATH': tmp.path},
+        )).stdout.toString().trim(),
+        '-id @rpath/asset.dylib asset.dylib',
+      );
+      expect(
+        (await Process.run(
+          p.join(tmp.path, 'codesign'),
+          const [],
+          environment: const {},
           includeParentEnvironment: false,
-        );
-        expect(plainCc.exitCode, 0);
-        expect(
-          plainCc.stdout.toString().trim(),
-          '-miphoneos-version-min=15.6 -fuse-ld=lld -target '
-          'arm64-apple-ios15.6 -isysroot /custom.sdk '
-          '--ld-path=/custom/ld asset.c',
-        );
-
-        expect(
-          (await Process.run(
-            p.join(tmp.path, 'otool'),
-            ['-L', 'asset.dylib'],
-            environment: const {},
-            includeParentEnvironment: false,
-          )).stdout.toString().trim(),
-          '-L asset.dylib',
-        );
-        expect(
-          (await Process.run(
-            p.join(tmp.path, 'install_name_tool'),
-            ['-id', '@rpath/asset.dylib', 'asset.dylib'],
-            environment: const {},
-            includeParentEnvironment: false,
-          )).stdout.toString().trim(),
-          '-id @rpath/asset.dylib asset.dylib',
-        );
-        expect(
-          (await Process.run(
-            p.join(tmp.path, 'codesign'),
-            const [],
-            environment: const {},
-            includeParentEnvironment: false,
-          )).exitCode,
-          0,
-        );
-      } finally {
-        await tmp.delete(recursive: true);
-      }
-    },
-  );
+        )).exitCode,
+        0,
+      );
+    } finally {
+      await tmp.delete(recursive: true);
+    }
+  });
 }

--- a/packages/xcross/test/flutter/build/ios_native_assets_test.dart
+++ b/packages/xcross/test/flutter/build/ios_native_assets_test.dart
@@ -130,6 +130,7 @@ void main() {
         "'-Xlinker', '26.5'",
       ),
     );
+    expect(shim, contains(r'& $compiler @compilerArguments'));
   });
 
   test('Windows uses the resolved clang as its host C compiler', () async {

--- a/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
+++ b/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
@@ -897,7 +897,7 @@ let package = Package(
         rewritten,
         contains(
           '.package(name: "firebase-ios-sdk", '
-          'path: "${swiftPath(p.join(vendorDir, 'firebase-ios-sdk@b9bf3adac18e6e3059167194aeb632f15a5ba4b2'))}")',
+          'path: "${swiftPath(p.join(vendorDir, 'fb@b9bf3adac18e'))}")',
         ),
       );
     });
@@ -970,6 +970,68 @@ let package = Package(
         expect(
           Directory(p.join(repaired, 'macos-arm64_x86_64')).existsSync(),
           isFalse,
+        );
+      },
+    );
+
+    test(
+      'repairs duplicate extractions without emptying the artifact',
+      () async {
+        final scratch = p.join(tmp.path, '.build');
+        for (final uuid in ['UUID-A', 'UUID-B']) {
+          final extracted = p.join(
+            scratch,
+            'artifacts',
+            'extract',
+            'firebase-ios-sdk@revision',
+            'FirebaseFirestoreInternal',
+            uuid,
+            'FirebaseFirestoreInternal.xcframework',
+          );
+          await File(p.join(extracted, 'Info.plist'))
+              .create(recursive: true)
+              .then(
+                (file) => file.writeAsString('''
+<plist><dict><key>AvailableLibraries</key><array><dict>
+<key>LibraryIdentifier</key><string>ios-arm64</string>
+<key>LibraryPath</key><string>FirebaseFirestoreInternal.framework</string>
+<key>SupportedArchitectures</key><array><string>arm64</string></array>
+<key>SupportedPlatform</key><string>ios</string>
+</dict></array></dict></plist>
+'''),
+              );
+          await File(
+            p.join(
+              extracted,
+              'ios-arm64',
+              'FirebaseFirestoreInternal.framework',
+              'FirebaseFirestoreInternal',
+            ),
+          ).create(recursive: true).then((file) => file.writeAsString(uuid));
+        }
+
+        expect(
+          await GeneratedPluginsPackage.repairWindowsBinaryArtifacts(scratch),
+          isTrue,
+        );
+        final repaired = p.join(
+          scratch,
+          'artifacts',
+          'firebase-ios-sdk@revision',
+          'FirebaseFirestoreInternal',
+          'FirebaseFirestoreInternal.xcframework',
+        );
+        expect(File(p.join(repaired, 'Info.plist')).existsSync(), isTrue);
+        expect(
+          File(
+            p.join(
+              repaired,
+              'ios-arm64',
+              'FirebaseFirestoreInternal.framework',
+              'FirebaseFirestoreInternal',
+            ),
+          ).readAsStringSync(),
+          anyOf('UUID-A', 'UUID-B'),
         );
       },
     );
@@ -2578,6 +2640,7 @@ module FirebaseFirestore {
         'GIT_CONFIG_KEY_0': 'core.symlinks',
         'GIT_CONFIG_VALUE_0': 'false',
         'EXPERIMENTAL_SPM_BUILDS': '1',
+        'SWIFTPM_MAXIMUM_CONCURRENT_OPERATIONS': '1',
       });
     });
   });

--- a/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
+++ b/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
@@ -1335,18 +1335,24 @@ let package = Package(
           );
 
           final stable = p.join(
-            fallback,
-            firstChecksum,
-            'First',
+            packageRoot,
+            '.xa',
+            firstChecksum.substring(0, 16),
             'First.xcframework',
           );
-          expect(manifestFile.readAsStringSync(), contains(swiftPath(stable)));
-          final packageLocal = Directory(
-            p.join(packageRoot, 'xcross-artifacts'),
+          expect(
+            manifestFile.readAsStringSync(),
+            contains(
+              p
+                  .join(
+                    '.xa',
+                    firstChecksum.substring(0, 16),
+                    'First.xcframework',
+                  )
+                  .replaceAll(r'\', r'\\'),
+            ),
           );
-          if (packageLocal.existsSync()) {
-            await packageLocal.delete(recursive: true);
-          }
+
           expect(Directory(stable).existsSync(), isTrue);
         }
 
@@ -1385,8 +1391,8 @@ let package = Package(
               windows: true,
             );
 
-        expect(recovery, SwiftPmBinaryArtifactPublication.reused);
-        expect(materializations, 1);
+        expect(recovery, SwiftPmBinaryArtifactPublication.published());
+        expect(materializations, 3);
       },
     );
 
@@ -1416,16 +1422,31 @@ let package = Package(
         );
 
         expect(
-          copiedTo,
-          p.join(
-            tmp.path,
-            'fallback',
-            firstChecksum,
-            'First',
-            'First.xcframework',
+          p.windows.normalize(copiedTo!),
+          endsWith(
+            p.windows.normalize(
+              p.join(
+                packageRoot,
+                '.xa',
+                firstChecksum.substring(0, 16),
+                'First.xcframework',
+              ),
+            ),
           ),
         );
-        expect(manifestFile.readAsStringSync(), contains(swiftPath(copiedTo!)));
+
+        expect(
+          manifestFile.readAsStringSync(),
+          contains(
+            p
+                .join(
+                  '.xa',
+                  firstChecksum.substring(0, 16),
+                  'First.xcframework',
+                )
+                .replaceAll(r'\', r'\\'),
+          ),
+        );
       },
     );
 

--- a/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
+++ b/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
@@ -1105,7 +1105,71 @@ let package = Package(
         isFalse,
       );
     });
+
+    test('stages repaired XCFrameworks into matching binary packages', () async {
+      final scratch = p.join(tmp.path, '.build');
+      final repaired = p.join(
+        scratch,
+        'artifacts',
+        'dependency',
+        'GenericBinary',
+        'GenericBinary.xcframework',
+      );
+      File(p.join(repaired, 'Info.plist'))
+        ..createSync(recursive: true)
+        ..writeAsStringSync('<plist/>');
+      File(
+        p.join(
+          repaired,
+          'ios-arm64',
+          'GenericBinary.framework',
+          'GenericBinary',
+        ),
+      )
+        ..createSync(recursive: true)
+        ..writeAsStringSync('binary');
+      final package = Directory(p.join(tmp.path, 'vendor', 'dependency'))
+        ..createSync(recursive: true);
+      final manifest = File(p.join(package.path, 'Package.swift'))
+        ..writeAsStringSync('''
+let package = Package(targets: [
+  .binaryTarget(
+    name: "GenericBinary",
+    url: "https://example.invalid/GenericBinary.zip",
+    checksum: "checksum"
+  )
+])
+''');
+
+      expect(
+        await GeneratedPluginsPackage.stageExtractedBinaryArtifacts(
+          scratchPath: scratch,
+          vendorDir: p.join(tmp.path, 'vendor'),
+        ),
+        isTrue,
+      );
+      expect(
+        manifest.readAsStringSync(),
+        contains(
+          '.binaryTarget(name: "GenericBinary", '
+          'path: "GenericBinary.xcframework")',
+        ),
+      );
+      expect(
+        File(
+          p.join(
+            package.path,
+            'GenericBinary.xcframework',
+            'ios-arm64',
+            'GenericBinary.framework',
+            'GenericBinary',
+          ),
+        ).readAsStringSync(),
+        'binary',
+      );
+    });
   });
+
 
   group('Windows checkout symlinks', () {
     test(

--- a/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
+++ b/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
@@ -849,6 +849,53 @@ let package = Package(
       expect(evaluations, 1);
     });
 
+    test('caches equivalent vendor checkouts within a build', () async {
+      final vendorDir = p.join(tmp.path, 'checkout-cache-vendor');
+      final first = p.join(tmp.path, 'checkout-first');
+      final second = p.join(tmp.path, 'checkout-second');
+      await Directory(first).create();
+      await Directory(second).create();
+      const manifest = '''
+import PackageDescription
+let package = Package(
+    name: "plugin",
+    dependencies: [.package(url: "https://example.com/dependency", exact: "1.0.0")],
+    targets: []
+)
+''';
+      final cache = <String, Future<void>>{};
+      var clones = 0;
+
+      Future<void> clone(
+        String _,
+        String _,
+        String _,
+        String destination,
+      ) async {
+        clones++;
+        await Directory(destination).create(recursive: true);
+        await File(
+          p.join(destination, 'Package.swift'),
+        ).writeAsString('import PackageDescription\n');
+      }
+
+      for (final packageDirectory in [first, second]) {
+        await GeneratedPluginsPackage.vendorUrlPackagesAsPathDeps(
+          manifest,
+          vendorDir: vendorDir,
+          packageDirectory: packageDirectory,
+          locateTool: (_) async => 'git',
+          evaluateDependencyRefs: (_) async => const {
+            'https://example.com/dependency': 'revision',
+          },
+          clonePackage: clone,
+          checkoutCache: cache,
+        );
+      }
+
+      expect(clones, 1);
+    });
+
     test('removes failed dependency evaluations from the cache', () async {
       final packageDirectory = p.join(tmp.path, 'failed-cache-package');
       await Directory(packageDirectory).create();

--- a/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
+++ b/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
@@ -1168,10 +1168,62 @@ let package = Package(targets: [
         'binary',
       );
     });
+
+    test('ignores broken extraction trees and repairs checkouts', () async {
+      final scratch = p.join(tmp.path, '.build');
+      final repaired = p.join(
+        scratch,
+        'artifacts',
+        'dependency',
+        'Target',
+        'Target.xcframework',
+      );
+      File(p.join(repaired, 'Info.plist'))
+        ..createSync(recursive: true)
+        ..writeAsStringSync('<plist/>');
+      final broken = Directory(
+        p.join(
+          scratch,
+          'artifacts',
+          'extract',
+          'dependency',
+          'Target',
+          'UUID',
+          'Target.xcframework',
+          'missing',
+        ),
+      )..createSync(recursive: true);
+      broken.deleteSync();
+      final checkout = Directory(
+        p.join(scratch, 'checkouts', 'dependency'),
+      )..createSync(recursive: true);
+      final manifest = File(p.join(checkout.path, 'Package.swift'))
+        ..writeAsStringSync('''
+let target = Target.binaryTarget(
+  name: "Target",
+  url: "https://example.invalid/Target.zip",
+  checksum: "checksum"
+)
+''');
+
+      expect(
+        await GeneratedPluginsPackage.stageExtractedBinaryArtifacts(
+          scratchPath: scratch,
+          vendorDir: p.join(tmp.path, 'missing-vendor'),
+        ),
+        isTrue,
+      );
+      expect(manifest.readAsStringSync(), contains('path: "Target.xcframework"'));
+      expect(
+        File(p.join(checkout.path, 'Target.xcframework', 'Info.plist'))
+            .existsSync(),
+        isTrue,
+      );
+    });
   });
 
-
   group('Windows checkout symlinks', () {
+
     test(
       'materializes tracked file symlinks without duplicate files',
       () async {

--- a/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
+++ b/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
@@ -957,6 +957,25 @@ let package = Package(
   });
 
   group('Windows binary artifacts', () {
+    test('bounds robocopy retries', () {
+      expect(
+        GeneratedPluginsPackage.windowsCopyArguments('source', 'destination'),
+        [
+          'source',
+          'destination',
+          '/E',
+          '/R:0',
+          '/W:0',
+          '/MT:8',
+          '/NFL',
+          '/NDL',
+          '/NJH',
+          '/NJS',
+          '/NP',
+        ],
+      );
+    });
+
     test(
       'repairs a failed extraction from its complete iOS device slice',
       () async {
@@ -1185,6 +1204,9 @@ let package = Package(
           ..writeAsStringSync('binary');
         final package = Directory(p.join(tmp.path, 'vendor', 'dependency'))
           ..createSync(recursive: true);
+        final stale = File(
+          p.join(package.path, 'GenericBinary.xcframework', 'stale'),
+        )..createSync(recursive: true);
         final manifest = File(p.join(package.path, 'Package.swift'))
           ..writeAsStringSync('''
 let package = Package(targets: [
@@ -1222,6 +1244,7 @@ let package = Package(targets: [
           ).readAsStringSync(),
           'binary',
         );
+        expect(stale.existsSync(), isFalse);
       },
     );
 

--- a/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
+++ b/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
@@ -9,6 +9,7 @@ import 'package:cli_kit/cli_kit.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:xcross/src/cli/basic/sdk_install.dart';
+import 'package:xcross/src/flutter/build/internal/swiftpm_workspace.dart';
 import 'package:xcross/src/flutter/build/ios_deployment_target.dart';
 import 'package:xcross/src/flutter/build/ios_plugin_package.dart';
 import 'package:xcross/src/flutter/build/ios_plugins.dart';
@@ -3057,18 +3058,21 @@ module FirebaseFirestore {
     test(
       'returns null and writes nothing when there are no SPM plugins',
       () async {
-        final outputDir = p.join(tmp.path, 'out');
+        final workspace = SwiftPmWorkspace.forProject(
+          tmp.path,
+          environment: {'XCROSS_CACHE_DIR': tmp.path},
+        );
 
         final result = await GeneratedPluginsPackage.build(
           projectRoot: tmp.path,
+          workspace: workspace,
           plugins: const [],
           flutterXcframework: p.join(tmp.path, 'Flutter.xcframework'),
-          outputDir: outputDir,
           deploymentTarget: IosDeploymentTarget.fallback,
         );
 
         expect(result, isNull);
-        expect(Directory(outputDir).existsSync(), isFalse);
+        expect(Directory(workspace.packages).existsSync(), isFalse);
       },
     );
 
@@ -3081,18 +3085,21 @@ module FirebaseFirestore {
           p.join(podspecOnly, 'ios', 'plugin_pod.podspec'),
         ).writeAsStringSync('');
         final plugin = IosPlugin(name: 'plugin_pod', packageRoot: podspecOnly);
-        final outputDir = p.join(tmp.path, 'out');
+        final workspace = SwiftPmWorkspace.forProject(
+          tmp.path,
+          environment: {'XCROSS_CACHE_DIR': tmp.path},
+        );
 
         final result = await GeneratedPluginsPackage.build(
           projectRoot: tmp.path,
+          workspace: workspace,
           plugins: [plugin],
           flutterXcframework: p.join(tmp.path, 'Flutter.xcframework'),
-          outputDir: outputDir,
           deploymentTarget: IosDeploymentTarget.fallback,
         );
 
         expect(result, isNull);
-        expect(Directory(outputDir).existsSync(), isFalse);
+        expect(Directory(workspace.packages).existsSync(), isFalse);
       },
     );
   });

--- a/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
+++ b/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
@@ -2640,7 +2640,6 @@ module FirebaseFirestore {
         'GIT_CONFIG_KEY_0': 'core.symlinks',
         'GIT_CONFIG_VALUE_0': 'false',
         'EXPERIMENTAL_SPM_BUILDS': '1',
-        'SWIFTPM_MAXIMUM_CONCURRENT_OPERATIONS': '1',
       });
     });
   });

--- a/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
+++ b/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
@@ -73,7 +73,61 @@ flutter:
     );
   }
 
+  group('incremental build fingerprint', () {
+    test('is stable until a plugin input changes', () async {
+      final plugin = makePlugin(
+        'stable_plugin',
+        packageManifest: 'let package = Package()\n',
+      );
+      final source = File(
+        p.join(plugin.swiftPackageDir, 'Sources', 'Plugin.swift'),
+      )
+        ..createSync(recursive: true)
+        ..writeAsStringSync('let value = 1\n');
+      final framework = Directory(p.join(tmp.path, 'Flutter.xcframework'))
+        ..createSync();
+      File(p.join(framework.path, 'Info.plist')).writeAsStringSync('<plist/>');
+
+      Future<String> fingerprint() =>
+          GeneratedPluginsPackage.incrementalBuildFingerprint(
+            plugins: [plugin],
+            flutterXcframework: framework.path,
+            deploymentTarget: const IosDeploymentTarget('15.0'),
+            verbose: false,
+            toolchainIdentity: 'swift-6.3.3',
+            sdkIdentity: 'ios-sdk',
+          );
+
+      final first = await fingerprint();
+      expect(await fingerprint(), first);
+      source.writeAsStringSync('let value = 2\n');
+      expect(await fingerprint(), isNot(first));
+    });
+
+    test('changes with build configuration', () async {
+      final plugin = makePlugin('plugin');
+      final framework = Directory(p.join(tmp.path, 'Flutter.xcframework'))
+        ..createSync();
+
+      Future<String> fingerprint({required bool verbose}) =>
+          GeneratedPluginsPackage.incrementalBuildFingerprint(
+            plugins: [plugin],
+            flutterXcframework: framework.path,
+            deploymentTarget: const IosDeploymentTarget('15.0'),
+            verbose: verbose,
+            toolchainIdentity: 'swift',
+            sdkIdentity: 'sdk',
+          );
+
+      expect(
+        await fingerprint(verbose: true),
+        isNot(await fingerprint(verbose: false)),
+      );
+    });
+  });
+
   group('flutterFrameworkManifest', () {
+
     test('matches the exact wrapper manifest', () {
       expect(GeneratedPluginsPackage.flutterFrameworkManifest(), '''
 // swift-tools-version: 5.9

--- a/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
+++ b/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
@@ -79,11 +79,10 @@ flutter:
         'stable_plugin',
         packageManifest: 'let package = Package()\n',
       );
-      final source = File(
-        p.join(plugin.swiftPackageDir, 'Sources', 'Plugin.swift'),
-      )
-        ..createSync(recursive: true)
-        ..writeAsStringSync('let value = 1\n');
+      final source =
+          File(p.join(plugin.swiftPackageDir, 'Sources', 'Plugin.swift'))
+            ..createSync(recursive: true)
+            ..writeAsStringSync('let value = 1\n');
       final framework = Directory(p.join(tmp.path, 'Flutter.xcframework'))
         ..createSync();
       File(p.join(framework.path, 'Info.plist')).writeAsStringSync('<plist/>');
@@ -127,7 +126,6 @@ flutter:
   });
 
   group('flutterFrameworkManifest', () {
-
     test('matches the exact wrapper manifest', () {
       expect(GeneratedPluginsPackage.flutterFrameworkManifest(), '''
 // swift-tools-version: 5.9
@@ -1160,32 +1158,34 @@ let package = Package(
       );
     });
 
-    test('stages repaired XCFrameworks into matching binary packages', () async {
-      final scratch = p.join(tmp.path, '.build');
-      final repaired = p.join(
-        scratch,
-        'artifacts',
-        'dependency',
-        'GenericBinary',
-        'GenericBinary.xcframework',
-      );
-      File(p.join(repaired, 'Info.plist'))
-        ..createSync(recursive: true)
-        ..writeAsStringSync('<plist/>');
-      File(
-        p.join(
-          repaired,
-          'ios-arm64',
-          'GenericBinary.framework',
+    test(
+      'stages repaired XCFrameworks into matching binary packages',
+      () async {
+        final scratch = p.join(tmp.path, '.build');
+        final repaired = p.join(
+          scratch,
+          'artifacts',
+          'dependency',
           'GenericBinary',
-        ),
-      )
-        ..createSync(recursive: true)
-        ..writeAsStringSync('binary');
-      final package = Directory(p.join(tmp.path, 'vendor', 'dependency'))
-        ..createSync(recursive: true);
-      final manifest = File(p.join(package.path, 'Package.swift'))
-        ..writeAsStringSync('''
+          'GenericBinary.xcframework',
+        );
+        File(p.join(repaired, 'Info.plist'))
+          ..createSync(recursive: true)
+          ..writeAsStringSync('<plist/>');
+        File(
+            p.join(
+              repaired,
+              'ios-arm64',
+              'GenericBinary.framework',
+              'GenericBinary',
+            ),
+          )
+          ..createSync(recursive: true)
+          ..writeAsStringSync('binary');
+        final package = Directory(p.join(tmp.path, 'vendor', 'dependency'))
+          ..createSync(recursive: true);
+        final manifest = File(p.join(package.path, 'Package.swift'))
+          ..writeAsStringSync('''
 let package = Package(targets: [
   .binaryTarget(
     name: "GenericBinary",
@@ -1195,33 +1195,34 @@ let package = Package(targets: [
 ])
 ''');
 
-      expect(
-        await GeneratedPluginsPackage.stageExtractedBinaryArtifacts(
-          scratchPath: scratch,
-          vendorDir: p.join(tmp.path, 'vendor'),
-        ),
-        isTrue,
-      );
-      expect(
-        manifest.readAsStringSync(),
-        contains(
-          '.binaryTarget(name: "GenericBinary", '
-          'path: "GenericBinary.xcframework")',
-        ),
-      );
-      expect(
-        File(
-          p.join(
-            package.path,
-            'GenericBinary.xcframework',
-            'ios-arm64',
-            'GenericBinary.framework',
-            'GenericBinary',
+        expect(
+          await GeneratedPluginsPackage.stageExtractedBinaryArtifacts(
+            scratchPath: scratch,
+            vendorDir: p.join(tmp.path, 'vendor'),
           ),
-        ).readAsStringSync(),
-        'binary',
-      );
-    });
+          isTrue,
+        );
+        expect(
+          manifest.readAsStringSync(),
+          contains(
+            '.binaryTarget(name: "GenericBinary", '
+            'path: "GenericBinary.xcframework")',
+          ),
+        );
+        expect(
+          File(
+            p.join(
+              package.path,
+              'GenericBinary.xcframework',
+              'ios-arm64',
+              'GenericBinary.framework',
+              'GenericBinary',
+            ),
+          ).readAsStringSync(),
+          'binary',
+        );
+      },
+    );
 
     test('ignores broken extraction trees and repairs checkouts', () async {
       final scratch = p.join(tmp.path, '.build');
@@ -1248,9 +1249,8 @@ let package = Package(targets: [
         ),
       )..createSync(recursive: true);
       broken.deleteSync();
-      final checkout = Directory(
-        p.join(scratch, 'checkouts', 'dependency'),
-      )..createSync(recursive: true);
+      final checkout = Directory(p.join(scratch, 'checkouts', 'dependency'))
+        ..createSync(recursive: true);
       final manifest = File(p.join(checkout.path, 'Package.swift'))
         ..writeAsStringSync('''
 let target = Target.binaryTarget(
@@ -1267,17 +1267,20 @@ let target = Target.binaryTarget(
         ),
         isTrue,
       );
-      expect(manifest.readAsStringSync(), contains('path: "Target.xcframework"'));
       expect(
-        File(p.join(checkout.path, 'Target.xcframework', 'Info.plist'))
-            .existsSync(),
+        manifest.readAsStringSync(),
+        contains('path: "Target.xcframework"'),
+      );
+      expect(
+        File(
+          p.join(checkout.path, 'Target.xcframework', 'Info.plist'),
+        ).existsSync(),
         isTrue,
       );
     });
   });
 
   group('Windows checkout symlinks', () {
-
     test(
       'materializes tracked file symlinks without duplicate files',
       () async {
@@ -2681,35 +2684,36 @@ module FirebaseFirestore {
     });
 
     test(
-      'does not retry an unrelated failure that exposes a missing header',
+      'prebuilds a newly exposed missing header despite truncated diagnostics',
       () async {
         final buildDir = p.join(tmp.path, 'arm64-apple-ios', 'debug');
         final include = p.join(buildDir, 'FirebaseFirestore.build', 'include');
         var attempts = 0;
 
-        await expectLater(
-          GeneratedPluginsPackage.buildWithInteropRecovery(
-            targetBuildDir: buildDir,
-            interopTargetCandidates: const {'FirebaseFirestore'},
-            windows: false,
-            build: () {
-              attempts++;
-              Directory(include).createSync(recursive: true);
-              File(p.join(include, 'module.modulemap')).writeAsStringSync('''
+        await GeneratedPluginsPackage.buildWithInteropRecovery(
+          targetBuildDir: buildDir,
+          interopTargetCandidates: const {'FirebaseFirestore'},
+          windows: false,
+          build: () async {
+            attempts++;
+            if (attempts != 1) return;
+            Directory(include).createSync(recursive: true);
+            File(p.join(include, 'module.modulemap')).writeAsStringSync('''
 module FirebaseFirestore {
   header "FirebaseFirestore-Swift.h"
 }
 ''');
-              return Future<void>.error(
-                StateError('unrelated compile failure'),
-              );
-            },
-            buildTarget: (_) async => fail('no target should be prebuilt'),
-          ),
-          throwsStateError,
+            throw StateError('command failed without compiler output');
+          },
+          buildTarget: (target) async {
+            expect(target, 'FirebaseFirestore');
+            File(
+              p.join(include, 'FirebaseFirestore-Swift.h'),
+            ).writeAsStringSync('// generated');
+          },
         );
 
-        expect(attempts, 1);
+        expect(attempts, 2);
       },
     );
 

--- a/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
+++ b/packages/xcross/test/flutter/build/ios_plugin_package_test.dart
@@ -4,9 +4,9 @@ import 'dart:io';
 import 'dart:isolate';
 import 'dart:typed_data';
 
-import 'package:archive/archive.dart';
 import 'package:cli_kit/cli_kit.dart';
 import 'package:path/path.dart' as p;
+import 'package:propertylistserialization/propertylistserialization.dart';
 import 'package:test/test.dart';
 import 'package:xcross/src/cli/basic/sdk_install.dart';
 import 'package:xcross/src/flutter/build/internal/swiftpm_workspace.dart';
@@ -14,9 +14,27 @@ import 'package:xcross/src/flutter/build/ios_deployment_target.dart';
 import 'package:xcross/src/flutter/build/ios_plugin_package.dart';
 import 'package:xcross/src/flutter/build/ios_plugins.dart';
 import 'package:xcross/src/flutter/build/preview_macro_stub_source.dart';
+import 'package:xcross/src/flutter/build/swiftpm_binary_artifact_preparer.dart';
+import 'package:xcross/src/flutter/build/swiftpm_binary_artifact_store.dart';
+import 'package:xcross/src/flutter/build/swiftpm_binary_target.dart';
 import 'package:xcross/src/flutter/errors.dart';
 
 String swiftPath(String path) => p.absolute(path).replaceAll(r'\', '/');
+
+SwiftPmBinaryArtifactProvenance binaryProvenance(
+  String identity,
+  String target,
+  String checksum,
+  String manifestPath,
+) {
+  final manifest =
+      '.binaryTarget(name: "$target", url: "https://example.invalid/archive.zip", checksum: "$checksum")';
+  return GeneratedPluginsPackage.scanBinaryArtifactProvenance(
+    packageIdentity: identity,
+    manifestPath: manifestPath,
+    manifest: manifest,
+  ).single;
+}
 
 /// Resolves a path under `lib/src/` without depending on the working
 /// directory the suite happens to be launched from.
@@ -831,6 +849,37 @@ let package = Package(
       expect(evaluations, 1);
     });
 
+    test('removes failed dependency evaluations from the cache', () async {
+      final packageDirectory = p.join(tmp.path, 'failed-cache-package');
+      await Directory(packageDirectory).create();
+      const manifest = '''
+import PackageDescription
+let package = Package(
+    name: "plugin",
+    dependencies: [.package(url: "https://example.com/dependency", exact: "1.0.0")],
+    targets: []
+)
+''';
+      final cache = <String, Future<Map<String, String>>>{};
+      var evaluations = 0;
+
+      Future<void> run() => GeneratedPluginsPackage.vendorUrlPackagesAsPathDeps(
+        manifest,
+        vendorDir: p.join(tmp.path, 'failed-cache-vendor'),
+        packageDirectory: packageDirectory,
+        evaluateDependencyRefs: (_) {
+          evaluations++;
+          throw StateError('failed evaluation');
+        },
+        evaluationCache: cache,
+      ).then((_) {});
+
+      await expectLater(run(), throwsStateError);
+      expect(cache, isEmpty);
+      await expectLater(run(), throwsStateError);
+      expect((evaluations, cache.length), (2, 0));
+    });
+
     test('invalidates dependency evaluation for manifest variants', () async {
       final vendorDir = p.join(tmp.path, 'variant-vendor');
       final packageDirectory = p.join(tmp.path, 'variant-package');
@@ -956,7 +1005,504 @@ let package = Package(
     });
   });
 
+  group('bootstrap binary recovery', () {
+    test('retries resolve once and preserves failed cache semantics', () async {
+      final package = Directory(p.join(tmp.path, 'package'))..createSync();
+      final resolved = File(p.join(package.path, 'Package.resolved'));
+      var resolves = 0;
+      var recoveries = 0;
+      final state = SwiftPmBinaryAttemptState();
+
+      final refs =
+          await GeneratedPluginsPackage.evaluateDependencyRefsWithRecovery(
+            package.path,
+            resolve: (_) async {
+              resolves++;
+              if (resolves == 1) throw StateError('original');
+              resolved.writeAsStringSync(
+                jsonEncode({
+                  'pins': [
+                    {
+                      'location': 'https://example.com/dependency',
+                      'state': {'revision': 'revision'},
+                    },
+                  ],
+                }),
+              );
+            },
+            recover: (_, attemptState) async {
+              expect(identical(attemptState, state), isTrue);
+              recoveries++;
+              attemptState.bootstrapRecovered.add('package\u0000target');
+              return true;
+            },
+            attemptState: state,
+          );
+
+      expect(refs, {'https://example.com/dependency': 'revision'});
+      expect((resolves, recoveries), (2, 1));
+      expect(state.bootstrapRecovered, hasLength(1));
+    });
+
+    test('rethrows original failure when recovery has no evidence', () async {
+      final original = StateError('original');
+      await expectLater(
+        GeneratedPluginsPackage.evaluateDependencyRefsWithRecovery(
+          tmp.path,
+          resolve: (_) async => throw original,
+          recover: (_, _) async => false,
+          attemptState: SwiftPmBinaryAttemptState(),
+        ),
+        throwsA(same(original)),
+      );
+    });
+
+    test('second resolve failure is terminal', () async {
+      var resolves = 0;
+      final second = StateError('second');
+      await expectLater(
+        GeneratedPluginsPackage.evaluateDependencyRefsWithRecovery(
+          tmp.path,
+          resolve: (_) {
+            resolves++;
+            if (resolves == 1) throw StateError('first');
+            throw second;
+          },
+          recover: (_, _) async => true,
+          attemptState: SwiftPmBinaryAttemptState(),
+        ),
+        throwsA(same(second)),
+      );
+      expect(resolves, 2);
+    });
+  });
+
+  group('binary artifact provenance', () {
+    test('keeps package and target identity when matching artifacts', () {
+      final first = GeneratedPluginsPackage.matchBinaryArtifactProvenance(
+        artifactPath: p.join('scratch', 'artifacts', 'one', 'SharedBinary'),
+        artifactsRoot: p.join('scratch', 'artifacts'),
+        provenance: [
+          binaryProvenance(
+            'one',
+            'SharedBinary',
+            'a' * 64,
+            'one/Package.swift',
+          ),
+          binaryProvenance(
+            'two',
+            'SharedBinary',
+            'b' * 64,
+            'two/Package.swift',
+          ),
+        ],
+      );
+      final second = GeneratedPluginsPackage.matchBinaryArtifactProvenance(
+        artifactPath: p.join('scratch', 'artifacts', 'two', 'SharedBinary'),
+        artifactsRoot: p.join('scratch', 'artifacts'),
+        provenance: [
+          binaryProvenance(
+            'one',
+            'SharedBinary',
+            'a' * 64,
+            'one/Package.swift',
+          ),
+          binaryProvenance(
+            'two',
+            'SharedBinary',
+            'b' * 64,
+            'two/Package.swift',
+          ),
+        ],
+      );
+
+      expect(first?.manifestPath, 'one/Package.swift');
+      expect(second?.manifestPath, 'two/Package.swift');
+    });
+
+    test('matches SwiftPM layout case-insensitively on Windows', () {
+      final match = GeneratedPluginsPackage.matchBinaryArtifactProvenance(
+        artifactPath: p.join('artifacts', 'PACKAGE', 'target'),
+        artifactsRoot: 'artifacts',
+        provenance: [
+          binaryProvenance('Package', 'Target', 'A' * 64, 'Package.swift'),
+        ],
+        windows: true,
+      );
+
+      expect(match?.packageIdentity, 'Package');
+    });
+
+    test('rejects ambiguous package identity and dynamic targets', () {
+      final duplicate = binaryProvenance(
+        'package',
+        'Target',
+        'a' * 64,
+        'Package.swift',
+      );
+      expect(
+        GeneratedPluginsPackage.matchBinaryArtifactProvenance(
+          artifactPath: p.join('artifacts', 'package', 'Target'),
+          artifactsRoot: 'artifacts',
+          provenance: [duplicate, duplicate],
+        ),
+        isNull,
+      );
+      expect(
+        GeneratedPluginsPackage.scanBinaryArtifactProvenance(
+          packageIdentity: 'package',
+          manifestPath: 'Package.swift',
+          manifest:
+              'let url = dynamicUrl\n.binaryTarget(name: "Target", url: url, checksum: checksum)',
+        ),
+        isEmpty,
+      );
+    });
+  });
+
+  group('bootstrap artifact evidence', () {
+    test('complete artifact does not recover an unrelated failure', () async {
+      final scratch = p.join(tmp.path, 'authoritative', 'scratch');
+      final store = p.join(tmp.path, 'authoritative', 'store');
+      final targetDirectory = p.join(scratch, 'artifacts', 'package', 'Target');
+      File(p.join(targetDirectory, 'Target.xcframework', 'Info.plist'))
+        ..createSync(recursive: true)
+        ..writeAsStringSync('<plist/>');
+
+      expect(
+        await GeneratedPluginsPackage.recoverBootstrapBinaryArtifacts(
+          scratchPath: scratch,
+          binaryArtifactStore: store,
+          provenance: [
+            binaryProvenance(
+              'package',
+              'Target',
+              'a' * 64,
+              p.join(tmp.path, 'Package.swift'),
+            ),
+          ],
+          attemptState: SwiftPmBinaryAttemptState(),
+          windows: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test(
+      'validates final artifact plist and selected library structurally',
+      () async {
+        final artifact = Directory(p.join(tmp.path, 'Final.xcframework'))
+          ..createSync();
+        final plist = {
+          'AvailableLibraries': [
+            {
+              'LibraryIdentifier': 'ios-arm64',
+              'LibraryPath': 'Final.framework',
+              'SupportedPlatform': 'ios',
+              'SupportedArchitectures': ['arm64'],
+            },
+          ],
+        };
+        File(p.join(artifact.path, 'Info.plist')).writeAsStringSync(
+          PropertyListSerialization.stringWithPropertyList(plist),
+        );
+        File(p.join(artifact.path, '.complete')).writeAsStringSync('');
+
+        expect(
+          await GeneratedPluginsPackage.hasCompleteSwiftPmArtifact(artifact),
+          isFalse,
+        );
+
+        Directory(
+          p.join(artifact.path, 'ios-arm64', 'Final.framework'),
+        ).createSync(recursive: true);
+        expect(
+          await GeneratedPluginsPackage.hasCompleteSwiftPmArtifact(artifact),
+          isTrue,
+        );
+      },
+    );
+
+    test('attempt key includes normalized checksum', () {
+      final upper = binaryProvenance(
+        'Package',
+        'Target',
+        'A' * 64,
+        'Package.swift',
+      );
+      expect(
+        GeneratedPluginsPackage.binaryArtifactAttemptKey(upper, windows: true),
+        'package\u0000target\u0000${'a' * 64}',
+      );
+    });
+  });
+
   group('Windows binary artifacts', () {
+    const firstChecksum =
+        '1111111111111111111111111111111111111111111111111111111111111111';
+    const secondChecksum =
+        '2222222222222222222222222222222222222222222222222222222222222222';
+
+    String manifest() =>
+        'let targets: [Target] = [\n'
+        '  .binaryTarget(name: "First", url: "https://example.invalid/first.zip", checksum: "$firstChecksum"),\n'
+        '  .binaryTarget(name: "Second", url: "https://example.invalid/second.zip", checksum: "$secondChecksum"),\n'
+        ']\n';
+
+    Future<SwiftPmPreparedBinaryArtifact> preparedArtifact(
+      String packageRoot,
+      SwiftPmRemoteBinaryTarget target,
+    ) async {
+      final artifact = Directory(
+        p.join(
+          packageRoot,
+          'prepared',
+          target.name,
+          '${target.name}.xcframework',
+        ),
+      )..createSync(recursive: true);
+      return SwiftPmPreparedBinaryArtifact(
+        target: target,
+        entry: SwiftPmBinaryArtifactEntry(
+          archiveChecksum: target.checksum,
+          targetName: target.name,
+          artifactPath: artifact.path,
+        ),
+      );
+    }
+
+    test('rewrites successful target and preserves unsupported call', () async {
+      final packageRoot = p.join(tmp.path, 'mixed');
+      final manifestFile = File(p.join(packageRoot, 'Package.swift'))
+        ..createSync(recursive: true)
+        ..writeAsStringSync(manifest());
+      final originalSecond = manifest().split('\n')[2];
+
+      await GeneratedPluginsPackage.prepareSupportedBinaryArtifacts(
+        packageRoot: packageRoot,
+        binaryArtifactStore: p.join(tmp.path, 'store'),
+        binaryArtifactFallback: p.join(tmp.path, 'fallback'),
+        packageLocalArtifactJunctionCapability: true,
+        windows: true,
+        prepare: (target) {
+          if (target.name == 'Second') {
+            throw FlutterBuildError('unsupported archive slice');
+          }
+          return preparedArtifact(packageRoot, target);
+        },
+        createAlias: ({required alias, required target}) async {
+          Directory(alias).createSync(recursive: true);
+        },
+      );
+
+      final rewritten = manifestFile.readAsStringSync();
+      expect(rewritten, contains('.binaryTarget(name: "First", path: '));
+      expect(rewritten.split('\n')[2], originalSecond);
+    });
+
+    test(
+      'materializes stable fallback once across clean staging and recovery',
+      () async {
+        final fallback = p.join(tmp.path, 'fallback');
+        final store = p.join(tmp.path, 'store');
+        var materializations = 0;
+
+        Future<SwiftPmBinaryArtifactPublication> materialize({
+          required String source,
+          required String destination,
+        }) async {
+          if (Directory(destination).existsSync()) {
+            return SwiftPmBinaryArtifactPublication.reused;
+          }
+          materializations++;
+          await Directory(destination).create(recursive: true);
+          return SwiftPmBinaryArtifactPublication.published();
+        }
+
+        for (final run in ['first-run', 'second-run']) {
+          final packageRoot = p.join(tmp.path, run);
+          final manifestFile = File(p.join(packageRoot, 'Package.swift'))
+            ..createSync(recursive: true)
+            ..writeAsStringSync(manifest().split('\n')[1]);
+          await GeneratedPluginsPackage.prepareSupportedBinaryArtifacts(
+            packageRoot: packageRoot,
+            binaryArtifactStore: store,
+            binaryArtifactFallback: fallback,
+            packageLocalArtifactJunctionCapability: false,
+            windows: true,
+            prepare: (target) => preparedArtifact(tmp.path, target),
+            materialize: materialize,
+          );
+
+          final stable = p.join(
+            fallback,
+            firstChecksum,
+            'First',
+            'First.xcframework',
+          );
+          expect(manifestFile.readAsStringSync(), contains(swiftPath(stable)));
+          final packageLocal = Directory(
+            p.join(packageRoot, 'xcross-artifacts'),
+          );
+          if (packageLocal.existsSync()) {
+            await packageLocal.delete(recursive: true);
+          }
+          expect(Directory(stable).existsSync(), isTrue);
+        }
+
+        final provenance = binaryProvenance(
+          'package',
+          'First',
+          firstChecksum,
+          'Package.swift',
+        );
+        final stable = p.join(
+          fallback,
+          firstChecksum,
+          'First',
+          'First.xcframework',
+        );
+        final recovery =
+            await GeneratedPluginsPackage.recoverFinalBinaryArtifact(
+              provenance: provenance,
+              preparedArtifactPath: p.join(
+                tmp.path,
+                'prepared',
+                'First',
+                'First.xcframework',
+              ),
+              binaryArtifactStore: store,
+              destination: p.join(
+                tmp.path,
+                'pruned',
+                'xcross-artifacts',
+                'First',
+              ),
+              materializedDestination: stable,
+              attemptState: SwiftPmBinaryAttemptState(),
+              packageLocalArtifactJunctionCapability: false,
+              materialize: materialize,
+              windows: true,
+            );
+
+        expect(recovery, SwiftPmBinaryArtifactPublication.reused);
+        expect(materializations, 1);
+      },
+    );
+
+    test(
+      'falls back to stable materialization when alias creation fails',
+      () async {
+        final packageRoot = p.join(tmp.path, 'alias-failure');
+        final manifestFile = File(p.join(packageRoot, 'Package.swift'))
+          ..createSync(recursive: true)
+          ..writeAsStringSync(manifest().split('\n')[1]);
+        String? copiedTo;
+
+        await GeneratedPluginsPackage.prepareSupportedBinaryArtifacts(
+          packageRoot: packageRoot,
+          binaryArtifactStore: p.join(tmp.path, 'store'),
+          binaryArtifactFallback: p.join(tmp.path, 'fallback'),
+          packageLocalArtifactJunctionCapability: true,
+          windows: true,
+          prepare: (target) => preparedArtifact(tmp.path, target),
+          createAlias: ({required alias, required target}) async =>
+              throw FileSystemException('junction unavailable', alias),
+          materialize: ({required source, required destination}) async {
+            copiedTo = destination;
+            await Directory(destination).create(recursive: true);
+            return SwiftPmBinaryArtifactPublication.published();
+          },
+        );
+
+        expect(
+          copiedTo,
+          p.join(
+            tmp.path,
+            'fallback',
+            firstChecksum,
+            'First',
+            'First.xcframework',
+          ),
+        );
+        expect(manifestFile.readAsStringSync(), contains(swiftPath(copiedTo!)));
+      },
+    );
+
+    test('leaves a download failure call byte-identical', () async {
+      final packageRoot = p.join(tmp.path, 'download');
+      final original = manifest().split('\n')[1];
+      final manifestFile = File(p.join(packageRoot, 'Package.swift'))
+        ..createSync(recursive: true)
+        ..writeAsStringSync('$original\n');
+      var writes = 0;
+
+      await GeneratedPluginsPackage.prepareSupportedBinaryArtifacts(
+        packageRoot: packageRoot,
+        binaryArtifactStore: p.join(tmp.path, 'store'),
+        binaryArtifactFallback: p.join(tmp.path, 'fallback'),
+        packageLocalArtifactJunctionCapability: true,
+        windows: true,
+        prepare: (_) => throw FlutterBuildError('download failed'),
+        writeManifest: (_, __) async => writes++,
+      );
+
+      expect(manifestFile.readAsStringSync(), '$original\n');
+      expect(writes, 0);
+    });
+
+    test(
+      'checksum failure rolls back aliases without manifest rewrite',
+      () async {
+        final packageRoot = p.join(tmp.path, 'security');
+        final original = manifest();
+        final manifestFile = File(p.join(packageRoot, 'Package.swift'))
+          ..createSync(recursive: true)
+          ..writeAsStringSync(original);
+        final aliases = <String>[];
+        var writes = 0;
+
+        await expectLater(
+          GeneratedPluginsPackage.prepareSupportedBinaryArtifacts(
+            packageRoot: packageRoot,
+            binaryArtifactStore: p.join(tmp.path, 'store'),
+            binaryArtifactFallback: p.join(tmp.path, 'fallback'),
+            packageLocalArtifactJunctionCapability: true,
+            windows: true,
+            prepare: (target) {
+              if (target.name == 'Second') {
+                throw FlutterBuildError(
+                  'checksum mismatch',
+                  isSecurityFailure: true,
+                );
+              }
+              return preparedArtifact(packageRoot, target);
+            },
+            createAlias: ({required alias, required target}) async {
+              Directory(alias).createSync(recursive: true);
+              aliases.add(alias);
+            },
+            removeAlias: (alias) async {
+              aliases.remove(alias);
+              await Directory(alias).delete(recursive: true);
+            },
+            writeManifest: (_, __) async => writes++,
+          ),
+          throwsA(
+            isA<FlutterBuildError>().having(
+              (error) => error.isSecurityFailure,
+              'isSecurityFailure',
+              isTrue,
+            ),
+          ),
+        );
+
+        expect(aliases, isEmpty);
+        expect(manifestFile.readAsStringSync(), original);
+        expect(writes, 0);
+      },
+    );
+
     test('bounds robocopy retries', () {
       expect(
         GeneratedPluginsPackage.windowsCopyArguments('source', 'destination'),
@@ -973,333 +1519,6 @@ let package = Package(
           '/NJS',
           '/NP',
         ],
-      );
-    });
-
-    test(
-      'repairs a failed extraction from its complete iOS device slice',
-      () async {
-        final scratch = p.join(tmp.path, '.build');
-        final extracted = p.join(
-          scratch,
-          'artifacts',
-          'extract',
-          'firebase-ios-sdk',
-          'FirebaseAnalytics',
-          'UUID',
-          'FirebaseAnalytics.xcframework',
-        );
-        await File(p.join(extracted, 'Info.plist'))
-            .create(recursive: true)
-            .then(
-              (file) => file.writeAsString('''
-<plist><dict><key>AvailableLibraries</key><array><dict>
-<key>LibraryIdentifier</key><string>ios-arm64</string>
-<key>LibraryPath</key><string>FirebaseAnalytics.framework</string>
-<key>SupportedArchitectures</key><array><string>arm64</string></array>
-<key>SupportedPlatform</key><string>ios</string>
-</dict></array></dict></plist>
-'''),
-            );
-        await File(
-          p.join(
-            extracted,
-            'ios-arm64',
-            'FirebaseAnalytics.framework',
-            'FirebaseAnalytics',
-          ),
-        ).create(recursive: true).then((file) => file.writeAsString('binary'));
-        await File(
-          p.join(extracted, 'macos-arm64_x86_64', 'broken-link'),
-        ).create(recursive: true);
-
-        expect(
-          await GeneratedPluginsPackage.repairWindowsBinaryArtifacts(scratch),
-          isTrue,
-        );
-        final repaired = p.join(
-          scratch,
-          'artifacts',
-          'firebase-ios-sdk',
-          'FirebaseAnalytics',
-          'FirebaseAnalytics.xcframework',
-        );
-        expect(
-          File(p.join(repaired, 'Info.plist')).readAsStringSync(),
-          contains('<string>ios-arm64</string>'),
-        );
-        expect(
-          File(
-            p.join(
-              repaired,
-              'ios-arm64',
-              'FirebaseAnalytics.framework',
-              'FirebaseAnalytics',
-            ),
-          ).readAsStringSync(),
-          'binary',
-        );
-        expect(
-          Directory(p.join(repaired, 'macos-arm64_x86_64')).existsSync(),
-          isFalse,
-        );
-      },
-    );
-
-    test(
-      'repairs duplicate extractions without emptying the artifact',
-      () async {
-        final scratch = p.join(tmp.path, '.build');
-        for (final uuid in ['UUID-A', 'UUID-B']) {
-          final extracted = p.join(
-            scratch,
-            'artifacts',
-            'extract',
-            'firebase-ios-sdk@revision',
-            'FirebaseFirestoreInternal',
-            uuid,
-            'FirebaseFirestoreInternal.xcframework',
-          );
-          await File(p.join(extracted, 'Info.plist'))
-              .create(recursive: true)
-              .then(
-                (file) => file.writeAsString('''
-<plist><dict><key>AvailableLibraries</key><array><dict>
-<key>LibraryIdentifier</key><string>ios-arm64</string>
-<key>LibraryPath</key><string>FirebaseFirestoreInternal.framework</string>
-<key>SupportedArchitectures</key><array><string>arm64</string></array>
-<key>SupportedPlatform</key><string>ios</string>
-</dict></array></dict></plist>
-'''),
-              );
-          await File(
-            p.join(
-              extracted,
-              'ios-arm64',
-              'FirebaseFirestoreInternal.framework',
-              'FirebaseFirestoreInternal',
-            ),
-          ).create(recursive: true).then((file) => file.writeAsString(uuid));
-        }
-
-        expect(
-          await GeneratedPluginsPackage.repairWindowsBinaryArtifacts(scratch),
-          isTrue,
-        );
-        final repaired = p.join(
-          scratch,
-          'artifacts',
-          'firebase-ios-sdk@revision',
-          'FirebaseFirestoreInternal',
-          'FirebaseFirestoreInternal.xcframework',
-        );
-        expect(File(p.join(repaired, 'Info.plist')).existsSync(), isTrue);
-        expect(
-          File(
-            p.join(
-              repaired,
-              'ios-arm64',
-              'FirebaseFirestoreInternal.framework',
-              'FirebaseFirestoreInternal',
-            ),
-          ).readAsStringSync(),
-          anyOf('UUID-A', 'UUID-B'),
-        );
-      },
-    );
-
-    test('extracts only the iOS device slice from a cached ZIP', () async {
-      final scratch = p.join(tmp.path, '.build');
-      final archive = Archive()
-        ..add(
-          ArchiveFile.string('Target.xcframework/Info.plist', '''
-<plist><dict><key>AvailableLibraries</key><array><dict>
-<key>LibraryIdentifier</key><string>ios-arm64</string>
-</dict></array></dict></plist>
-'''),
-        )
-        ..add(
-          ArchiveFile.string(
-            'Target.xcframework/ios-arm64/Target.framework/Target',
-            'binary',
-          ),
-        )
-        ..add(
-          ArchiveFile.string(
-            'Target.xcframework/macos-arm64/Target.framework/Target',
-            'macos',
-          ),
-        );
-      final zip = File(
-        p.join(scratch, 'artifacts', 'package', 'Target', 'Target.zip'),
-      );
-      await zip.create(recursive: true);
-      await zip.writeAsBytes(ZipEncoder().encode(archive));
-      await Directory(p.join(scratch, 'artifacts', 'extract')).create();
-
-      expect(
-        await GeneratedPluginsPackage.repairWindowsBinaryArtifacts(scratch),
-        isTrue,
-      );
-      final target = p.join(
-        scratch,
-        'artifacts',
-        'package',
-        'Target',
-        'Target',
-        'Target.xcframework',
-      );
-      expect(
-        File(
-          p.join(target, 'ios-arm64', 'Target.framework', 'Target'),
-        ).readAsStringSync(),
-        'binary',
-      );
-      expect(Directory(p.join(target, 'macos-arm64')).existsSync(), isFalse);
-    });
-
-    test('ignores incomplete extraction directories', () async {
-      final scratch = p.join(tmp.path, '.build');
-      await Directory(
-        p.join(
-          scratch,
-          'artifacts',
-          'extract',
-          'package',
-          'target',
-          'UUID',
-          'Target.xcframework',
-        ),
-      ).create(recursive: true);
-
-      expect(
-        await GeneratedPluginsPackage.repairWindowsBinaryArtifacts(scratch),
-        isFalse,
-      );
-    });
-
-    test(
-      'stages repaired XCFrameworks into matching binary packages',
-      () async {
-        final scratch = p.join(tmp.path, '.build');
-        final repaired = p.join(
-          scratch,
-          'artifacts',
-          'dependency',
-          'GenericBinary',
-          'GenericBinary.xcframework',
-        );
-        File(p.join(repaired, 'Info.plist'))
-          ..createSync(recursive: true)
-          ..writeAsStringSync('<plist/>');
-        File(
-            p.join(
-              repaired,
-              'ios-arm64',
-              'GenericBinary.framework',
-              'GenericBinary',
-            ),
-          )
-          ..createSync(recursive: true)
-          ..writeAsStringSync('binary');
-        final package = Directory(p.join(tmp.path, 'vendor', 'dependency'))
-          ..createSync(recursive: true);
-        final stale = File(
-          p.join(package.path, 'GenericBinary.xcframework', 'stale'),
-        )..createSync(recursive: true);
-        final manifest = File(p.join(package.path, 'Package.swift'))
-          ..writeAsStringSync('''
-let package = Package(targets: [
-  .binaryTarget(
-    name: "GenericBinary",
-    url: "https://example.invalid/GenericBinary.zip",
-    checksum: "checksum"
-  )
-])
-''');
-
-        expect(
-          await GeneratedPluginsPackage.stageExtractedBinaryArtifacts(
-            scratchPath: scratch,
-            vendorDir: p.join(tmp.path, 'vendor'),
-          ),
-          isTrue,
-        );
-        expect(
-          manifest.readAsStringSync(),
-          contains(
-            '.binaryTarget(name: "GenericBinary", '
-            'path: "GenericBinary.xcframework")',
-          ),
-        );
-        expect(
-          File(
-            p.join(
-              package.path,
-              'GenericBinary.xcframework',
-              'ios-arm64',
-              'GenericBinary.framework',
-              'GenericBinary',
-            ),
-          ).readAsStringSync(),
-          'binary',
-        );
-        expect(stale.existsSync(), isFalse);
-      },
-    );
-
-    test('ignores broken extraction trees and repairs checkouts', () async {
-      final scratch = p.join(tmp.path, '.build');
-      final repaired = p.join(
-        scratch,
-        'artifacts',
-        'dependency',
-        'Target',
-        'Target.xcframework',
-      );
-      File(p.join(repaired, 'Info.plist'))
-        ..createSync(recursive: true)
-        ..writeAsStringSync('<plist/>');
-      final broken = Directory(
-        p.join(
-          scratch,
-          'artifacts',
-          'extract',
-          'dependency',
-          'Target',
-          'UUID',
-          'Target.xcframework',
-          'missing',
-        ),
-      )..createSync(recursive: true);
-      broken.deleteSync();
-      final checkout = Directory(p.join(scratch, 'checkouts', 'dependency'))
-        ..createSync(recursive: true);
-      final manifest = File(p.join(checkout.path, 'Package.swift'))
-        ..writeAsStringSync('''
-let target = Target.binaryTarget(
-  name: "Target",
-  url: "https://example.invalid/Target.zip",
-  checksum: "checksum"
-)
-''');
-
-      expect(
-        await GeneratedPluginsPackage.stageExtractedBinaryArtifacts(
-          scratchPath: scratch,
-          vendorDir: p.join(tmp.path, 'missing-vendor'),
-        ),
-        isTrue,
-      );
-      expect(
-        manifest.readAsStringSync(),
-        contains('path: "Target.xcframework"'),
-      );
-      expect(
-        File(
-          p.join(checkout.path, 'Target.xcframework', 'Info.plist'),
-        ).existsSync(),
-        isTrue,
       );
     });
   });
@@ -1562,6 +1781,72 @@ let package = Package(targets: [
   });
 
   group('writeGeneratedPackages', () {
+    test(
+      'passes build-scoped recovery inputs to dependency evaluation',
+      () async {
+        const url = 'https://example.com/owner/repository.git';
+        final plugin = makePlugin(
+          'plugin_scope',
+          packageManifest:
+              '''
+import PackageDescription
+let package = Package(
+  name: "plugin_scope",
+  dependencies: [.package(name: "DeclaredIdentity", url: "$url", exact: "1.0.0")],
+  targets: []
+)
+''',
+        );
+        final flutter = Directory(p.join(tmp.path, 'Flutter.xcframework'))
+          ..createSync();
+        final scratch = p.join(tmp.path, 'authoritative-scratch');
+        final store = p.join(tmp.path, 'authoritative-store');
+        var evaluated = false;
+
+        await GeneratedPluginsPackage.writeGeneratedPackages(
+          outputDir: p.join(tmp.path, 'scoped-output'),
+          plugins: [plugin],
+          flutterXcframework: flutter.path,
+          deploymentTarget: IosDeploymentTarget.fallback,
+          copyFlutterXcframework: true,
+          vendorRemotePackages: true,
+          scratchPath: scratch,
+          binaryArtifactStore: store,
+          swiftPmArtifactJunctionCapability: true,
+          evaluateDependencyRefs:
+              (
+                directory, {
+                required scratchPath,
+                required binaryArtifactStore,
+                required binaryArtifactFallback,
+                required swiftPmArtifactJunctionCapability,
+                required packageLocalArtifactJunctionCapability,
+                required dependencies,
+              }) async {
+                evaluated = true;
+                expect(directory, contains('plugin_scope'));
+                expect(scratchPath, scratch);
+                expect(binaryArtifactStore, store);
+                expect(swiftPmArtifactJunctionCapability, isTrue);
+                expect(dependencies, hasLength(1));
+                expect(dependencies.single.identity, 'DeclaredIdentity');
+                expect(dependencies.single.url, url);
+                return const {
+                  'https://example.com/owner/repository': 'revision',
+                };
+              },
+          clonePackage: (_, _, _, destination) async {
+            await Directory(destination).create(recursive: true);
+            await File(
+              p.join(destination, 'Package.swift'),
+            ).writeAsString('import PackageDescription\n');
+          },
+        );
+
+        expect(evaluated, isTrue);
+      },
+    );
+
     test(
       'stages normalized plugin manifest without modifying source',
       () async {
@@ -3078,6 +3363,62 @@ module FirebaseFirestore {
   });
 
   group('build', () {
+    test('passes workspace recovery inputs through the build path', () async {
+      const url = 'https://example.com/dependency.git';
+      final plugin = makePlugin(
+        'build_scope',
+        packageManifest:
+            '''
+import PackageDescription
+let package = Package(
+  name: "build_scope",
+  dependencies: [.package(url: "$url", exact: "1.0.0")],
+  targets: []
+)
+''',
+      );
+      final workspace = SwiftPmWorkspace.forProject(
+        tmp.path,
+        environment: {'XCROSS_CACHE_DIR': p.join(tmp.path, 'cache')},
+      );
+      final flutter = Directory(p.join(tmp.path, 'Flutter.xcframework'))
+        ..createSync();
+
+      await expectLater(
+        GeneratedPluginsPackage.build(
+          projectRoot: tmp.path,
+          workspace: workspace,
+          plugins: [plugin],
+          flutterXcframework: flutter.path,
+          deploymentTarget: IosDeploymentTarget.fallback,
+          swiftPmArtifactJunctionCapability: true,
+          evaluateDependencyRefs:
+              (
+                _, {
+                required scratchPath,
+                required binaryArtifactStore,
+                required binaryArtifactFallback,
+                required swiftPmArtifactJunctionCapability,
+                required packageLocalArtifactJunctionCapability,
+                required dependencies,
+              }) {
+                expect(scratchPath, workspace.scratch);
+                expect(binaryArtifactStore, workspace.binaryArtifactStore);
+                expect(swiftPmArtifactJunctionCapability, isTrue);
+                expect(dependencies.single.identity, 'dependency');
+                throw StateError('evaluation reached');
+              },
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            'evaluation reached',
+          ),
+        ),
+      );
+    });
+
     test(
       'returns null and writes nothing when there are no SPM plugins',
       () async {
@@ -3092,6 +3433,8 @@ module FirebaseFirestore {
           plugins: const [],
           flutterXcframework: p.join(tmp.path, 'Flutter.xcframework'),
           deploymentTarget: IosDeploymentTarget.fallback,
+          artifactJunctionCapabilityResolver: () async =>
+              fail('must not resolve capabilities without SPM plugins'),
         );
 
         expect(result, isNull);
@@ -3119,12 +3462,40 @@ module FirebaseFirestore {
           plugins: [plugin],
           flutterXcframework: p.join(tmp.path, 'Flutter.xcframework'),
           deploymentTarget: IosDeploymentTarget.fallback,
+          artifactJunctionCapabilityResolver: () async =>
+              fail('must not resolve capabilities for ObjC-only plugins'),
         );
 
         expect(result, isNull);
         expect(Directory(workspace.packages).existsSync(), isFalse);
       },
     );
+
+    test('invokes the capability resolver once for SPM plugins', () async {
+      final plugin = makePlugin('resolver_plugin');
+      final workspace = SwiftPmWorkspace.forProject(
+        tmp.path,
+        environment: {'XCROSS_CACHE_DIR': tmp.path},
+      );
+      var resolverCalls = 0;
+
+      await expectLater(
+        GeneratedPluginsPackage.build(
+          projectRoot: tmp.path,
+          workspace: workspace,
+          plugins: [plugin],
+          flutterXcframework: p.join(tmp.path, 'Flutter.xcframework'),
+          deploymentTarget: IosDeploymentTarget.fallback,
+          artifactJunctionCapabilityResolver: () {
+            resolverCalls++;
+            throw StateError('resolver reached');
+          },
+        ),
+        throwsStateError,
+      );
+
+      expect(resolverCalls, 1);
+    });
   });
 
   group('Swift SDK / toolchain mismatch', () {

--- a/packages/xcross/test/flutter/build/swiftpm_binary_artifact_preparer_test.dart
+++ b/packages/xcross/test/flutter/build/swiftpm_binary_artifact_preparer_test.dart
@@ -712,14 +712,14 @@ void main() {
       'package-local junction survives repeated resolve and cross-build',
       () => expectProductionProbe(SwiftPmGateMode.packageLocalArtifact),
       skip: windowsGateSkip,
-      timeout: const Timeout(Duration(minutes: 2)),
+      timeout: const Timeout(Duration(minutes: 10)),
     );
 
     test(
       'SwiftPM artifact junction survives repeated resolve and cross-build',
       () => expectProductionProbe(SwiftPmGateMode.swiftPmArtifact),
       skip: windowsGateSkip,
-      timeout: const Timeout(Duration(minutes: 2)),
+      timeout: const Timeout(Duration(minutes: 10)),
     );
   });
 

--- a/packages/xcross/test/flutter/build/swiftpm_binary_artifact_preparer_test.dart
+++ b/packages/xcross/test/flutter/build/swiftpm_binary_artifact_preparer_test.dart
@@ -693,22 +693,16 @@ void main() {
   group('Windows alias feasibility gates', () {
     Future<void> expectProductionProbe(SwiftPmGateMode mode) async {
       final sdk = DarwinSdk.current()!;
-      final cacheRoot = Platform.environment['XCROSS_CACHE_DIR']!;
-      final toolchainIdentity = jsonEncode(
-        await GeneratedPluginsPackage.resolveBuildToolchainIdentity(sdk),
-      );
-      final sdkIdentity = jsonEncode(
-        await SdkInstall.sdkBuildIdentity(sdk.swiftSdkPath),
-      );
       expect(
-        await SwiftPmGateEvidence(
-          p.join(cacheRoot, 'swiftpm', 'gate-evidence-v2'),
-        ).verifies(
+        await probeSwiftPmGate(
           mode: mode,
-          platformIdentity:
-              '${Platform.operatingSystem}-${Platform.operatingSystemVersion}',
-          toolchainIdentity: toolchainIdentity,
-          sdkIdentity: sdkIdentity,
+          root: temp.path,
+          toolchainIdentity: jsonEncode(
+            await GeneratedPluginsPackage.resolveBuildToolchainIdentity(sdk),
+          ),
+          sdkIdentity: jsonEncode(
+            await SdkInstall.sdkBuildIdentity(sdk.swiftSdkPath),
+          ),
         ),
         isTrue,
       );

--- a/packages/xcross/test/flutter/build/swiftpm_binary_artifact_preparer_test.dart
+++ b/packages/xcross/test/flutter/build/swiftpm_binary_artifact_preparer_test.dart
@@ -712,12 +712,14 @@ void main() {
       'package-local junction survives repeated resolve and cross-build',
       () => expectProductionProbe(SwiftPmGateMode.packageLocalArtifact),
       skip: windowsGateSkip,
+      timeout: const Timeout(Duration(minutes: 2)),
     );
 
     test(
       'SwiftPM artifact junction survives repeated resolve and cross-build',
       () => expectProductionProbe(SwiftPmGateMode.swiftPmArtifact),
       skip: windowsGateSkip,
+      timeout: const Timeout(Duration(minutes: 2)),
     );
   });
 

--- a/packages/xcross/test/flutter/build/swiftpm_binary_artifact_preparer_test.dart
+++ b/packages/xcross/test/flutter/build/swiftpm_binary_artifact_preparer_test.dart
@@ -51,6 +51,13 @@ void main() {
     ).readAsStringSync();
     expect(manifest, contains('checksum: "${first.checksum}"'));
     expect(manifest, contains('.binaryTarget'));
+    final decoded = ZipDecoder().decodeBytes(first.archive.readAsBytesSync());
+    final binary = decoded.files.singleWhere(
+      (entry) => entry.name.endsWith('/BinaryFixture'),
+    );
+    final bytes = binary.content as List<int>;
+    expect(bytes, hasLength(greaterThan(32)));
+    expect(utf8.decode(bytes.take(8).toList()), '!<arch>\n');
   });
 
   test('selects metadata device slice and excludes simulator slice', () async {

--- a/packages/xcross/test/flutter/build/swiftpm_binary_artifact_preparer_test.dart
+++ b/packages/xcross/test/flutter/build/swiftpm_binary_artifact_preparer_test.dart
@@ -1,0 +1,1222 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:crypto/crypto.dart';
+import 'package:darwin_sdk_kit/darwin_sdk_kit.dart';
+import 'package:path/path.dart' as p;
+import 'package:propertylistserialization/propertylistserialization.dart';
+import 'package:test/test.dart';
+import 'package:xcross/src/cli/basic/sdk_install.dart';
+import 'package:xcross/src/flutter/build/internal/swiftpm_binary_fixture.dart';
+import 'package:xcross/src/flutter/build/internal/swiftpm_gate_evidence.dart';
+import 'package:xcross/src/flutter/build/ios_plugin_package.dart';
+import 'package:xcross/src/flutter/build/swiftpm_binary_artifact_preparer.dart';
+import 'package:xcross/src/flutter/build/swiftpm_binary_artifact_store.dart';
+import 'package:xcross/src/flutter/build/swiftpm_binary_target.dart';
+import 'package:xcross/src/flutter/errors.dart';
+
+void main() {
+  late Directory temp;
+  late SwiftPmBinaryArtifactStore store;
+
+  setUp(() {
+    temp = Directory.systemTemp.createTempSync('xcross_swiftpm_preparer-');
+    store = SwiftPmBinaryArtifactStore(p.join(temp.path, 'store'));
+  });
+
+  tearDown(() => temp.deleteSync(recursive: true));
+
+  test('generates deterministic SwiftPM XCFramework ZIP fixture', () {
+    final first = SwiftPmBinaryFixture.generate(
+      root: p.join(temp.path, 'first'),
+      archiveUrl: Uri.parse('http://127.0.0.1:8123/BinaryFixture.zip'),
+    );
+    final second = SwiftPmBinaryFixture.generate(
+      root: p.join(temp.path, 'second'),
+      archiveUrl: Uri.parse('http://127.0.0.1:8123/BinaryFixture.zip'),
+    );
+
+    expect(first.archive.readAsBytesSync(), second.archive.readAsBytesSync());
+    expect(first.checksum, second.checksum);
+    final manifest = File(
+      p.join(
+        first.pluginRoot.path,
+        'ios',
+        'binary_fixture_plugin',
+        'Package.swift',
+      ),
+    ).readAsStringSync();
+    expect(manifest, contains('checksum: "${first.checksum}"'));
+    expect(manifest, contains('.binaryTarget'));
+  });
+
+  test('selects metadata device slice and excludes simulator slice', () async {
+    final fixture = createFixture(temp, 'Fixture', defaultLibraries);
+
+    final entry = await SwiftPmBinaryArtifactPreparer(
+      store: store,
+    ).prepareDownloadedArchive(target: fixture.target, archive: fixture.file);
+
+    expect(
+      File(
+        p.join(
+          entry.artifactPath,
+          'ios-arm64_armv7',
+          'Fixture.framework',
+          'Fixture',
+        ),
+      ).readAsStringSync(),
+      'device',
+    );
+    expect(
+      Directory(
+        p.join(entry.artifactPath, 'ios-arm64_x86_64-simulator'),
+      ).existsSync(),
+      isFalse,
+    );
+    final plist = readPlist(p.join(entry.artifactPath, 'Info.plist'));
+    final availableLibraries = plist['AvailableLibraries']! as List;
+    expect(availableLibraries, hasLength(1));
+    expect(
+      (availableLibraries.single! as Map)['LibraryIdentifier'],
+      'ios-arm64_armv7',
+    );
+  });
+
+  test('requires exactly one eligible device slice', () async {
+    final noDevice = createFixture(temp, 'None', [defaultLibraries.last]);
+    await expectLater(
+      SwiftPmBinaryArtifactPreparer(store: store).prepareDownloadedArchive(
+        target: noDevice.target,
+        archive: noDevice.file,
+      ),
+      throwsBuildErrorContaining('exactly one'),
+    );
+
+    final duplicate = createFixture(temp, 'Duplicate', [
+      defaultLibraries.first,
+      {...defaultLibraries.first, 'LibraryIdentifier': 'ios-arm64-other'},
+    ]);
+    await expectLater(
+      SwiftPmBinaryArtifactPreparer(store: store).prepareDownloadedArchive(
+        target: duplicate.target,
+        archive: duplicate.file,
+      ),
+      throwsBuildErrorContaining('exactly one'),
+    );
+  });
+
+  test('requires declared library path to be retained', () async {
+    final fixture = createFixture(
+      temp,
+      'Missing',
+      defaultLibraries,
+      omitDeviceLibrary: true,
+    );
+
+    await expectLater(
+      SwiftPmBinaryArtifactPreparer(
+        store: store,
+      ).prepareDownloadedArchive(target: fixture.target, archive: fixture.file),
+      throwsBuildErrorContaining('LibraryPath'),
+    );
+  });
+
+  test('prepares two targets from one archive independently', () async {
+    final archive = Archive();
+    addEntries(archive, xcframeworkEntries('A', defaultLibraries));
+    addEntries(archive, xcframeworkEntries('B', defaultLibraries));
+    final file = writeArchive(temp, 'both.zip', archive);
+    final checksum = sha256.convert(file.readAsBytesSync()).toString();
+    final preparer = SwiftPmBinaryArtifactPreparer(store: store);
+
+    final a = await preparer.prepareDownloadedArchive(
+      target: target('A', checksum),
+      archive: file,
+    );
+    final b = await preparer.prepareDownloadedArchive(
+      target: target('B', checksum),
+      archive: file,
+    );
+
+    expect(a.artifactPath, isNot(b.artifactPath));
+    expect(p.basename(a.artifactPath), 'A.xcframework');
+    expect(p.basename(b.artifactPath), 'B.xcframework');
+  });
+
+  test('downloads, verifies, publishes, and reuses prepared target', () async {
+    final source = createFixture(temp, 'Download', defaultLibraries);
+    var downloads = 0;
+    final preparer = SwiftPmBinaryArtifactPreparer(
+      store: store,
+      download: (url, destination, maximumBytes) async {
+        downloads++;
+        await source.file.copy(destination.path);
+      },
+    );
+
+    final first = await preparer.prepare(source.target);
+    final second = await preparer.prepare(source.target);
+
+    expect(first.entry.artifactPath, second.entry.artifactPath);
+    expect(first.target, same(source.target));
+    expect(downloads, 1);
+    expect(
+      File(store.archivePath(source.target.checksum)).existsSync(),
+      isTrue,
+    );
+  });
+
+  test('does not soften checksum mismatch', () async {
+    final source = createFixture(temp, 'BadChecksum', defaultLibraries);
+    final badTarget = target('BadChecksum', '0' * 64);
+    final preparer = SwiftPmBinaryArtifactPreparer(
+      store: store,
+      download: (url, destination, maximumBytes) =>
+          source.file.copy(destination.path),
+    );
+
+    await expectLater(
+      preparer.prepare(badTarget),
+      throwsBuildErrorContaining('checksum mismatch'),
+    );
+  });
+
+  for (final unsafe in [
+    '../escape',
+    '/absolute',
+    'C:/drive',
+    'bad\u0000name',
+  ]) {
+    test(
+      'rejects unsafe ZIP path ${unsafe.replaceAll('\u0000', '<NUL>')}',
+      () async {
+        final fixture = createFixture(
+          temp,
+          'Unsafe${unsafe.hashCode}',
+          defaultLibraries,
+          extraEntries: [ArchiveFile.string(unsafe, 'bad')],
+        );
+
+        await expectLater(
+          SwiftPmBinaryArtifactPreparer(store: store).prepareDownloadedArchive(
+            target: fixture.target,
+            archive: fixture.file,
+          ),
+          throwsBuildErrorContaining('unsafe'),
+        );
+        expect(File(p.join(temp.path, 'escape')).existsSync(), isFalse);
+      },
+    );
+  }
+
+  test('rejects case-folded destination collision', () async {
+    final fixture = createFixture(
+      temp,
+      'CaseCollision',
+      defaultLibraries,
+      extraEntries: [
+        ArchiveFile.string('Foo', 'one'),
+        ArchiveFile.string('foo', 'one'),
+      ],
+    );
+
+    await expectLater(
+      SwiftPmBinaryArtifactPreparer(
+        store: store,
+      ).prepareDownloadedArchive(target: fixture.target, archive: fixture.file),
+      throwsBuildErrorContaining('collision'),
+    );
+  });
+
+  test('rejects duplicate path with conflicting bytes', () async {
+    final fixture = createFixture(
+      temp,
+      'DuplicatePath',
+      defaultLibraries,
+      extraEntries: [
+        ArchiveFile.string('duplicateA', 'one'),
+        ArchiveFile.string('duplicateB', 'two'),
+      ],
+    );
+    replaceAscii(fixture.file, 'duplicateB', 'duplicateA');
+    final duplicateTarget = target(
+      'DuplicatePath',
+      sha256.convert(fixture.file.readAsBytesSync()).toString(),
+    );
+
+    await expectLater(
+      SwiftPmBinaryArtifactPreparer(store: store).prepareDownloadedArchive(
+        target: duplicateTarget,
+        archive: fixture.file,
+      ),
+      throwsBuildErrorContaining('duplicate'),
+    );
+  });
+
+  test('enforces compressed archive byte limit before decode', () async {
+    final fixture = createFixture(temp, 'CompressedBytes', defaultLibraries);
+
+    await expectLater(
+      SwiftPmBinaryArtifactPreparer(
+        store: store,
+        maxArchiveBytes: fixture.file.lengthSync() - 1,
+      ).prepareDownloadedArchive(target: fixture.target, archive: fixture.file),
+      throwsBuildErrorContaining('archive byte limit'),
+    );
+  });
+
+  test(
+    'rejects announced oversized download before persisting bytes',
+    () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(server.close);
+      server.listen((request) async {
+        request.response.contentLength = 11;
+        request.response.add(List<int>.filled(11, 1));
+        await request.response.close();
+      });
+      final remote = SwiftPmRemoteBinaryTarget(
+        name: 'AnnouncedOversize',
+        url: Uri.parse(
+          'http://${server.address.host}:${server.port}/archive.zip',
+        ),
+        checksum: '0' * 64,
+        start: 0,
+        end: 0,
+      );
+
+      await expectLater(
+        SwiftPmBinaryArtifactPreparer(
+          store: store,
+          maxArchiveBytes: 10,
+        ).prepare(remote),
+        throwsBuildErrorContaining(
+          'SwiftPM binary artifact exceeds compressed archive byte limit',
+        ),
+      );
+
+      expect(File(store.archivePath(remote.checksum)).existsSync(), isFalse);
+      expect(await stagingFiles(store), isEmpty);
+    },
+  );
+
+  test(
+    'aborts chunked oversized download without persisting past limit',
+    () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(server.close);
+      server.listen((request) async {
+        request.response
+          ..add(List<int>.filled(6, 1))
+          ..add(List<int>.filled(6, 2));
+        await request.response.close();
+      });
+      final remote = SwiftPmRemoteBinaryTarget(
+        name: 'ChunkedOversize',
+        url: Uri.parse(
+          'http://${server.address.host}:${server.port}/archive.zip',
+        ),
+        checksum: '0' * 64,
+        start: 0,
+        end: 0,
+      );
+
+      await expectLater(
+        SwiftPmBinaryArtifactPreparer(
+          store: store,
+          maxArchiveBytes: 10,
+        ).prepare(remote),
+        throwsBuildErrorContaining(
+          'SwiftPM binary artifact exceeds compressed archive byte limit',
+        ),
+      );
+
+      expect(File(store.archivePath(remote.checksum)).existsSync(), isFalse);
+      expect(await stagingFiles(store), isEmpty);
+    },
+  );
+
+  for (final unsafe in [
+    'CON',
+    'nul.txt',
+    'AUX.tar.gz',
+    'COM1.txt',
+    r'clock$.log',
+    'bad?name',
+    'trailing.',
+    'trailing ',
+    'stream:ads',
+    'control\u0001name',
+    'caf\u00e9',
+  ]) {
+    test('rejects Windows-unsafe ZIP component $unsafe', () async {
+      final fixture = createFixture(
+        temp,
+        'WindowsUnsafe${unsafe.hashCode.abs()}',
+        defaultLibraries,
+        extraEntries: [ArchiveFile.string('directory/$unsafe', 'bad')],
+      );
+
+      await expectLater(
+        SwiftPmBinaryArtifactPreparer(store: store).prepareDownloadedArchive(
+          target: fixture.target,
+          archive: fixture.file,
+        ),
+        throwsBuildErrorContaining('unsafe'),
+      );
+    });
+  }
+
+  test('rejects Windows-unsafe plist paths', () async {
+    final fixture = createFixture(temp, 'UnsafeMetadata', [
+      {...defaultLibraries.first, 'LibraryPath': 'NUL.framework'},
+    ]);
+
+    await expectLater(
+      SwiftPmBinaryArtifactPreparer(
+        store: store,
+      ).prepareDownloadedArchive(target: fixture.target, archive: fixture.file),
+      throwsBuildErrorContaining('LibraryPath is unsafe'),
+    );
+  });
+
+  test('wraps archive decode failures', () async {
+    final file = File(p.join(temp.path, 'invalid.zip'))
+      ..writeAsStringSync('not a ZIP');
+    final invalidTarget = target(
+      'Invalid',
+      sha256.convert(file.readAsBytesSync()).toString(),
+    );
+
+    await expectLater(
+      SwiftPmBinaryArtifactPreparer(
+        store: store,
+      ).prepareDownloadedArchive(target: invalidTarget, archive: file),
+      throwsBuildErrorContaining('not a valid ZIP'),
+    );
+  });
+
+  test(
+    'does not decompress unselected slice files during inspection',
+    () async {
+      final fixture = createFixture(
+        temp,
+        'IgnoredCorruption',
+        defaultLibraries,
+      );
+      corruptZipEntry(
+        fixture.file,
+        'IgnoredCorruption.xcframework/'
+        'ios-arm64_x86_64-simulator/Fixture.framework/Fixture',
+      );
+      final updatedTarget = target(
+        'IgnoredCorruption',
+        sha256.convert(fixture.file.readAsBytesSync()).toString(),
+      );
+
+      final entry = await SwiftPmBinaryArtifactPreparer(
+        store: store,
+      ).prepareDownloadedArchive(target: updatedTarget, archive: fixture.file);
+
+      expect(
+        File(
+          p.join(
+            entry.artifactPath,
+            'ios-arm64_armv7',
+            'Fixture.framework',
+            'Fixture',
+          ),
+        ).readAsStringSync(),
+        'device',
+      );
+    },
+  );
+
+  test('wraps selected slice decompression failures', () async {
+    final fixture = createFixture(temp, 'CorruptSelected', defaultLibraries);
+    corruptZipEntry(
+      fixture.file,
+      'CorruptSelected.xcframework/'
+      'ios-arm64_armv7/Fixture.framework/Fixture',
+    );
+    final updatedTarget = target(
+      'CorruptSelected',
+      sha256.convert(fixture.file.readAsBytesSync()).toString(),
+    );
+
+    await expectLater(
+      SwiftPmBinaryArtifactPreparer(
+        store: store,
+      ).prepareDownloadedArchive(target: updatedTarget, archive: fixture.file),
+      throwsBuildErrorContaining('could not be decompressed'),
+    );
+  });
+
+  test('enforces archive entry limit', () async {
+    final fixture = createFixture(temp, 'Entries', defaultLibraries);
+
+    await expectLater(
+      SwiftPmBinaryArtifactPreparer(
+        store: store,
+        maxEntries: 2,
+      ).prepareDownloadedArchive(target: fixture.target, archive: fixture.file),
+      throwsBuildErrorContaining('entry limit'),
+    );
+  });
+
+  test('enforces expanded byte limit', () async {
+    final fixture = createFixture(temp, 'Bytes', defaultLibraries);
+
+    await expectLater(
+      SwiftPmBinaryArtifactPreparer(
+        store: store,
+        maxExpandedBytes: 10,
+      ).prepareDownloadedArchive(target: fixture.target, archive: fixture.file),
+      throwsBuildErrorContaining('expanded byte limit'),
+    );
+  });
+
+  test('declines selected slices that depend on symlinks', () async {
+    final link = ArchiveFile.string(
+      'Linked.xcframework/ios-arm64_armv7/Fixture.framework/Fixture',
+      'Versions/Current/Fixture',
+    )..mode = 0xa1ff;
+    final fixture = createFixture(
+      temp,
+      'Linked',
+      defaultLibraries,
+      omitDeviceLibrary: true,
+      extraEntries: [link],
+    );
+    markZipEntryAsUnix(fixture.file, link.name);
+    final linkedTarget = target(
+      'Linked',
+      sha256.convert(fixture.file.readAsBytesSync()).toString(),
+    );
+
+    await expectLater(
+      SwiftPmBinaryArtifactPreparer(
+        store: store,
+      ).prepareDownloadedArchive(target: linkedTarget, archive: fixture.file),
+      throwsBuildErrorContaining('unsupported'),
+    );
+    expect(
+      await store.findCompleteTarget(linkedTarget.checksum, 'Linked'),
+      isNull,
+    );
+  });
+
+  test('rejects malformed plist shapes without cast errors', () async {
+    final archive = Archive()
+      ..addFile(
+        ArchiveFile.string(
+          'Malformed.xcframework/Info.plist',
+          PropertyListSerialization.stringWithPropertyList({
+            'AvailableLibraries': ['not a dictionary'],
+          }),
+        ),
+      );
+    final file = writeArchive(temp, 'malformed.zip', archive);
+    final checksum = sha256.convert(file.readAsBytesSync()).toString();
+
+    await expectLater(
+      SwiftPmBinaryArtifactPreparer(store: store).prepareDownloadedArchive(
+        target: target('Malformed', checksum),
+        archive: file,
+      ),
+      throwsA(isA<FlutterBuildError>()),
+    );
+  });
+
+  group('artifact aliases', () {
+    test('recognizes only the Windows mount-point reparse tag', () {
+      expect(
+        isWindowsMountPointReparseOutput(
+          'Reparse Tag Value : 0xa0000003\nTag value: Microsoft Mount Point',
+        ),
+        isTrue,
+      );
+      expect(
+        isWindowsMountPointReparseOutput(
+          'Reparse Tag Value : 0xA000000C\nTag value: Microsoft Symbolic Link',
+        ),
+        isFalse,
+      );
+      expect(
+        isWindowsMountPointReparseOutput('Reparse point found with no tag'),
+        isFalse,
+      );
+    });
+
+    test('requires a complete store entry', () async {
+      final alias = p.join(temp.path, 'alias');
+      final incomplete = p.join(temp.path, 'incomplete');
+      Directory(incomplete).createSync();
+
+      await expectLater(
+        SwiftPmBinaryArtifactPreparer(
+          store: store,
+        ).createBinaryArtifactJunction(alias: alias, target: incomplete),
+        throwsA(isA<FileSystemException>()),
+      );
+      expect(
+        FileSystemEntity.typeSync(alias, followLinks: false),
+        FileSystemEntityType.notFound,
+      );
+    });
+
+    test('refuses to replace or remove an ordinary directory', () async {
+      final fixture = createFixture(temp, 'Unowned', defaultLibraries);
+      final entry = await SwiftPmBinaryArtifactPreparer(
+        store: store,
+      ).prepareDownloadedArchive(target: fixture.target, archive: fixture.file);
+      final alias = Directory(p.join(temp.path, 'ordinary'))..createSync();
+      final sentinel = File(p.join(alias.path, 'keep'))
+        ..writeAsStringSync('safe');
+      final preparer = SwiftPmBinaryArtifactPreparer(store: store);
+
+      await expectLater(
+        preparer.createBinaryArtifactJunction(
+          alias: alias.path,
+          target: entry.artifactPath,
+        ),
+        throwsA(isA<FileSystemException>()),
+      );
+      await expectLater(
+        preparer.removeBinaryArtifactAlias(alias.path),
+        throwsA(isA<FileSystemException>()),
+      );
+
+      expect(sentinel.readAsStringSync(), 'safe');
+    });
+
+    test('stale marker does not authorize removing a real directory', () async {
+      final alias = Directory(p.join(temp.path, 'stale-real'))..createSync();
+      final sentinel = File(p.join(alias.path, 'keep'))
+        ..writeAsStringSync('safe');
+      writeAliasMarker(alias.path, p.join(temp.path, 'missing-target'));
+
+      await expectLater(
+        SwiftPmBinaryArtifactPreparer(
+          store: store,
+        ).removeBinaryArtifactAlias(alias.path),
+        throwsA(isA<FileSystemException>()),
+      );
+
+      expect(sentinel.readAsStringSync(), 'safe');
+    });
+
+    test('mismatched marker does not authorize a retargeted alias', () async {
+      final first = Directory(p.join(temp.path, 'first'))..createSync();
+      final second = Directory(p.join(temp.path, 'second'))..createSync();
+      final alias = p.join(temp.path, 'retargeted');
+      await Link(alias).create(second.path);
+      writeAliasMarker(alias, first.path);
+
+      await expectLater(
+        SwiftPmBinaryArtifactPreparer(
+          store: store,
+        ).removeBinaryArtifactAlias(alias),
+        throwsA(isA<FileSystemException>()),
+      );
+
+      expect(Link(alias).existsSync(), isTrue);
+      expect(second.existsSync(), isTrue);
+    }, skip: Platform.isWindows ? 'uses a Unix symlink fixture' : false);
+
+    test('marker for the wrong alias type cannot authorize removal', () async {
+      final alias = File(p.join(temp.path, 'wrong-type'))
+        ..writeAsStringSync('safe');
+      writeAliasMarker(alias.path, temp.path);
+
+      await expectLater(
+        SwiftPmBinaryArtifactPreparer(
+          store: store,
+        ).removeBinaryArtifactAlias(alias.path),
+        throwsA(isA<FileSystemException>()),
+      );
+
+      expect(alias.readAsStringSync(), 'safe');
+    });
+
+    test('interrupted marker publication cannot own a later path', () async {
+      final alias = p.join(temp.path, 'interrupted');
+      writeAliasMarker(alias, temp.path, suffix: '.tmp-interrupted');
+      final real = Directory(alias)..createSync();
+      final sentinel = File(p.join(real.path, 'keep'))
+        ..writeAsStringSync('safe');
+
+      await expectLater(
+        SwiftPmBinaryArtifactPreparer(
+          store: store,
+        ).removeBinaryArtifactAlias(alias),
+        throwsA(isA<FileSystemException>()),
+      );
+
+      expect(sentinel.readAsStringSync(), 'safe');
+    });
+
+    test(
+      'replacing and removing a managed alias preserves its target',
+      () async {
+        final fixture = createFixture(temp, 'Alias', defaultLibraries);
+        final entry = await SwiftPmBinaryArtifactPreparer(store: store)
+            .prepareDownloadedArchive(
+              target: fixture.target,
+              archive: fixture.file,
+            );
+        final alias = p.join(temp.path, 'alias');
+        final preparer = SwiftPmBinaryArtifactPreparer(store: store);
+        await preparer.createBinaryArtifactJunction(
+          alias: alias,
+          target: entry.artifactPath,
+        );
+        await preparer.createBinaryArtifactJunction(
+          alias: alias,
+          target: entry.artifactPath,
+        );
+        await preparer.removeBinaryArtifactAlias(alias);
+
+        expect(Directory(alias).existsSync(), isFalse);
+        expect(
+          File(p.join(entry.artifactPath, 'Info.plist')).existsSync(),
+          isTrue,
+        );
+      },
+    );
+  });
+
+  group('Windows alias feasibility gates', () {
+    Future<void> expectProductionProbe(SwiftPmGateMode mode) async {
+      final sdk = DarwinSdk.current()!;
+      expect(
+        await probeSwiftPmGate(
+          mode: mode,
+          root: temp.path,
+          toolchainIdentity: jsonEncode(
+            await GeneratedPluginsPackage.resolveBuildToolchainIdentity(sdk),
+          ),
+          sdkIdentity: jsonEncode(
+            await SdkInstall.sdkBuildIdentity(sdk.swiftSdkPath),
+          ),
+        ),
+        isTrue,
+      );
+    }
+
+    test(
+      'package-local junction survives repeated resolve and cross-build',
+      () => expectProductionProbe(SwiftPmGateMode.packageLocalArtifact),
+      skip: windowsGateSkip,
+    );
+
+    test(
+      'SwiftPM artifact junction survives repeated resolve and cross-build',
+      () => expectProductionProbe(SwiftPmGateMode.swiftPmArtifact),
+      skip: windowsGateSkip,
+    );
+  });
+
+  group('bounded materialization', () {
+    Future<String> source(String name) async {
+      final fixture = createFixture(temp, name, defaultLibraries);
+      return (await SwiftPmBinaryArtifactPreparer(
+            store: store,
+          ).prepareDownloadedArchive(
+            target: fixture.target,
+            archive: fixture.file,
+          ))
+          .artifactPath;
+    }
+
+    for (var exitCode = 0; exitCode <= 7; exitCode++) {
+      test('accepts Robocopy exit code $exitCode', () async {
+        final artifact = await source('Success$exitCode');
+        final destination = p.join(temp.path, 'destination-$exitCode');
+        final process = FakeProcess(exitValue: exitCode);
+        final outcome = await SwiftPmBinaryArtifactPreparer(store: store)
+            .materializeBinaryArtifact(
+              source: artifact,
+              destination: destination,
+              startProcess: (_, arguments) async {
+                copyDirectorySync(artifact, arguments[1]);
+                return process;
+              },
+            );
+        expect(outcome, SwiftPmBinaryArtifactPublication.published());
+        expect(process.killed, isFalse);
+        expect(Directory(destination).existsSync(), isTrue);
+      });
+    }
+
+    test('reports a concurrent identical publisher as reused', () async {
+      final artifact = await source('ConcurrentPublisher');
+      final destination = p.join(temp.path, 'concurrent-destination');
+
+      final outcome = await SwiftPmBinaryArtifactPreparer(store: store)
+          .materializeBinaryArtifact(
+            source: artifact,
+            destination: destination,
+            startProcess: (_, arguments) async {
+              copyDirectorySync(artifact, arguments[1]);
+              copyDirectorySync(artifact, destination);
+              return FakeProcess(exitValue: 0);
+            },
+          );
+
+      expect(outcome, SwiftPmBinaryArtifactPublication.reused);
+      expect(Directory(destination).existsSync(), isTrue);
+    });
+
+    test('failed copy leaves no final or temporary destination', () async {
+      final artifact = await source('FailedCopy');
+      final destination = p.join(temp.path, 'failed-destination');
+      await expectLater(
+        SwiftPmBinaryArtifactPreparer(store: store).materializeBinaryArtifact(
+          source: artifact,
+          destination: destination,
+          startProcess: (_, arguments) async {
+            File(p.join(arguments[1], 'partial'))
+              ..createSync(recursive: true)
+              ..writeAsStringSync('partial');
+            return FakeProcess(exitValue: 8);
+          },
+        ),
+        throwsA(isA<FileSystemException>()),
+      );
+      expectMaterializationAbsent(destination);
+    });
+
+    test('rejects Robocopy exit code 8 with bounded diagnostics', () async {
+      final artifact = await source('Diagnostics');
+      final process = FakeProcess(
+        exitValue: 8,
+        stdoutText: 'o' * 5000,
+        stderrText: 'e' * 5000,
+      );
+      await expectLater(
+        SwiftPmBinaryArtifactPreparer(store: store).materializeBinaryArtifact(
+          source: artifact,
+          destination: p.join(temp.path, 'diagnostic-destination'),
+          startProcess: (_, _) async => process,
+        ),
+        throwsA(
+          isA<FileSystemException>().having(
+            (error) => error.message.length,
+            'bounded message length',
+            lessThan(3000),
+          ),
+        ),
+      );
+    });
+
+    test(
+      'kills timed out copy and removes its temporary destination',
+      () async {
+        final artifact = await source('Timeout');
+        final destination = p.join(temp.path, 'timeout-destination');
+        final process = FakeBinaryCopyProcess();
+        final future = SwiftPmBinaryArtifactPreparer(store: store)
+            .materializeBinaryArtifact(
+              source: artifact,
+              destination: destination,
+              timeout: const Duration(milliseconds: 1),
+              startProcess: (_, arguments) async {
+                File(p.join(arguments[1], 'partial'))
+                  ..createSync(recursive: true)
+                  ..writeAsStringSync('partial');
+                return process;
+              },
+            );
+
+        await expectLater(future, throwsA(isA<FileSystemException>()));
+        expect(process.killed, isTrue);
+        expect(process.exitObservedAfterKill, isTrue);
+        expectMaterializationAbsent(destination);
+      },
+    );
+
+    test('quarantines a live timed-out copy until it exits', () async {
+      final artifact = await source('KillRefusal');
+      final destination = p.join(temp.path, 'refused-destination');
+      final process = FakeBinaryCopyProcess(
+        killResult: false,
+        exitAfterKill: false,
+      );
+      String? temporary;
+      final stopwatch = Stopwatch()..start();
+
+      await expectLater(
+        SwiftPmBinaryArtifactPreparer(store: store).materializeBinaryArtifact(
+          source: artifact,
+          destination: destination,
+          timeout: const Duration(milliseconds: 1),
+          startProcess: (_, arguments) async {
+            temporary = arguments[1];
+            File(p.join(temporary!, 'partial'))
+              ..createSync(recursive: true)
+              ..writeAsStringSync('partial');
+            return process;
+          },
+        ),
+        throwsA(
+          isA<FileSystemException>().having(
+            (error) => error.message,
+            'message',
+            allOf(contains('kill returned false'), contains('grace period')),
+          ),
+        ),
+      );
+
+      expect(stopwatch.elapsed, lessThan(const Duration(seconds: 1)));
+      expect(Directory(destination).existsSync(), isFalse);
+      expect(Directory(temporary!).existsSync(), isTrue);
+      File(p.join(temporary!, 'still-writing')).writeAsStringSync('safe');
+
+      expect(
+        File(p.join(temporary!, '.xcross-live-copy-quarantine')).existsSync(),
+        isTrue,
+      );
+      process.complete(8);
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(Directory(temporary!).existsSync(), isTrue);
+      expect(Directory(destination).existsSync(), isFalse);
+    });
+  });
+}
+
+Future<List<File>> stagingFiles(SwiftPmBinaryArtifactStore store) async {
+  final staging = Directory(p.join(store.root, '.staging'));
+  if (!staging.existsSync()) return const [];
+  return [
+    await for (final entity in staging.list(recursive: true))
+      if (entity is File) entity,
+  ];
+}
+
+void copyDirectorySync(String source, String destination) {
+  for (final entity in Directory(source).listSync(recursive: true)) {
+    final relative = p.relative(entity.path, from: source);
+    final output = p.join(destination, relative);
+    if (entity is Directory) {
+      Directory(output).createSync(recursive: true);
+    } else if (entity is File) {
+      File(output).createSync(recursive: true);
+      entity.copySync(output);
+    }
+  }
+}
+
+void expectMaterializationAbsent(String destination) {
+  expect(
+    FileSystemEntity.typeSync(destination, followLinks: false),
+    FileSystemEntityType.notFound,
+  );
+  final parent = Directory(p.dirname(destination));
+  final temporaryPrefix = '.${p.basename(destination)}.xcross-copy-';
+  expect(
+    parent
+        .listSync(followLinks: false)
+        .where((entity) => p.basename(entity.path).startsWith(temporaryPrefix)),
+    isEmpty,
+  );
+}
+
+void writeAliasMarker(String alias, String target, {String suffix = ''}) {
+  File('$alias.xcross-alias.json$suffix').writeAsStringSync(
+    jsonEncode({
+      'alias': p.normalize(p.absolute(alias)),
+      'target': p.normalize(p.absolute(target)),
+    }),
+  );
+}
+
+final windowsGateSkip = !Platform.isWindows
+    ? 'Windows-only SwiftPM junction feasibility gate'
+    : (Platform.environment['XCROSS_SWIFT_SDKS_PATH'] == null
+          ? 'XCROSS_SWIFT_SDKS_PATH is unavailable'
+          : false);
+
+Directory createRawXcframework(Directory temp, String name) {
+  final framework = Directory(p.join(temp.path, '$name.xcframework'));
+  File(p.join(framework.path, 'Info.plist'))
+    ..createSync(recursive: true)
+    ..writeAsStringSync(
+      PropertyListSerialization.stringWithPropertyList({
+        'AvailableLibraries': [
+          {
+            'LibraryIdentifier': 'ios-arm64',
+            'LibraryPath': '$name.framework',
+            'SupportedArchitectures': ['arm64'],
+            'SupportedPlatform': 'ios',
+          },
+        ],
+      }),
+    );
+  File(p.join(framework.path, 'ios-arm64', '$name.framework', name))
+    ..createSync(recursive: true)
+    ..writeAsBytesSync(emptyMachO());
+  return framework;
+}
+
+Uint8List emptyMachO() {
+  final bytes = Uint8List(32);
+  ByteData.sublistView(bytes).setUint32(0, 0xfeedfacf, Endian.little);
+  return bytes;
+}
+
+File writeRawXcframeworkZip(Directory temp, Directory fixture, String name) {
+  final archive = Archive();
+  for (final entity in fixture.listSync(recursive: true)) {
+    if (entity is! File) continue;
+    final relative = p.relative(entity.path, from: fixture.parent.path);
+    archive.addFile(
+      ArchiveFile(relative, entity.lengthSync(), entity.readAsBytesSync()),
+    );
+  }
+  return writeArchive(temp, name, archive);
+}
+
+const defaultLibraries = <Map<String, Object?>>[
+  {
+    'LibraryIdentifier': 'ios-arm64_armv7',
+    'LibraryPath': 'Fixture.framework',
+    'SupportedArchitectures': ['arm64', 'armv7'],
+    'SupportedPlatform': 'ios',
+  },
+  {
+    'LibraryIdentifier': 'ios-arm64_x86_64-simulator',
+    'LibraryPath': 'Fixture.framework',
+    'SupportedArchitectures': ['arm64', 'x86_64'],
+    'SupportedPlatform': 'ios',
+    'SupportedPlatformVariant': 'simulator',
+  },
+];
+
+Map<String, Object?> xcframeworkPlist(List<Map<String, Object?>> libraries) => {
+  'AvailableLibraries': libraries,
+  'CFBundlePackageType': 'XFWK',
+  'XCFrameworkFormatVersion': '1.0',
+};
+
+List<ArchiveFile> xcframeworkEntries(
+  String name,
+  List<Map<String, Object?>> libraries, {
+  bool omitDeviceLibrary = false,
+}) {
+  final root = '$name.xcframework';
+  final files = <ArchiveFile>[
+    ArchiveFile.string(
+      '$root/Info.plist',
+      PropertyListSerialization.stringWithPropertyList(
+        xcframeworkPlist(libraries),
+      ),
+    ),
+  ];
+  for (final library in libraries) {
+    final identifier = library['LibraryIdentifier']! as String;
+    if (omitDeviceLibrary && identifier == 'ios-arm64_armv7') continue;
+    final value = library['SupportedPlatformVariant'] == 'simulator'
+        ? 'simulator'
+        : 'device';
+    files.add(
+      ArchiveFile.string('$root/$identifier/Fixture.framework/Fixture', value),
+    );
+  }
+  return files;
+}
+
+ArchiveFixture createFixture(
+  Directory temp,
+  String name,
+  List<Map<String, Object?>> libraries, {
+  bool omitDeviceLibrary = false,
+  List<ArchiveFile> extraEntries = const [],
+}) {
+  final archive = Archive();
+  addEntries(
+    archive,
+    xcframeworkEntries(name, libraries, omitDeviceLibrary: omitDeviceLibrary),
+  );
+  addEntries(archive, extraEntries);
+  final file = writeArchive(temp, '$name.zip', archive);
+  final checksum = sha256.convert(file.readAsBytesSync()).toString();
+  return ArchiveFixture(file, target(name, checksum));
+}
+
+void markZipEntryAsUnix(File file, String name) {
+  final bytes = file.readAsBytesSync();
+  final encodedName = utf8.encode(name);
+  for (var offset = 0; offset <= bytes.length - 46; offset++) {
+    if (_uint32(bytes, offset) != 0x02014b50) continue;
+    final nameLength = _uint16(bytes, offset + 28);
+    if (nameLength != encodedName.length) continue;
+    final found = bytes.sublist(offset + 46, offset + 46 + nameLength);
+    if (!_bytesEqual(found, encodedName)) continue;
+    bytes[offset + 5] = 3;
+  }
+  file.writeAsBytesSync(bytes);
+}
+
+int _uint16(List<int> bytes, int offset) =>
+    bytes[offset] | (bytes[offset + 1] << 8);
+
+int _uint32(List<int> bytes, int offset) =>
+    _uint16(bytes, offset) | (_uint16(bytes, offset + 2) << 16);
+
+bool _bytesEqual(List<int> left, List<int> right) {
+  if (left.length != right.length) return false;
+  for (var index = 0; index < left.length; index++) {
+    if (left[index] != right[index]) return false;
+  }
+  return true;
+}
+
+void corruptZipEntry(File file, String name) {
+  final bytes = file.readAsBytesSync();
+  final encodedName = utf8.encode(name);
+  for (var offset = 0; offset <= bytes.length - 46; offset++) {
+    if (_uint32(bytes, offset) != 0x02014b50) continue;
+    final nameLength = _uint16(bytes, offset + 28);
+    if (nameLength != encodedName.length) continue;
+    final found = bytes.sublist(offset + 46, offset + 46 + nameLength);
+    if (!_bytesEqual(found, encodedName)) continue;
+    final localOffset = _uint32(bytes, offset + 42);
+    final localNameLength = _uint16(bytes, localOffset + 26);
+    final localExtraLength = _uint16(bytes, localOffset + 28);
+    final contentOffset = localOffset + 30 + localNameLength + localExtraLength;
+    bytes[contentOffset] ^= 0xff;
+    file.writeAsBytesSync(bytes);
+    return;
+  }
+  fail('ZIP entry not found: $name');
+}
+
+void replaceAscii(File file, String from, String to) {
+  final bytes = file.readAsBytesSync();
+  final source = ascii.encode(from);
+  final replacement = ascii.encode(to);
+  expect(replacement, hasLength(source.length));
+  for (var start = 0; start <= bytes.length - source.length; start++) {
+    var matches = true;
+    for (var offset = 0; offset < source.length; offset++) {
+      if (bytes[start + offset] != source[offset]) {
+        matches = false;
+        break;
+      }
+    }
+    if (!matches) continue;
+    bytes.setRange(start, start + replacement.length, replacement);
+  }
+  file.writeAsBytesSync(bytes);
+}
+
+void addEntries(Archive archive, Iterable<ArchiveFile> entries) {
+  for (final entry in entries) {
+    archive.addFile(entry);
+  }
+}
+
+File writeArchive(Directory temp, String name, Archive archive) {
+  final file = File(p.join(temp.path, name));
+  file.writeAsBytesSync(ZipEncoder().encode(archive));
+  return file;
+}
+
+SwiftPmRemoteBinaryTarget target(String name, String checksum) =>
+    SwiftPmRemoteBinaryTarget(
+      name: name,
+      url: Uri.parse(
+        'https://example.invalid/private/path/$name.zip?token=secret',
+      ),
+      checksum: checksum,
+      start: 0,
+      end: 1,
+    );
+
+Map<Object?, Object?> readPlist(String path) =>
+    PropertyListSerialization.propertyListWithString(
+          File(path).readAsStringSync(),
+        )
+        as Map<Object?, Object?>;
+
+Matcher throwsBuildErrorContaining(String text) => throwsA(
+  isA<FlutterBuildError>().having(
+    (error) => error.toString().toLowerCase(),
+    'message',
+    contains(text.toLowerCase()),
+  ),
+);
+
+final class ArchiveFixture {
+  const ArchiveFixture(this.file, this.target);
+
+  final File file;
+  final SwiftPmRemoteBinaryTarget target;
+}
+
+final class FakeProcess implements BinaryCopyProcess {
+  FakeProcess({this.exitValue, this.stdoutText = '', this.stderrText = ''});
+
+  final int? exitValue;
+  final String stdoutText;
+  final String stderrText;
+  final Completer<int> _exit = Completer<int>();
+  bool killed = false;
+
+  @override
+  Future<int> get exitCode {
+    if (exitValue != null && !_exit.isCompleted) _exit.complete(exitValue);
+    return _exit.future;
+  }
+
+  @override
+  bool kill() {
+    killed = true;
+    if (!_exit.isCompleted) _exit.complete(-1);
+    return true;
+  }
+
+  @override
+  Stream<List<int>> get stdout => Stream.value(utf8.encode(stdoutText));
+
+  @override
+  Stream<List<int>> get stderr => Stream.value(utf8.encode(stderrText));
+}
+
+final class FakeBinaryCopyProcess implements BinaryCopyProcess {
+  FakeBinaryCopyProcess({this.killResult = true, this.exitAfterKill = true});
+
+  final bool killResult;
+  final bool exitAfterKill;
+  final Completer<int> _exit = Completer<int>();
+  bool killed = false;
+  bool exitObservedAfterKill = false;
+
+  @override
+  Future<int> get exitCode => _exit.future.then((value) {
+    exitObservedAfterKill = killed;
+    return value;
+  });
+
+  @override
+  bool kill() {
+    killed = true;
+    if (exitAfterKill && !_exit.isCompleted) _exit.complete(-1);
+    return killResult;
+  }
+
+  void complete(int exitCode) {
+    if (!_exit.isCompleted) _exit.complete(exitCode);
+  }
+
+  @override
+  Stream<List<int>> get stdout => const Stream.empty();
+
+  @override
+  Stream<List<int>> get stderr => const Stream.empty();
+}

--- a/packages/xcross/test/flutter/build/swiftpm_binary_artifact_preparer_test.dart
+++ b/packages/xcross/test/flutter/build/swiftpm_binary_artifact_preparer_test.dart
@@ -693,16 +693,22 @@ void main() {
   group('Windows alias feasibility gates', () {
     Future<void> expectProductionProbe(SwiftPmGateMode mode) async {
       final sdk = DarwinSdk.current()!;
+      final cacheRoot = Platform.environment['XCROSS_CACHE_DIR']!;
+      final toolchainIdentity = jsonEncode(
+        await GeneratedPluginsPackage.resolveBuildToolchainIdentity(sdk),
+      );
+      final sdkIdentity = jsonEncode(
+        await SdkInstall.sdkBuildIdentity(sdk.swiftSdkPath),
+      );
       expect(
-        await probeSwiftPmGate(
+        await SwiftPmGateEvidence(
+          p.join(cacheRoot, 'swiftpm', 'gate-evidence-v2'),
+        ).verifies(
           mode: mode,
-          root: temp.path,
-          toolchainIdentity: jsonEncode(
-            await GeneratedPluginsPackage.resolveBuildToolchainIdentity(sdk),
-          ),
-          sdkIdentity: jsonEncode(
-            await SdkInstall.sdkBuildIdentity(sdk.swiftSdkPath),
-          ),
+          platformIdentity:
+              '${Platform.operatingSystem}-${Platform.operatingSystemVersion}',
+          toolchainIdentity: toolchainIdentity,
+          sdkIdentity: sdkIdentity,
         ),
         isTrue,
       );

--- a/packages/xcross/test/flutter/build/swiftpm_binary_artifact_store_test.dart
+++ b/packages/xcross/test/flutter/build/swiftpm_binary_artifact_store_test.dart
@@ -1,0 +1,307 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:xcross/src/flutter/build/swiftpm_binary_artifact_store.dart';
+import 'package:xcross/src/flutter/errors.dart';
+
+void main() {
+  late Directory temp;
+  late SwiftPmBinaryArtifactStore store;
+
+  setUp(() {
+    temp = Directory.systemTemp.createTempSync('xcross_swiftpm_store-');
+    store = SwiftPmBinaryArtifactStore(p.join(temp.path, 'store'));
+  });
+
+  tearDown(() => temp.deleteSync(recursive: true));
+
+  test('publishes and reuses a verified archive', () async {
+    final bytes = utf8.encode('archive');
+    final checksum = sha256.convert(bytes).toString();
+    final first = File(p.join(temp.path, 'first.zip'))..writeAsBytesSync(bytes);
+
+    final published = await store.publishArchive(first, checksum);
+    final second = File(p.join(temp.path, 'second.zip'))
+      ..writeAsBytesSync(bytes);
+    final reused = await store.publishArchive(second, checksum);
+
+    expect(published.path, store.archivePath(checksum));
+    expect(await published.readAsBytes(), bytes);
+    expect(reused.path, published.path);
+  });
+
+  test('canonicalizes archive and target checksum identity', () async {
+    final bytes = utf8.encode('archive');
+    final checksum = sha256.convert(bytes).toString();
+    final archive = File(p.join(temp.path, 'archive.zip'))
+      ..writeAsBytesSync(bytes);
+
+    final published = await store.publishArchive(
+      archive,
+      checksum.toUpperCase(),
+    );
+    final target = await publishFixture(
+      store,
+      temp,
+      checksum: 'ABC',
+      target: 'A',
+    );
+
+    expect(published.path, store.archivePath(checksum));
+    expect(
+      store.archivePath(checksum.toUpperCase()),
+      store.archivePath(checksum),
+    );
+    expect(store.targetRoot('ABC', 'A'), store.targetRoot('abc', 'A'));
+    expect(target.archiveChecksum, 'abc');
+    expect(await store.findCompleteTarget('abc', 'A'), isNotNull);
+  });
+
+  test('rejects an archive with a mismatched checksum', () async {
+    final archive = File(p.join(temp.path, 'bad.zip'))
+      ..writeAsStringSync('archive');
+
+    await expectLater(
+      store.publishArchive(archive, '0' * 64),
+      throwsA(isA<FlutterBuildError>()),
+    );
+  });
+
+  test('same archive supports distinct target entries', () async {
+    final a = await publishFixture(store, temp, checksum: 'abc', target: 'A');
+    final b = await publishFixture(store, temp, checksum: 'abc', target: 'B');
+
+    expect(a.artifactPath, isNot(b.artifactPath));
+    expect(store.archivePath('abc'), endsWith('abc.zip'));
+    expect(await store.findCompleteTarget('abc', 'A'), isNotNull);
+    expect(await store.findCompleteTarget('abc', 'B'), isNotNull);
+  });
+
+  test('separates target entries by checksum', () async {
+    final a = await publishFixture(store, temp, checksum: 'abc', target: 'A');
+    final b = await publishFixture(store, temp, checksum: 'def', target: 'A');
+
+    expect(a.artifactPath, isNot(b.artifactPath));
+  });
+
+  test('does not reuse an entry without completion marker', () async {
+    Directory(store.targetRoot('abc', 'A')).createSync(recursive: true);
+
+    expect(await store.findCompleteTarget('abc', 'A'), isNull);
+  });
+
+  test('concurrent publication exposes one complete target', () async {
+    final results = await Future.wait([
+      publishFixture(store, temp, checksum: 'abc', target: 'A', value: 'one'),
+      publishFixture(store, temp, checksum: 'abc', target: 'A', value: 'two'),
+    ]);
+
+    expect(results[0].artifactPath, results[1].artifactPath);
+    final found = await store.findCompleteTarget('abc', 'A');
+    expect(found, isNotNull);
+    expect(
+      File(p.join(found!.artifactPath, 'payload')).readAsStringSync(),
+      anyOf('one', 'two'),
+    );
+    final metadata =
+        jsonDecode(
+              File(
+                p.join(store.targetRoot('abc', 'A'), 'metadata.json'),
+              ).readAsStringSync(),
+            )
+            as Map<String, Object?>;
+    expect(metadata['archiveChecksum'], 'abc');
+    expect(metadata['targetName'], 'A');
+    expect(metadata['artifactDirectoryName'], 'A.artifactbundle');
+  });
+
+  test('recovers publication from an incomplete destination', () async {
+    final poisoned = Directory(store.targetRoot('abc', 'A'))
+      ..createSync(recursive: true);
+    File(p.join(poisoned.path, 'partial')).writeAsStringSync('keep');
+
+    final published = await publishFixture(
+      store,
+      temp,
+      checksum: 'abc',
+      target: 'A',
+    );
+
+    expect(Directory(published.artifactPath).existsSync(), isTrue);
+    expect(await store.findCompleteTarget('abc', 'A'), isNotNull);
+    final preserved = poisoned.parent
+        .listSync(recursive: true, followLinks: false)
+        .whereType<File>()
+        .any(
+          (entry) =>
+              p.basename(entry.path) == 'partial' &&
+              entry.readAsStringSync() == 'keep',
+        );
+    expect(preserved, isTrue);
+  });
+
+  test(
+    'streams multi-chunk target files with stable mutation-sensitive digest',
+    () async {
+      Future<SwiftPmBinaryArtifactEntry> publishLarge(String checksum) {
+        final staging = temp.createTempSync('large-$checksum-');
+        final artifact = Directory(p.join(staging.path, 'A.artifactbundle'))
+          ..createSync();
+        final payload = File(
+          p.join(artifact.path, 'payload'),
+        ).openSync(mode: FileMode.write);
+        final chunk = List<int>.generate(64 * 1024, (index) => index & 0xff);
+        for (var index = 0; index < 48; index++) {
+          payload.writeFromSync(chunk);
+        }
+        payload.closeSync();
+        return store.publishTarget(
+          checksum: checksum,
+          targetName: 'A',
+          stagingRoot: staging,
+          artifactDirectoryName: 'A.artifactbundle',
+          metadata: const {},
+        );
+      }
+
+      String treeDigest(String checksum) {
+        final metadata =
+            jsonDecode(
+                  File(
+                    p.join(store.targetRoot(checksum, 'A'), 'metadata.json'),
+                  ).readAsStringSync(),
+                )
+                as Map<String, Object?>;
+        return metadata['treeDigest']! as String;
+      }
+
+      final first = await publishLarge('abc');
+      final second = await publishLarge('def');
+
+      expect(treeDigest('abc'), treeDigest('def'));
+      final payload = File(p.join(first.artifactPath, 'payload'));
+      final handle = payload.openSync(mode: FileMode.append);
+      handle.writeByteSync(1);
+      handle.closeSync();
+      expect(await store.findCompleteTarget('abc', 'A'), isNull);
+      expect(await store.findCompleteTarget('def', 'A'), isNotNull);
+      expect(
+        File(p.join(second.artifactPath, 'payload')).lengthSync(),
+        3 * 1024 * 1024,
+      );
+    },
+  );
+
+  test('requires a real artifact directory root', () async {
+    final staging = temp.createTempSync('file-artifact-');
+    File(p.join(staging.path, 'A.artifactbundle')).writeAsStringSync('value');
+
+    await expectLater(
+      store.publishTarget(
+        checksum: 'abc',
+        targetName: 'A',
+        stagingRoot: staging,
+        artifactDirectoryName: 'A.artifactbundle',
+        metadata: const {},
+      ),
+      throwsA(isA<FlutterBuildError>()),
+    );
+  });
+
+  test('rejects symlinks anywhere in a staged target tree', () async {
+    final staging = fixture(temp, 'linked', 'A.artifactbundle', 'value');
+    final outside = File(p.join(temp.path, 'outside'))..writeAsStringSync('x');
+    Link(
+      p.join(staging.path, 'A.artifactbundle', 'link'),
+    ).createSync(outside.path);
+
+    await expectLater(
+      store.publishTarget(
+        checksum: 'abc',
+        targetName: 'A',
+        stagingRoot: staging,
+        artifactDirectoryName: 'A.artifactbundle',
+        metadata: const {},
+      ),
+      throwsA(isA<FlutterBuildError>()),
+    );
+    expect(await store.findCompleteTarget('abc', 'A'), isNull);
+  });
+
+  test('does not reuse a published tree containing a symlink', () async {
+    final published = await publishFixture(
+      store,
+      temp,
+      checksum: 'abc',
+      target: 'A',
+    );
+    final outside = File(p.join(temp.path, 'outside'))..writeAsStringSync('x');
+    Link(p.join(published.artifactPath, 'link')).createSync(outside.path);
+
+    expect(await store.findCompleteTarget('abc', 'A'), isNull);
+  });
+
+  test('does not accept a symlink as the target root', () async {
+    final elsewhere = temp.createTempSync('elsewhere-');
+    File(p.join(elsewhere.path, '.complete')).writeAsStringSync('');
+    final target = store.targetRoot('abc', 'A');
+    Directory(target).parent.createSync(recursive: true);
+    Link(target).createSync(elsewhere.path);
+
+    expect(await store.findCompleteTarget('abc', 'A'), isNull);
+  });
+
+  test('rejects unsafe target and artifact names', () async {
+    for (final target in ['.', '..', 'A/B', r'A\B']) {
+      expect(() => store.targetRoot('abc', target), throwsArgumentError);
+    }
+    final staging = fixture(temp, 'unsafe', 'artifact', 'value');
+    await expectLater(
+      store.publishTarget(
+        checksum: 'abc',
+        targetName: 'A',
+        stagingRoot: staging,
+        artifactDirectoryName: '../artifact',
+        metadata: const {},
+      ),
+      throwsArgumentError,
+    );
+  });
+}
+
+Future<SwiftPmBinaryArtifactEntry> publishFixture(
+  SwiftPmBinaryArtifactStore store,
+  Directory temp, {
+  required String checksum,
+  required String target,
+  String value = 'artifact',
+}) {
+  return store.publishTarget(
+    checksum: checksum,
+    targetName: target,
+    stagingRoot: fixture(
+      temp,
+      '$checksum-$target',
+      '$target.artifactbundle',
+      value,
+    ),
+    artifactDirectoryName: '$target.artifactbundle',
+    metadata: {'fixture': value},
+  );
+}
+
+Directory fixture(
+  Directory temp,
+  String name,
+  String artifactName,
+  String value,
+) {
+  final root = temp.createTempSync('$name-');
+  final artifact = Directory(p.join(root.path, artifactName))
+    ..createSync(recursive: true);
+  File(p.join(artifact.path, 'payload')).writeAsStringSync(value);
+  return root;
+}

--- a/packages/xcross/test/flutter/build/swiftpm_binary_artifact_store_test.dart
+++ b/packages/xcross/test/flutter/build/swiftpm_binary_artifact_store_test.dart
@@ -254,6 +254,43 @@ void main() {
     expect(await store.findCompleteTarget('abc', 'A'), isNull);
   });
 
+  test('rejects a Windows directory junction in a staged tree', () async {
+    if (!Platform.isWindows) return;
+    final staging = fixture(temp, 'junction', 'A.artifactbundle', 'value');
+    final target = temp.createTempSync('junction-target-');
+    final junction = p.join(staging.path, 'A.artifactbundle', 'junction');
+    final created = await Process.run('cmd.exe', [
+      '/d',
+      '/c',
+      'mklink',
+      '/J',
+      junction,
+      target.path,
+    ]);
+    if (created.exitCode != 0) {
+      markTestSkipped('directory junction creation is unavailable');
+      return;
+    }
+
+    await expectLater(
+      store.publishTarget(
+        checksum: 'abc',
+        targetName: 'A',
+        stagingRoot: staging,
+        artifactDirectoryName: 'A.artifactbundle',
+        metadata: const {},
+      ),
+      throwsA(
+        isA<FlutterBuildError>().having(
+          (error) => error.isSecurityFailure,
+          'isSecurityFailure',
+          isTrue,
+        ),
+      ),
+    );
+    expect(await store.findCompleteTarget('abc', 'A'), isNull);
+  });
+
   test('rejects unsafe target and artifact names', () async {
     for (final target in ['.', '..', 'A/B', r'A\B']) {
       expect(() => store.targetRoot('abc', target), throwsArgumentError);

--- a/packages/xcross/test/flutter/build/swiftpm_binary_target_test.dart
+++ b/packages/xcross/test/flutter/build/swiftpm_binary_target_test.dart
@@ -1,0 +1,140 @@
+import 'package:test/test.dart';
+import 'package:xcross/src/flutter/build/swiftpm_binary_target.dart';
+
+void main() {
+  const checksum =
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+  test('discovers only eligible direct literal targets', () {
+    const source = '''
+let targets: [Target] = [
+  .binaryTarget(
+    name: "Good",
+    url: "https://example.invalid/Good.zip",
+    checksum: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  ),
+  .binaryTarget(name: dynamicName, url: makeURL(), checksum: checksum),
+]
+''';
+
+    final targets = SwiftPmBinaryTargetManifest.discover(source);
+    expect(targets, hasLength(1));
+    expect(targets.single.name, 'Good');
+    expect(targets.single.url.path, '/Good.zip');
+    expect(
+      source.substring(targets.single.start, targets.single.end),
+      startsWith('.binaryTarget('),
+    );
+  });
+
+  test('ignores binaryTarget text in comments and Swift strings', () {
+    const source = r'''
+// .binaryTarget(name: "Comment", url: "https://x/Comment.zip", checksum: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+let text = #".binaryTarget(name: \"Raw\", url: \"https://x/Raw.zip\", checksum: \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\")"#
+let multiline = """
+.binaryTarget(name: "Multiline", url: "https://x/Multiline.zip", checksum: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+"""
+/* outer /* nested */ .binaryTarget(name: "Block", url: "https://x/Block.zip", checksum: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") */
+''';
+    expect(SwiftPmBinaryTargetManifest.discover(source), isEmpty);
+  });
+
+  test('decodes escaped, raw, and multiline direct literals', () {
+    const source = r'''
+.binaryTarget(name: "Escaped \"Name\"", url: #"https://example.invalid/Escaped.zip"#, checksum: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+.binaryTarget(
+  name: """
+Multi
+""",
+  url: """
+https://example.invalid/Multi.zip
+""",
+  checksum: """
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+"""
+)
+''';
+    final targets = SwiftPmBinaryTargetManifest.discover(source);
+    expect(targets.map((target) => target.name), ['Escaped "Name"', 'Multi']);
+  });
+
+  test('raw escaped delimiters do not expose code', () {
+    const source = r'''
+let text = #"prefix \#" .binaryTarget(name: "Hidden", url: "https://x/Hidden.zip", checksum: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")"#
+''';
+    expect(SwiftPmBinaryTargetManifest.discover(source), isEmpty);
+  });
+
+  test('rejects raw escapes rather than changing evaluated values', () {
+    const source = r'''
+.binaryTarget(name: #"Changed\#nValue"#, url: "https://x/Raw.zip", checksum: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+''';
+    expect(SwiftPmBinaryTargetManifest.discover(source), isEmpty);
+  });
+
+  test('rejects indented multiline literals', () {
+    const source =
+        '''
+.binaryTarget(
+  name: """
+    Indented
+    """,
+  url: "https://x/Indented.zip",
+  checksum: "$checksum"
+)
+''';
+    expect(SwiftPmBinaryTargetManifest.discover(source), isEmpty);
+  });
+
+  test('rejects computed, interpolated, and ineligible values', () {
+    const source =
+        '''
+.binaryTarget(name: "Computed", url: makeURL(), checksum: "$checksum")
+.binaryTarget(name: "Interpolated \\(value)", url: "https://x/I.zip", checksum: "$checksum")
+.binaryTarget(name: "NotZip", url: "https://x/file.tar.gz", checksum: "$checksum")
+.binaryTarget(name: "UserInfo", url: "https://user@x/File.zip", checksum: "$checksum")
+.binaryTarget(name: "Hostless", url: "https:/Artifact.zip", checksum: "$checksum")
+.binaryTarget(name: "BadChecksum", url: "https://x/File.zip", checksum: "abc")
+.binaryTarget(name: "BadScheme", url: "file:///tmp/File.zip", checksum: "$checksum")
+''';
+    expect(SwiftPmBinaryTargetManifest.discover(source), isEmpty);
+  });
+
+  test('rewrites matched calls from the end without touching neighbors', () {
+    const source =
+        'targets: [.binaryTarget(name: "A", url: "https://x/A.zip", checksum: "$checksum"), .target(name: "Keep"), .binaryTarget(name: "B", url: "https://x/B.zip", checksum: "$checksum")]';
+    final targets = SwiftPmBinaryTargetManifest.discover(source);
+    final rewritten = SwiftPmBinaryTargetManifest.rewriteToLocalPaths(source, {
+      targets.first: 'xcross-artifacts/A "quoted".xcframework',
+      targets.last: 'xcross-artifacts/B.xcframework',
+    });
+    expect(
+      rewritten,
+      contains(
+        r'.binaryTarget(name: "A", path: "xcross-artifacts/A \"quoted\".xcframework")',
+      ),
+    );
+    expect(rewritten, contains('.target(name: "Keep")'));
+    expect(
+      rewritten,
+      endsWith(
+        '.binaryTarget(name: "B", path: "xcross-artifacts/B.xcframework")]',
+      ),
+    );
+  });
+
+  test('rejects rewrite targets that do not belong to the source', () {
+    const first =
+        '.binaryTarget(name: "A", url: "https://x/A.zip", checksum: "$checksum")';
+    const second =
+        '.binaryTarget(name: "B", url: "https://x/B.zip", checksum: "$checksum")';
+    final foreignTarget = SwiftPmBinaryTargetManifest.discover(second).single;
+
+    expect(
+      () => SwiftPmBinaryTargetManifest.rewriteToLocalPaths(first, {
+        foreignTarget: 'A.xcframework',
+      }),
+      throwsArgumentError,
+    );
+  });
+}

--- a/packages/xcross/test/flutter/build/swiftpm_workspace_test.dart
+++ b/packages/xcross/test/flutter/build/swiftpm_workspace_test.dart
@@ -1,0 +1,98 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:xcross/src/flutter/build/internal/swiftpm_workspace.dart';
+
+void main() {
+  late Directory temp;
+
+  setUp(() {
+    temp = Directory.systemTemp.createTempSync('xcross_swiftpm_workspace-');
+  });
+
+  tearDown(() => temp.deleteSync(recursive: true));
+
+  test('uses a stable project key', () {
+    final first = SwiftPmWorkspace.forProject(
+      temp.path,
+      environment: {'XCROSS_CACHE_DIR': p.join(temp.path, 'cache')},
+    );
+    final second = SwiftPmWorkspace.forProject(
+      p.join(temp.path, '.'),
+      environment: {'XCROSS_CACHE_DIR': p.join(temp.path, 'cache')},
+    );
+
+    expect(second.root, first.root);
+    expect(p.basename(first.root), hasLength(16));
+  });
+
+  test('uses different keys for different projects', () {
+    final firstProject = Directory(p.join(temp.path, 'first'))..createSync();
+    final secondProject = Directory(p.join(temp.path, 'second'))..createSync();
+    final environment = {'XCROSS_CACHE_DIR': p.join(temp.path, 'cache')};
+
+    final first = SwiftPmWorkspace.forProject(
+      firstProject.path,
+      environment: environment,
+    );
+    final second = SwiftPmWorkspace.forProject(
+      secondProject.path,
+      environment: environment,
+    );
+
+    expect(second.root, isNot(first.root));
+  });
+
+  test('honors XCROSS_CACHE_DIR', () {
+    final cache = p.join(temp.path, 'custom-cache');
+    final workspace = SwiftPmWorkspace.forProject(
+      temp.path,
+      environment: {'XCROSS_CACHE_DIR': cache},
+    );
+
+    expect(p.isWithin(cache, workspace.root), isTrue);
+    expect(workspace.packages, p.join(workspace.root, 'plugins'));
+    expect(workspace.scratch, p.join(workspace.root, 'scratch'));
+    expect(workspace.vendor, p.join(workspace.root, 'vendor'));
+  });
+
+  test('uses LOCALAPPDATA on Windows', () {
+    final localAppData = p.join(temp.path, 'local');
+    final workspace = SwiftPmWorkspace.forProject(
+      temp.path,
+      environment: {'LOCALAPPDATA': localAppData},
+      windows: true,
+    );
+
+    expect(
+      p.isWithin(p.join(localAppData, 'xcross'), workspace.root),
+      isTrue,
+    );
+  });
+
+  test('uses XDG_CACHE_HOME on POSIX', () {
+    final xdg = p.join(temp.path, 'xdg');
+    final workspace = SwiftPmWorkspace.forProject(
+      temp.path,
+      environment: {'XDG_CACHE_HOME': xdg},
+      windows: false,
+    );
+
+    expect(p.isWithin(p.join(xdg, 'xcross'), workspace.root), isTrue);
+  });
+
+  test('falls back to the home cache on POSIX', () {
+    final home = p.join(temp.path, 'home');
+    final workspace = SwiftPmWorkspace.forProject(
+      temp.path,
+      environment: {'HOME': home},
+      windows: false,
+    );
+
+    expect(
+      p.isWithin(p.join(home, '.cache', 'xcross'), workspace.root),
+      isTrue,
+    );
+  });
+}

--- a/packages/xcross/test/flutter/build/swiftpm_workspace_test.dart
+++ b/packages/xcross/test/flutter/build/swiftpm_workspace_test.dart
@@ -51,7 +51,16 @@ void main() {
       environment: {'XCROSS_CACHE_DIR': cache},
     );
 
+    expect(workspace.cacheRoot, cache);
     expect(p.isWithin(cache, workspace.root), isTrue);
+    expect(
+      workspace.binaryArtifactStore,
+      p.join(cache, 'swiftpm', 'binary-artifacts-v1'),
+    );
+    expect(
+      workspace.binaryArtifactFallback,
+      p.join(workspace.root, 'binary-artifacts'),
+    );
     expect(workspace.packages, p.join(workspace.root, 'plugins'));
     expect(workspace.scratch, p.join(workspace.root, 'scratch'));
     expect(workspace.vendor, p.join(workspace.root, 'vendor'));
@@ -65,10 +74,7 @@ void main() {
       windows: true,
     );
 
-    expect(
-      p.isWithin(p.join(localAppData, 'xcross'), workspace.root),
-      isTrue,
-    );
+    expect(p.isWithin(p.join(localAppData, 'xcross'), workspace.root), isTrue);
   });
 
   test('uses XDG_CACHE_HOME on POSIX', () {

--- a/packages/xcross/test/release_packaging_test.dart
+++ b/packages/xcross/test/release_packaging_test.dart
@@ -21,6 +21,7 @@ void main() {
       r'download "$base_url/$LICENSE_ASSET" "$staging_dir/$LICENSE_ASSET"',
       r'tar -C "$staging_dir" -xzf "$staging_dir/$archive_name"',
       r'install -m 0755 "$staging_dir/bin/$BINARY_NAME" "$installed_binary"',
+      r'install -m 0755 "$staging_dir/bin/xcrun" "$INSTALL_DIR/xcrun"',
       r'install -m 0644 "$staging_dir/$LICENSE_ASSET" "$installed_license"',
       r'"$installed_binary" --help',
     ]) {
@@ -39,6 +40,7 @@ void main() {
       'LOCALAPPDATA',
       'sysv_abi_bridge.dll',
       r'bin\xcross.exe',
+      r'bin\xcrun.exe',
       '--help',
       r"Join-Path $env:LOCALAPPDATA 'xcross'",
       'SetEnvironmentVariable',

--- a/packages/xcross/test/update/build_xcross_test.dart
+++ b/packages/xcross/test/update/build_xcross_test.dart
@@ -21,6 +21,18 @@ void main() {
       ..createSync(recursive: true);
     generatedPath = p.join(lib.path, 'version.g.dart');
     File(generatedPath).writeAsStringSync(generatedSource);
+    final builtBin = Directory(
+      p.join(sandbox.path, 'build', 'cli', 'test', 'bundle', 'bin'),
+    )..createSync(recursive: true);
+    File(
+      p.join(builtBin.path, Platform.isWindows ? 'xcross.exe' : 'xcross'),
+    ).writeAsStringSync('');
+    final xcrunBin = Directory(
+      p.join(sandbox.path, 'build', 'xcrun', 'bundle', 'bin'),
+    )..createSync(recursive: true);
+    File(
+      p.join(xcrunBin.path, Platform.isWindows ? 'xcrun.exe' : 'xcrun'),
+    ).writeAsStringSync('');
   }
 
   setUp(() => sandbox = Directory.systemTemp.createTempSync('xcross-build-'));

--- a/packages/xcross/test/update/self_update_test.dart
+++ b/packages/xcross/test/update/self_update_test.dart
@@ -43,10 +43,15 @@ void main() {
   File installedLib(String name, String contents) =>
       File(p.join(prefix.path, 'lib', name))..writeAsStringSync(contents);
 
-  File bundleBin(String contents) =>
-      File(p.join(bundle.path, 'bin', _exeName()))
-        ..createSync(recursive: true)
-        ..writeAsStringSync(contents);
+  File bundleBin(String contents) {
+    final bin = File(p.join(bundle.path, 'bin', _exeName()))
+      ..createSync(recursive: true)
+      ..writeAsStringSync(contents);
+    File(
+      p.join(bundle.path, 'bin', Platform.isWindows ? 'xcrun.exe' : 'xcrun'),
+    ).writeAsStringSync('xcrun');
+    return bin;
+  }
 
   File bundleLib(String name, String contents) =>
       File(p.join(bundle.path, 'lib', name))
@@ -250,9 +255,13 @@ void main() {
           ),
     );
 
-    expect(Directory(layout.binDir).listSync().map((e) => p.basename(e.path)), [
-      _exeName(),
-    ]);
+    expect(
+      Directory(
+        layout.binDir,
+      ).listSync().map((e) => p.basename(e.path)).toSet(),
+      {_exeName(), if (Platform.isWindows) 'xcrun.exe' else 'xcrun'},
+    );
+
     expect(
       Directory(
         layout.libDir,

--- a/packages/xcross/tool/build_xcross.dart
+++ b/packages/xcross/tool/build_xcross.dart
@@ -40,33 +40,47 @@ Future<int> buildXcross({
   try {
     await generated.writeAsString(_identitySource(version, released));
     final run = runBuild ?? _runBuild;
-    final result = await run(Platform.resolvedExecutable, const [
-      'build',
-      'cli',
-      '-t',
-      'bin/xcross.dart',
-    ], workingDirectory: packageRoot.path);
-    if (result != 0) return result;
-    final binDirectory = _builtBinDirectory(packageRoot);
+    final xcrossResult = await _buildCliExecutable(
+      run,
+      packageRoot,
+      target: 'bin/xcross.dart',
+    );
+    if (xcrossResult != 0) return xcrossResult;
+
     final xcrunBuild = p.join(packageRoot.path, 'build', 'xcrun');
-    final xcrunResult = await run(Platform.resolvedExecutable, [
-      'build',
-      'cli',
-      '-t',
-      'bin/xcrun.dart',
-      '-o',
-      xcrunBuild,
-    ], workingDirectory: packageRoot.path);
+    final xcrunResult = await _buildCliExecutable(
+      run,
+      packageRoot,
+      target: 'bin/xcrun.dart',
+      output: xcrunBuild,
+    );
     if (xcrunResult != 0) return xcrunResult;
+
     final executable = Platform.isWindows ? 'xcrun.exe' : 'xcrun';
-    await File(
-      p.join(xcrunBuild, 'bundle', 'bin', executable),
-    ).copy(p.join(binDirectory.path, executable));
+    final source = p.join(xcrunBuild, 'bundle', 'bin', executable);
+    final destination = p.join(
+      _builtBinDirectory(packageRoot).path,
+      executable,
+    );
+    await File(source).copy(destination);
     return 0;
   } finally {
     await generated.writeAsBytes(original, flush: true);
   }
 }
+
+Future<int> _buildCliExecutable(
+  BuildCliRun run,
+  Directory packageRoot, {
+  required String target,
+  String? output,
+}) => run(Platform.resolvedExecutable, [
+  'build',
+  'cli',
+  '-t',
+  target,
+  if (output != null) ...['-o', output],
+], workingDirectory: packageRoot.path);
 
 Directory _builtBinDirectory(Directory packageRoot) {
   final build = Directory(p.join(packageRoot.path, 'build', 'cli'));

--- a/packages/xcross/tool/build_xcross.dart
+++ b/packages/xcross/tool/build_xcross.dart
@@ -39,15 +39,45 @@ Future<int> buildXcross({
   final original = await generated.readAsBytes();
   try {
     await generated.writeAsString(_identitySource(version, released));
-    return await (runBuild ?? _runBuild)(Platform.resolvedExecutable, const [
+    final run = runBuild ?? _runBuild;
+    final result = await run(Platform.resolvedExecutable, const [
       'build',
       'cli',
       '-t',
       'bin/xcross.dart',
     ], workingDirectory: packageRoot.path);
+    if (result != 0) return result;
+    final binDirectory = _builtBinDirectory(packageRoot);
+    final xcrunBuild = p.join(packageRoot.path, 'build', 'xcrun');
+    final xcrunResult = await run(Platform.resolvedExecutable, [
+      'build',
+      'cli',
+      '-t',
+      'bin/xcrun.dart',
+      '-o',
+      xcrunBuild,
+    ], workingDirectory: packageRoot.path);
+    if (xcrunResult != 0) return xcrunResult;
+    final executable = Platform.isWindows ? 'xcrun.exe' : 'xcrun';
+    await File(
+      p.join(xcrunBuild, 'bundle', 'bin', executable),
+    ).copy(p.join(binDirectory.path, executable));
+    return 0;
   } finally {
     await generated.writeAsBytes(original, flush: true);
   }
+}
+
+Directory _builtBinDirectory(Directory packageRoot) {
+  final build = Directory(p.join(packageRoot.path, 'build', 'cli'));
+  final executable = Platform.isWindows ? 'xcross.exe' : 'xcross';
+  for (final entity in build.listSync(recursive: true).whereType<File>()) {
+    if (p.basename(entity.path) == executable &&
+        p.basename(p.dirname(entity.path)) == 'bin') {
+      return entity.parent;
+    }
+  }
+  throw StateError('dart build cli did not produce bin/$executable');
 }
 
 void _validateIdentity(

--- a/packages/xcross/tool/swiftpm_binary_fixture.dart
+++ b/packages/xcross/tool/swiftpm_binary_fixture.dart
@@ -1,0 +1,18 @@
+import 'dart:io';
+
+import 'package:xcross/src/flutter/build/internal/swiftpm_binary_fixture.dart';
+
+void main(List<String> arguments) {
+  if (arguments.length != 2) {
+    stderr.writeln('usage: swiftpm_binary_fixture.dart <output> <archive-url>');
+    exitCode = 64;
+    return;
+  }
+  final fixture = SwiftPmBinaryFixture.generate(
+    root: arguments[0],
+    archiveUrl: Uri.parse(arguments[1]),
+  );
+  stdout.writeln('archive=${fixture.archive.path}');
+  stdout.writeln('checksum=${fixture.checksum}');
+  stdout.writeln('plugin=${fixture.pluginRoot.path}');
+}

--- a/packages/xcross/tool/swiftpm_gate_evidence.dart
+++ b/packages/xcross/tool/swiftpm_gate_evidence.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:darwin_sdk_kit/darwin_sdk_kit.dart';
+import 'package:path/path.dart' as p;
+import 'package:xcross/src/cli/basic/sdk_install.dart';
+import 'package:xcross/src/flutter/build/internal/swiftpm_gate_evidence.dart';
+import 'package:xcross/src/flutter/build/ios_plugin_package.dart';
+
+Future<void> main(List<String> arguments) async {
+  if (!Platform.isWindows ||
+      arguments.length != 2 ||
+      arguments.first != 'record') {
+    throw ArgumentError('usage: swiftpm_gate_evidence record <mode>');
+  }
+  final mode = SwiftPmGateMode.values.singleWhere(
+    (candidate) => candidate.name == arguments[1],
+  );
+  final cacheRoot = Platform.environment['XCROSS_CACHE_DIR'];
+  if (cacheRoot == null || cacheRoot.isEmpty) {
+    throw StateError('XCROSS_CACHE_DIR is required');
+  }
+  final sdk = DarwinSdk.current();
+  if (sdk == null) throw StateError('Darwin SDK is required');
+  final passed =
+      await SwiftPmGateEvidence(
+        p.join(cacheRoot, 'swiftpm', 'gate-evidence-v2'),
+      ).verifies(
+        mode: mode,
+        platformIdentity:
+            '${Platform.operatingSystem}-${Platform.operatingSystemVersion}',
+        toolchainIdentity: jsonEncode(
+          await GeneratedPluginsPackage.resolveBuildToolchainIdentity(sdk),
+        ),
+        sdkIdentity: jsonEncode(
+          await SdkInstall.sdkBuildIdentity(sdk.swiftSdkPath),
+        ),
+      );
+  if (!passed) throw StateError('${mode.name} feasibility probe failed');
+}


### PR DESCRIPTION
## Summary

- make Flutter iOS native-asset hooks work on Windows with executable Apple tool forwarders and shims for `xcrun`, `plutil`, `rsync`, `otool`, `install_name_tool`, and the LLVM compiler/linker tools
- ship the `xcrun` compatibility executable in release and self-update bundles and expose it to native-asset hooks
- stage SwiftPM plugin builds in a short, project-scoped cache workspace to avoid Windows path limits while preserving build reuse
- repair and validate plugin binary artifacts, framework search paths, install names, and generated package manifests before cross-compiling the aggregate plugin library
- isolate SwiftPM scratch paths so Windows example builds can run reliably and reuse unchanged outputs
- update the example submodule and integration workflow to build the packaged `xcross`/`xcrun` bundle and validate Flutter and Compose projects on Linux and Windows

## Validation

- expanded unit coverage for Apple tool aliases, `xcrun`, native assets, SwiftPM workspaces, plugin package generation, release packaging, and self-update behavior
- GitHub Actions: `Flutter and Compose SwiftPM build` on `ubuntu-24.04` and `windows-2022`