### PR TITLE
feat(nix): `flake.nix` support

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,130 @@
+name: Nix
+
+on:
+  pull_request:
+    paths:
+      - flake.nix
+      - flake.lock
+      - .github/workflows/nix.yml
+      - README.md
+  push:
+    branches: [main]
+    paths:
+      - flake.nix
+      - flake.lock
+      - .github/workflows/nix.yml
+      - README.md
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: nix-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Check (${{ matrix.system }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            system: x86_64-linux
+          - runner: ubuntu-24.04-arm
+            system: aarch64-linux
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+          submodules: true
+
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@2a0be2498974c2b6327e19780488744384637d88 # v3.21.7
+
+      - name: Check flake
+        run: nix flake check --print-build-logs
+
+      - name: Create consumer flake
+        env:
+          SYSTEM: ${{ matrix.system }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/xcross-consumer"
+          cp -R examples/flutter_example/. "$RUNNER_TEMP/xcross-consumer/"
+          cd "$RUNNER_TEMP/xcross-consumer"
+          cat > flake.nix <<'EOF'
+          {
+            inputs = {
+              nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+              xcross.url = "path:__XCROSS_SOURCE__";
+            };
+
+            outputs = { nixpkgs, xcross, ... }:
+              let
+                system = "__SYSTEM__";
+                pkgs = nixpkgs.legacyPackages.${system};
+              in {
+                devShells.${system}.default = pkgs.mkShell {
+                  inputsFrom = [ xcross.devShells.${system}.default ];
+                  packages = [ pkgs.flutter ];
+                };
+              };
+          }
+          EOF
+          sed -i \
+            -e "s/__SYSTEM__/$SYSTEM/" \
+            -e "s|__XCROSS_SOURCE__|$GITHUB_WORKSPACE|" \
+            flake.nix
+          nix flake lock
+
+      - name: Export consumer environment
+        working-directory: ${{ runner.temp }}/xcross-consumer
+        run: |
+          nix develop --command bash -euo pipefail -c '
+            printf "XCROSS_NIX_PATH=%s\n" "$PATH" >> "$GITHUB_ENV"
+          '
+
+      - name: Check Swift toolchain pairing
+        working-directory: ${{ runner.temp }}/xcross-consumer
+        run: |
+          nix develop --command bash -euo pipefail -c '
+            test "$(dirname "$(readlink -f "$(command -v swift)")")" = \
+              "$(dirname "$(readlink -f "$(command -v swiftc)")")"
+            test -x "$SWIFT_EXEC"
+            test "$SWIFT_EXEC" = "$SWIFT_EXEC_MANIFEST"
+            package="$(mktemp -d)"
+            swift package init --package-path "$package" --type empty
+            swift package describe --package-path "$package" --type json >/dev/null
+          '
+
+      - name: Restore cached Darwin SDK
+        if: matrix.system == 'x86_64-linux'
+        uses: ./.github/actions/setup-darwin-sdk
+        env:
+          PATH: ${{ env.XCROSS_NIX_PATH }}
+
+      - name: Build source xcross
+        if: matrix.system == 'x86_64-linux'
+        working-directory: ${{ runner.temp }}/xcross-consumer
+        run: |
+          nix develop --command bash -euo pipefail -c '
+            cp -R "$GITHUB_WORKSPACE" "$RUNNER_TEMP/xcross-source"
+            cd "$RUNNER_TEMP/xcross-source"
+            dart pub get
+            cd packages/xcross
+            dart run tool/build_xcross.dart
+          '
+
+      - name: Build Flutter example
+        if: matrix.system == 'x86_64-linux'
+        working-directory: ${{ runner.temp }}/xcross-consumer
+        run: |
+          nix develop --command bash -euo pipefail -c '
+            "$RUNNER_TEMP/xcross-source/packages/xcross/build/cli/linux_x64/bundle/bin/xcross" flutter build
+            test "$(find build/xcross-ios -maxdepth 1 -type d -name "*.app" | wc -l)" -eq 1
+          '

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -7,6 +7,8 @@ on:
       - flake.lock
       - .github/workflows/nix.yml
       - README.md
+      - packages/xcross/lib/src/config/**
+      - packages/xcross/lib/src/cli/runner.dart
   push:
     branches: [main]
     paths:
@@ -14,6 +16,8 @@ on:
       - flake.lock
       - .github/workflows/nix.yml
       - README.md
+      - packages/xcross/lib/src/config/**
+      - packages/xcross/lib/src/cli/runner.dart
   workflow_dispatch:
 
 permissions:
@@ -60,8 +64,8 @@ jobs:
           cat > flake.nix <<'EOF'
           {
             inputs = {
-              nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
               xcross.url = "path:__XCROSS_SOURCE__";
+              nixpkgs.follows = "xcross/nixpkgs";
             };
 
             outputs = { nixpkgs, xcross, ... }:
@@ -71,7 +75,6 @@ jobs:
               in {
                 devShells.${system}.default = pkgs.mkShell {
                   inputsFrom = [ xcross.devShells.${system}.default ];
-                  packages = [ pkgs.flutter ];
                 };
               };
           }
@@ -85,14 +88,14 @@ jobs:
       - name: Export consumer environment
         working-directory: ${{ runner.temp }}/xcross-consumer
         run: |
-          nix develop --command bash -euo pipefail -c '
+          nix develop --command bash -euo pipefail <<'SH'
             printf "XCROSS_NIX_PATH=%s\n" "$PATH" >> "$GITHUB_ENV"
-          '
+          SH
 
       - name: Check Swift toolchain pairing
         working-directory: ${{ runner.temp }}/xcross-consumer
         run: |
-          nix develop --command bash -euo pipefail -c '
+          nix develop --command bash -euo pipefail <<'SH'
             test "$(dirname "$(readlink -f "$(command -v swift)")")" = \
               "$(dirname "$(readlink -f "$(command -v swiftc)")")"
             test -x "$SWIFT_EXEC"
@@ -100,7 +103,49 @@ jobs:
             package="$(mktemp -d)"
             swift package init --package-path "$package" --type empty
             swift package describe --package-path "$package" --type json >/dev/null
-          '
+          SH
+
+      - name: Check Nix configuration
+        working-directory: ${{ runner.temp }}/xcross-consumer
+        run: |
+          nix develop --command python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          config_path = Path(os.environ["XCROSS_CONFIG"])
+          assert str(config_path).startswith("/nix/store/"), config_path
+          config = json.loads(config_path.read_text())
+          assert set(config["excluded_commands"]) == {"config", "setup"}
+          roots = {key: Path(os.path.expandvars(value)) for key, value in config["roots"].items()}
+          for key in ("flutterSdk", "javaHome", "xcross"):
+              assert roots[key].is_absolute() and roots[key].exists(), (key, roots[key])
+              assert str(roots[key]).startswith("/nix/store/"), (key, roots[key])
+          assert (roots["flutterSdk"] / "bin/cache/dart-sdk/bin/dart").is_file()
+          assert roots["flutterSdk"] == Path(os.environ["FLUTTER_ROOT"])
+          assert roots["javaHome"] == Path(os.environ["JAVA_HOME"])
+          for key, variable in (("darwinSdk", "XCROSS_DARWIN_BUNDLE"), ("konanData", "KONAN_DATA_DIR")):
+              assert roots[key].is_absolute(), (key, roots[key])
+              assert roots[key] == Path(os.environ[variable]), (key, roots[key])
+              assert not str(roots[key]).startswith("/nix/store/"), (key, roots[key])
+          for directory in [config["toolchains"]["swift"], *config["toolchains"]["llvm"]]:
+              assert directory.startswith("/nix/store/") and Path(directory).is_dir(), directory
+          for key in ("SWIFT_EXEC", "SWIFT_EXEC_MANIFEST", "CC", "CXX"):
+              assert os.access(config["environment"][key], os.X_OK), key
+          PY
+          nix develop --command bash -euo pipefail <<'SH'
+            xcross --help > "$RUNNER_TEMP/xcross-nix-help"
+            for command in config setup; do
+              status=0
+              env -u XCROSS_CONFIG -u XCROSS_DARWIN_BUNDLE -u KONAN_DATA_DIR \
+                xcross "$command" --help > "$RUNNER_TEMP/xcross-nix-command" 2>&1 || status=$?
+              test "$status" -eq 64
+              grep -F "Could not find a command named" "$RUNNER_TEMP/xcross-nix-command"
+              if grep -Eq "^[[:space:]]+$command[[:space:]]" "$RUNNER_TEMP/xcross-nix-help"; then
+                exit 1
+              fi
+            done
+          SH
 
       - name: Restore cached Darwin SDK
         if: matrix.system == 'x86_64-linux'
@@ -112,19 +157,34 @@ jobs:
         if: matrix.system == 'x86_64-linux'
         working-directory: ${{ runner.temp }}/xcross-consumer
         run: |
-          nix develop --command bash -euo pipefail -c '
+          nix develop --command bash -euo pipefail <<'SH'
             cp -R "$GITHUB_WORKSPACE" "$RUNNER_TEMP/xcross-source"
             cd "$RUNNER_TEMP/xcross-source"
             dart pub get
             cd packages/xcross
             dart run tool/build_xcross.dart
-          '
+          SH
+
+      - name: Check source command exclusions
+        if: matrix.system == 'x86_64-linux'
+        working-directory: ${{ runner.temp }}/xcross-consumer
+        run: |
+          nix develop --command bash -euo pipefail <<'SH'
+            executable="$RUNNER_TEMP/xcross-source/packages/xcross/build/cli/linux_x64/bundle/bin/xcross"
+            "$executable" --help
+            for command in config setup; do
+              status=0
+              "$executable" "$command" --help > "$RUNNER_TEMP/xcross-source-command" 2>&1 || status=$?
+              test "$status" -eq 64
+              grep -F "Could not find a command named" "$RUNNER_TEMP/xcross-source-command"
+            done
+          SH
 
       - name: Build Flutter example
         if: matrix.system == 'x86_64-linux'
         working-directory: ${{ runner.temp }}/xcross-consumer
         run: |
-          nix develop --command bash -euo pipefail -c '
+          nix develop --command bash -euo pipefail <<'SH'
             "$RUNNER_TEMP/xcross-source/packages/xcross/build/cli/linux_x64/bundle/bin/xcross" flutter build
             test "$(find build/xcross-ios -maxdepth 1 -type d -name "*.app" | wc -l)" -eq 1
-          '
+          SH

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -9,6 +9,7 @@ on:
       - README.md
       - packages/xcross/lib/src/config/**
       - packages/xcross/lib/src/cli/runner.dart
+      - packages/xcross/lib/src/flutter/build/**
   push:
     branches: [main]
     paths:
@@ -18,6 +19,7 @@ on:
       - README.md
       - packages/xcross/lib/src/config/**
       - packages/xcross/lib/src/cli/runner.dart
+      - packages/xcross/lib/src/flutter/build/**
   workflow_dispatch:
 
 permissions:
@@ -191,6 +193,32 @@ jobs:
         uses: ./.github/actions/setup-darwin-sdk
         env:
           PATH: ${{ env.XCROSS_NIX_PATH }}
+
+      - name: Check packaged xcrun shim dispatch
+        if: matrix.system == 'x86_64-linux'
+        working-directory: ${{ runner.temp }}/xcross-consumer
+        run: |
+          nix develop --command bash -euo pipefail <<'SH'
+            packaged_xcrun="$(dirname "$(command -v xcross)")/xcrun"
+            [[ "$packaged_xcrun" == /nix/store/*/bin/xcrun ]]
+            test -x "$packaged_xcrun"
+            shims="$(mktemp -d)"
+            trap 'rm -rf "$shims"' EXIT
+            cat > "$shims/clang" <<'CLANG'
+          #!/usr/bin/env bash
+          printf '%s\0' "$@" > "$XCROSS_SHIM_ARGS"
+          exit 37
+          CLANG
+            chmod +x "$shims/clang"
+            test "$(PATH="$shims:$PATH" "$packaged_xcrun" --find clang)" = "$shims/clang"
+            export XCROSS_SHIM_ARGS="$shims/actual"
+            args=(-c 'source with spaces.c' -o 'output with spaces.o' '')
+            printf '%s\0' "${args[@]}" > "$shims/expected"
+            status=0
+            PATH="$shims:$PATH" "$packaged_xcrun" --sdk iphoneos clang "${args[@]}" || status=$?
+            test "$status" -eq 37
+            cmp "$shims/expected" "$shims/actual"
+          SH
 
       - name: Build source xcross
         if: matrix.system == 'x86_64-linux'

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -72,9 +72,44 @@ jobs:
               let
                 system = "__SYSTEM__";
                 pkgs = nixpkgs.legacyPackages.${system};
+                xcrossPackage = xcross.packages.${system}.default;
+                inherit (xcrossPackage) swiftToolchain swiftCompiler;
+                config = pkgs.writeText "consumer-xcross-config.yaml" (builtins.toJSON {
+                  roots = {
+                    darwinSdk = "$XCROSS_DARWIN_BUNDLE";
+                    flutterSdk = "${pkgs.flutter}";
+                    xcross = "${xcrossPackage}/bin/xcross";
+                    javaHome = "${pkgs.jdk.home}";
+                    konanData = "$KONAN_DATA_DIR";
+                  };
+                  toolchains = {
+                    swift = "${swiftToolchain}/bin";
+                    llvm = [
+                      "${swiftToolchain}/bin"
+                      "${pkgs.llvmPackages_21.llvm}/bin"
+                      "${pkgs.llvmPackages_21.lld}/bin"
+                    ];
+                  };
+                  excluded_commands = [ "config" "setup" ];
+                  environment = {
+                    SWIFT_EXEC = "${swiftCompiler}";
+                    SWIFT_EXEC_MANIFEST = "${swiftCompiler}";
+                    CC = "${swiftToolchain}/bin/clang";
+                    CXX = "${swiftToolchain}/bin/clang++";
+                    FLUTTER_ROOT = "${pkgs.flutter}";
+                  };
+                });
               in {
                 devShells.${system}.default = pkgs.mkShell {
                   inputsFrom = [ xcross.devShells.${system}.default ];
+                  packages = [ pkgs.flutter pkgs.jdk ];
+                  XCROSS_CONFIG = config;
+                  FLUTTER_ROOT = "${pkgs.flutter}";
+                  JAVA_HOME = "${pkgs.jdk.home}";
+                  shellHook = ''
+                    export XCROSS_DARWIN_BUNDLE="''${XCROSS_DARWIN_BUNDLE:-''${XDG_CONFIG_HOME:-$HOME/.config}/xcross/swift-sdks/xcross-darwin.artifactbundle}"
+                    export KONAN_DATA_DIR="''${KONAN_DATA_DIR:-$HOME/.konan}"
+                  '';
                 };
               };
           }
@@ -137,13 +172,17 @@ jobs:
             xcross --help > "$RUNNER_TEMP/xcross-nix-help"
             for command in config setup; do
               status=0
-              env -u XCROSS_CONFIG -u XCROSS_DARWIN_BUNDLE -u KONAN_DATA_DIR \
-                xcross "$command" --help > "$RUNNER_TEMP/xcross-nix-command" 2>&1 || status=$?
+              xcross "$command" --help > "$RUNNER_TEMP/xcross-nix-command" 2>&1 || status=$?
               test "$status" -eq 64
               grep -F "Could not find a command named" "$RUNNER_TEMP/xcross-nix-command"
               if grep -Eq "^[[:space:]]+$command[[:space:]]" "$RUNNER_TEMP/xcross-nix-help"; then
                 exit 1
               fi
+            done
+            alternate_config="$RUNNER_TEMP/xcross-alternate-config.yaml"
+            printf '{}\n' > "$alternate_config"
+            for command in config setup; do
+              XCROSS_CONFIG="$alternate_config" xcross "$command" --help
             done
           SH
 

--- a/docs/NixOS.md
+++ b/docs/NixOS.md
@@ -1,0 +1,296 @@
+# NixOS
+
+xcross provides Linux packages and development shells for `x86_64-linux` and
+`aarch64-linux`. A project consuming the xcross flake should own the xcross
+configuration because Flutter, Java, writable cache locations, and policy such
+as disabled commands belong to the project environment, not to the xcross
+package.
+
+## Design
+
+The integration has two layers:
+
+- The xcross flake provides the xcross release, Swift, LLVM, device tools,
+  Python, and `pymobiledevice3`.
+- The consumer flake provides Flutter, Java, `XCROSS_CONFIG`, and writable
+  project or user roots.
+
+The xcross package exposes these attributes for composing the consumer config:
+
+- `xcross.packages.${system}.default`
+- `xcross.packages.${system}.default.swiftToolchain`
+- `xcross.packages.${system}.default.swiftCompiler`
+- `xcross.devShells.${system}.default`
+
+Use `inputsFrom` to inherit the xcross runtime dependencies. Make the consumer's
+`nixpkgs` input follow `xcross/nixpkgs` so packages and toolchain paths come from
+the same pinned package set.
+
+The configuration is immutable in the Nix store, but it may contain environment
+references such as `$HOME`. xcross expands those references when it loads the
+configuration. This keeps compiler and SDK paths reproducible while keeping
+mutable Apple SDK and Kotlin/Native data outside `/nix/store`.
+
+## NixOS host configuration
+
+The Swift release used by xcross is an upstream Linux binary distribution. On
+NixOS, enable `nix-ld` so those binaries can use their expected dynamic loader.
+Enable the system `usbmuxd` service when connecting iPhones over USB:
+
+```nix
+{ ... }:
+{
+  programs.nix-ld.enable = true;
+  services.usbmuxd.enable = true;
+}
+```
+
+Apply the system configuration before entering the project shell:
+
+```sh
+sudo nixos-rebuild switch
+```
+
+`services.usbmuxd` also installs the Apple USB udev rule. The service is not
+required for a workflow that never uses USB, but USB is normally needed for the
+initial device pairing even when later runs use Wi-Fi.
+
+## Consumer flake
+
+Add this `flake.nix` to the Flutter project:
+
+```nix
+{
+  description = "Flutter iOS development with xcross";
+
+  inputs = {
+    xcross.url = "github:arxdeus/xcross";
+    nixpkgs.follows = "xcross/nixpkgs";
+  };
+
+  outputs =
+    { nixpkgs, xcross, ... }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      eachSystem = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      devShells = eachSystem (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          xcrossPackage = xcross.packages.${system}.default;
+          inherit (xcrossPackage) swiftToolchain swiftCompiler;
+
+          xcrossConfig = pkgs.writeText "xcross-config.yaml" (builtins.toJSON {
+            roots = {
+              darwinSdk = "$XCROSS_DARWIN_BUNDLE";
+              flutterSdk = "${pkgs.flutter}";
+              xcross = "${xcrossPackage}/bin/xcross";
+              javaHome = "${pkgs.jdk.home}";
+              konanData = "$KONAN_DATA_DIR";
+            };
+
+            toolchains = {
+              swift = "${swiftToolchain}/bin";
+              llvm = [
+                "${swiftToolchain}/bin"
+                "${pkgs.llvmPackages_21.llvm}/bin"
+                "${pkgs.llvmPackages_21.lld}/bin"
+              ];
+            };
+
+            excluded_commands = [
+              "config"
+              "setup"
+            ];
+
+            environment = {
+              SWIFT_EXEC = "${swiftCompiler}";
+              SWIFT_EXEC_MANIFEST = "${swiftCompiler}";
+              CC = "${swiftToolchain}/bin/clang";
+              CXX = "${swiftToolchain}/bin/clang++";
+              FLUTTER_ROOT = "${pkgs.flutter}";
+            };
+          });
+        in
+        {
+          default = pkgs.mkShell {
+            inputsFrom = [ xcross.devShells.${system}.default ];
+
+            packages = [
+              pkgs.flutter
+              pkgs.jdk
+            ];
+
+            XCROSS_CONFIG = xcrossConfig;
+            FLUTTER_ROOT = "${pkgs.flutter}";
+            JAVA_HOME = "${pkgs.jdk.home}";
+
+            shellHook = ''
+              export XCROSS_DARWIN_BUNDLE="''${XCROSS_DARWIN_BUNDLE:-''${XDG_CONFIG_HOME:-$HOME/.config}/xcross/swift-sdks/xcross-darwin.artifactbundle}"
+              export KONAN_DATA_DIR="''${KONAN_DATA_DIR:-$HOME/.konan}"
+            '';
+          };
+        }
+      );
+    };
+}
+```
+
+Run the shell:
+
+```sh
+nix develop
+```
+
+For automatic activation with direnv:
+
+```sh
+printf 'use flake\n' > .envrc
+direnv allow
+```
+
+Commit both `flake.nix` and `flake.lock` to the project.
+
+## Why the consumer owns the config
+
+`XCROSS_CONFIG` selects the exact configuration file loaded by xcross. Defining
+it in the consumer shell has several benefits:
+
+- The project selects its Flutter and Java versions.
+- All executable and toolchain paths resolve to the consumer's Nix store paths.
+- Writable paths follow the user's home or project policy.
+- Multiple projects may use different xcross configurations simultaneously.
+- The xcross package remains reusable and does not override an explicit
+  consumer configuration.
+
+The example disables `xcross config` and `xcross setup`. Those commands mutate
+or install host state and should not manage a declarative Nix environment.
+Configuration changes belong in the consumer flake, and dependencies belong in
+`packages` or `inputsFrom`.
+
+`xcross sdk install` remains available because importing an Apple SDK is a
+separate operation that writes private, non-redistributable data to the
+configured `roots.darwinSdk` location.
+
+## Roots
+
+The example configures these roots:
+
+| Root | Value | Mutability |
+|---|---|---|
+| `flutterSdk` | `${pkgs.flutter}` | Immutable Nix store path |
+| `xcross` | `${xcrossPackage}/bin/xcross` | Immutable Nix store path |
+| `javaHome` | `${pkgs.jdk.home}` | Immutable Nix store path |
+| `darwinSdk` | `$XCROSS_DARWIN_BUNDLE` | Writable user path |
+| `konanData` | `$KONAN_DATA_DIR` | Writable user path |
+
+By default, the Darwin artifact bundle is stored at:
+
+```text
+${XDG_CONFIG_HOME:-$HOME/.config}/xcross/swift-sdks/xcross-darwin.artifactbundle
+```
+
+Kotlin/Native data defaults to:
+
+```text
+$HOME/.konan
+```
+
+Override either location before entering the shell or through direnv:
+
+```sh
+export XCROSS_DARWIN_BUNDLE="$PWD/.xcross/xcross-darwin.artifactbundle"
+export KONAN_DATA_DIR="$PWD/.xcross/konan"
+nix develop
+```
+
+Do not place these writable roots in `/nix/store`.
+
+## Toolchains and dependencies
+
+`inputsFrom = [ xcross.devShells.${system}.default ]` supplies:
+
+- xcross and xcrun
+- the matching Swift toolchain
+- LLVM and LLD
+- Python and `pymobiledevice3`
+- `usbmuxd`, `libimobiledevice`, and USB utilities
+- Git, pkg-config, and GnuPG
+
+The consumer adds Flutter and Java because those versions are application
+choices. Add other project tools to `packages`, for example:
+
+```nix
+packages = [
+  pkgs.flutter
+  pkgs.jdk
+  pkgs.cmake
+  pkgs.ninja
+];
+```
+
+The Swift compiler wrapper is intentional. `swiftCompiler` invokes the selected
+Swift compiler with LLD, and both `SWIFT_EXEC` and `SWIFT_EXEC_MANIFEST` must
+refer to that same wrapper. Keep the Swift and LLVM directories from the xcross
+package rather than independently selecting incompatible toolchains.
+
+## Preparing the Darwin SDK
+
+Download a complete `Xcode.xip` from
+[xcodereleases.com](https://xcodereleases.com/), then import it from the Nix
+shell:
+
+```sh
+nix develop
+xcross sdk install ~/Downloads/Xcode.xip
+```
+
+The resulting Darwin SDK is tied to the configured Swift toolchain. Re-import
+the SDK after changing the xcross input or any input that changes
+`swiftToolchain`.
+
+The imported SDK is Apple-licensed material. Keep it private and do not commit,
+cache publicly, or copy it into a Nix derivation.
+
+## Verification
+
+Inside `nix develop`, verify the selected environment:
+
+```sh
+printf '%s\n' "$XCROSS_CONFIG"
+test -f "$XCROSS_CONFIG"
+test -x "$SWIFT_EXEC"
+test "$SWIFT_EXEC" = "$SWIFT_EXEC_MANIFEST"
+test -x "$FLUTTER_ROOT/bin/flutter"
+xcross --help
+```
+
+`xcross --help` should not list `config` or `setup`. Running either command
+should report that the command does not exist.
+
+To inspect the generated configuration:
+
+```sh
+cat "$XCROSS_CONFIG"
+```
+
+The file is JSON, which is valid YAML and is accepted by xcross.
+
+## Updating
+
+Update the pinned xcross and nixpkgs inputs together:
+
+```sh
+nix flake update
+nix flake check
+```
+
+After an update, enter a fresh shell and verify Swift, Flutter, and xcross again.
+If the Swift store path changed, rebuild the Darwin SDK with `xcross sdk install`.
+Do not use `xcross update` for a Nix-managed installation. Update the flake input
+instead.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,55 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787736819,
+        "narHash": "sha256-cV5xEJJK3BvhU8rEd4mC9UsmDi5qscv/kzGPhBRC5WA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9fbb54b33e91ee4ca368e35a78e0613c720600b3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "xcross-linux-arm64": "xcross-linux-arm64",
+        "xcross-linux-x64": "xcross-linux-x64"
+      }
+    },
+    "xcross-linux-arm64": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1788019657,
+        "narHash": "sha256-LQd69qIH8mkHuBqfK6epZrKjhrIT3gjXMOkvYt5mh7c=",
+        "type": "tarball",
+        "url": "https://github.com/arxdeus/xcross/releases/download/v1.3.2/xcross-linux-arm64.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/arxdeus/xcross/releases/download/v1.3.2/xcross-linux-arm64.tar.gz"
+      }
+    },
+    "xcross-linux-x64": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1788019657,
+        "narHash": "sha256-GxAiAeAb5Kwi1UfOplR83HatClnUH7lftiFC4nMWFq0=",
+        "type": "tarball",
+        "url": "https://github.com/arxdeus/xcross/releases/download/v1.3.2/xcross-linux-x64.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/arxdeus/xcross/releases/download/v1.3.2/xcross-linux-x64.tar.gz"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -26,27 +26,27 @@
     "xcross-linux-arm64": {
       "flake": false,
       "locked": {
-        "lastModified": 1788019657,
-        "narHash": "sha256-LQd69qIH8mkHuBqfK6epZrKjhrIT3gjXMOkvYt5mh7c=",
+        "lastModified": 1788661026,
+        "narHash": "sha256-1KVhOlvPETtgPae4mXH+o6n68/dVRiQEfiGGtoVmruA=",
         "type": "tarball",
-        "url": "https://github.com/arxdeus/xcross/releases/download/v1.3.2/xcross-linux-arm64.tar.gz"
+        "url": "https://github.com/arxdeus/xcross/releases/download/v1.4.0/xcross-linux-arm64.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/arxdeus/xcross/releases/download/v1.3.2/xcross-linux-arm64.tar.gz"
+        "url": "https://github.com/arxdeus/xcross/releases/download/v1.4.0/xcross-linux-arm64.tar.gz"
       }
     },
     "xcross-linux-x64": {
       "flake": false,
       "locked": {
-        "lastModified": 1788019657,
-        "narHash": "sha256-GxAiAeAb5Kwi1UfOplR83HatClnUH7lftiFC4nMWFq0=",
+        "lastModified": 1788661049,
+        "narHash": "sha256-N88Nj86Gu8j0qZebKSLD/ZsoooMtWABuOqhCVWdbgEY=",
         "type": "tarball",
-        "url": "https://github.com/arxdeus/xcross/releases/download/v1.3.2/xcross-linux-x64.tar.gz"
+        "url": "https://github.com/arxdeus/xcross/releases/download/v1.4.0/xcross-linux-x64.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/arxdeus/xcross/releases/download/v1.3.2/xcross-linux-x64.tar.gz"
+        "url": "https://github.com/arxdeus/xcross/releases/download/v1.4.0/xcross-linux-x64.tar.gz"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,235 @@
+{
+  description = "xcross Linux development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    xcross-linux-x64 = {
+      url = "https://github.com/arxdeus/xcross/releases/download/v1.3.2/xcross-linux-x64.tar.gz";
+      flake = false;
+    };
+
+    xcross-linux-arm64 = {
+      url = "https://github.com/arxdeus/xcross/releases/download/v1.3.2/xcross-linux-arm64.tar.gz";
+      flake = false;
+    };
+  };
+
+  outputs =
+    inputs@{ nixpkgs, ... }:
+    let
+      xcrossVersion = "1.3.2";
+      swiftVersion = "6.3.3";
+
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+
+      eachSystem = nixpkgs.lib.genAttrs systems;
+
+      xcrossReleases = {
+        x86_64-linux = inputs.xcross-linux-x64;
+        aarch64-linux = inputs.xcross-linux-arm64;
+      };
+
+      swiftToolchainSources = {
+        x86_64-linux = {
+          url = "https://download.swift.org/swift-${swiftVersion}-release/ubuntu2404/swift-${swiftVersion}-RELEASE/swift-${swiftVersion}-RELEASE-ubuntu24.04.tar.gz";
+          hash = "sha256-2oJypf3czWWxUp7Q5S4EUm4urdQjfVjWIg7+uXPGzRk=";
+        };
+        aarch64-linux = {
+          url = "https://download.swift.org/swift-${swiftVersion}-release/ubuntu2404-aarch64/swift-${swiftVersion}-RELEASE/swift-${swiftVersion}-RELEASE-ubuntu24.04-aarch64.tar.gz";
+          hash = "sha256-RxJjlUKWU/p2jTcGVYduwbaPapXHiE9eTxeXABQcm38=";
+        };
+      };
+
+      pymobiledeviceOverlay = final: previous: {
+        python313 = previous.python313.override {
+          packageOverrides = pythonFinal: pythonPrevious: {
+            pyimg4 = pythonPrevious.pyimg4.overridePythonAttrs (old: {
+              pythonRelaxDeps = (old.pythonRelaxDeps or [ ]) ++ [ "asn1" ];
+              doCheck = false;
+              meta = old.meta // {
+                broken = false;
+              };
+            });
+          };
+        };
+        python313Packages = final.python313.pkgs;
+      };
+
+      packagesFor = system:
+        import nixpkgs {
+          inherit system;
+          overlays = [ pymobiledeviceOverlay ];
+        };
+
+      environmentFor = system:
+        let
+          pkgs = packagesFor system;
+          xcrossRelease = xcrossReleases.${system};
+          swiftToolchainSource = swiftToolchainSources.${system};
+
+          swiftToolchain = pkgs.stdenv.mkDerivation {
+            pname = "swift-toolchain";
+            version = swiftVersion;
+            src = pkgs.fetchurl {
+              inherit (swiftToolchainSource) url hash;
+            };
+
+            dontConfigure = true;
+            dontBuild = true;
+            dontFixup = true;
+
+            installPhase = ''
+              runHook preInstall
+              mkdir -p "$out"
+              cp -r usr/* "$out/"
+              runHook postInstall
+            '';
+          };
+
+          swiftCompiler = pkgs.writeShellScript "xcross-swiftc" ''
+            exec ${swiftToolchain}/bin/swiftc -use-ld=lld "$@"
+          '';
+
+          runtimePackages = [
+            swiftToolchain
+            pkgs.python313
+            pkgs.python313Packages.pymobiledevice3
+            pkgs.usbmuxd
+            pkgs.libimobiledevice
+            pkgs.usbutils
+            pkgs.pkg-config
+            pkgs.gnupg
+          ];
+
+          xcross = pkgs.stdenvNoCC.mkDerivation {
+            pname = "xcross";
+            version = xcrossVersion;
+            src = xcrossRelease;
+
+            nativeBuildInputs = [ pkgs.makeWrapper ];
+
+            dontBuild = true;
+            dontFixup = true;
+
+            installPhase = ''
+              runHook preInstall
+              mkdir -p "$out/bin" "$out/lib/xcross" "$out/share/licenses/xcross"
+              cp -r bin lib "$out/lib/xcross/"
+              install -m 0644 ${./LICENSE} "$out/share/licenses/xcross/LICENSE"
+              install -m 0644 ${./packages/apple_developer_kit/ADI_LICENSE} \
+                "$out/share/licenses/xcross/provision-dart.txt"
+
+              for executable in xcross xcrun; do
+                makeWrapper "$out/lib/xcross/bin/$executable" "$out/bin/$executable" \
+                  --prefix PATH : ${pkgs.lib.makeBinPath runtimePackages} \
+                  --set SWIFT_EXEC ${swiftCompiler} \
+                  --set SWIFT_EXEC_MANIFEST ${swiftCompiler} \
+                  --set CC ${swiftToolchain}/bin/clang \
+                  --set CXX ${swiftToolchain}/bin/clang++
+                cmp "$src/bin/$executable" "$out/lib/xcross/bin/$executable"
+              done
+              runHook postInstall
+            '';
+
+            meta = {
+              description = "Build, run, and hot-reload Flutter iOS apps from Linux";
+              homepage = "https://github.com/arxdeus/xcross";
+              license = pkgs.lib.licenses.mit;
+              mainProgram = "xcross";
+              platforms = systems;
+            };
+          };
+
+          userPackages = [ xcross ] ++ runtimePackages;
+
+          contributorPackages = userPackages ++ [
+            pkgs.cmake
+            pkgs.ninja
+            pkgs.git
+            pkgs.unzip
+            pkgs.xz
+          ];
+
+          shellHook = ''
+            export SWIFT_EXEC=${swiftCompiler}
+            export SWIFT_EXEC_MANIFEST=${swiftCompiler}
+            export CC=${swiftToolchain}/bin/clang
+            export CXX=${swiftToolchain}/bin/clang++
+          '';
+
+          smokeCheck = pkgs.runCommand "xcross-smoke-check" {
+            nativeBuildInputs = [ xcross ];
+          } ''
+            test -x ${xcross}/bin/xcross
+            test -x ${xcross}/bin/xcrun
+            test -d ${xcross}/lib/xcross/lib
+            cmp ${xcrossRelease}/bin/xcross ${xcross}/lib/xcross/bin/xcross
+            cmp ${xcrossRelease}/bin/xcrun ${xcross}/lib/xcross/bin/xcrun
+            touch "$out"
+          '';
+        in
+        {
+          inherit
+            pkgs
+            xcross
+            userPackages
+            contributorPackages
+            shellHook
+            smokeCheck
+            ;
+        };
+    in
+    {
+      packages = eachSystem (
+        system:
+        let
+          environment = environmentFor system;
+        in
+        {
+          inherit (environment) xcross;
+          default = environment.xcross;
+        }
+      );
+
+      apps = eachSystem (
+        system:
+        let
+          environment = environmentFor system;
+          app = {
+            type = "app";
+            program = "${environment.xcross}/bin/xcross";
+          };
+        in
+        {
+          xcross = app;
+          default = app;
+        }
+      );
+
+      devShells = eachSystem (
+        system:
+        let
+          environment = environmentFor system;
+        in
+        {
+          default = environment.pkgs.mkShell {
+            packages = environment.userPackages;
+            inherit (environment) shellHook;
+          };
+
+          contributor = environment.pkgs.mkShell {
+            packages = environment.contributorPackages;
+            inherit (environment) shellHook;
+          };
+        }
+      );
+
+      checks = eachSystem (system: {
+        smoke = (environmentFor system).smokeCheck;
+      });
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -98,8 +98,6 @@
             swiftToolchain
             pkgs.llvmPackages_21.llvm
             pkgs.llvmPackages_21.lld
-            pkgs.flutter
-            pkgs.jdk
             pkgs.git
             pkgs.python313
             pkgs.python313Packages.pymobiledevice3
@@ -110,38 +108,6 @@
             pkgs.gnupg
           ];
 
-          runtimeEnvironment = pkgs.writeText "xcross-nix-environment" ''
-            export XCROSS_DARWIN_BUNDLE="''${XCROSS_DARWIN_BUNDLE:-''${XDG_CONFIG_HOME:-$HOME/.config}/xcross/swift-sdks/xcross-darwin.artifactbundle}"
-            export KONAN_DATA_DIR="''${KONAN_DATA_DIR:-$HOME/.konan}"
-          '';
-
-          configTemplate = pkgs.writeText "xcross-nix-config.yaml" (builtins.toJSON {
-            roots = {
-              darwinSdk = "$XCROSS_DARWIN_BUNDLE";
-              flutterSdk = "${pkgs.flutter}";
-              xcross = "@out@/bin/xcross";
-              javaHome = "${pkgs.jdk.home}";
-              konanData = "$KONAN_DATA_DIR";
-            };
-            toolchains = {
-              swift = "${swiftToolchain}/bin";
-              llvm = [
-                "${swiftToolchain}/bin"
-                "${pkgs.llvmPackages_21.llvm}/bin"
-                "${pkgs.llvmPackages_21.lld}/bin"
-              ];
-            };
-            excluded_commands = [ "config" "setup" ];
-            environment = {
-              PATH = map (package: "${package}/bin") runtimePackages;
-              SWIFT_EXEC = "${swiftCompiler}";
-              SWIFT_EXEC_MANIFEST = "${swiftCompiler}";
-              CC = "${swiftToolchain}/bin/clang";
-              CXX = "${swiftToolchain}/bin/clang++";
-              FLUTTER_ROOT = "${pkgs.flutter}";
-            };
-          });
-
           xcross = pkgs.stdenvNoCC.mkDerivation {
             pname = "xcross";
             version = xcrossVersion;
@@ -149,23 +115,21 @@
 
             nativeBuildInputs = [ pkgs.makeWrapper ];
 
+            passthru = { inherit swiftToolchain swiftCompiler; };
+
             dontBuild = true;
             dontFixup = true;
 
             installPhase = ''
               runHook preInstall
-              mkdir -p "$out/bin" "$out/lib/xcross" "$out/share/licenses/xcross" "$out/share/xcross"
+              mkdir -p "$out/bin" "$out/lib/xcross" "$out/share/licenses/xcross"
               cp -r bin lib "$out/lib/xcross/"
-              substitute ${configTemplate} "$out/share/xcross/config.yaml" \
-                --replace-fail '@out@' "$out"
               install -m 0644 ${./LICENSE} "$out/share/licenses/xcross/LICENSE"
               install -m 0644 ${./packages/apple_developer_kit/ADI_LICENSE} \
                 "$out/share/licenses/xcross/provision-dart.txt"
 
               for executable in xcross xcrun; do
                 makeWrapper "$out/lib/xcross/bin/$executable" "$out/bin/$executable" \
-                  --run "source ${runtimeEnvironment}" \
-                  --set XCROSS_CONFIG "$out/share/xcross/config.yaml" \
                   --prefix PATH : ${pkgs.lib.makeBinPath runtimePackages} \
                   --set SWIFT_EXEC ${swiftCompiler} \
                   --set SWIFT_EXEC_MANIFEST ${swiftCompiler} \
@@ -196,10 +160,6 @@
           ];
 
           shellHook = ''
-            source ${runtimeEnvironment}
-            export XCROSS_CONFIG=${xcross}/share/xcross/config.yaml
-            export FLUTTER_ROOT=${pkgs.flutter}
-            export JAVA_HOME=${pkgs.jdk.home}
             export SWIFT_EXEC=${swiftCompiler}
             export SWIFT_EXEC_MANIFEST=${swiftCompiler}
             export CC=${swiftToolchain}/bin/clang

--- a/flake.nix
+++ b/flake.nix
@@ -129,8 +129,12 @@
                 "$out/share/licenses/xcross/provision-dart.txt"
 
               for executable in xcross xcrun; do
+                pathMode=--prefix
+                if [ "$executable" = xcrun ]; then
+                  pathMode=--suffix
+                fi
                 makeWrapper "$out/lib/xcross/bin/$executable" "$out/bin/$executable" \
-                  --prefix PATH : ${pkgs.lib.makeBinPath runtimePackages} \
+                  "$pathMode" PATH : ${pkgs.lib.makeBinPath runtimePackages} \
                   --set SWIFT_EXEC ${swiftCompiler} \
                   --set SWIFT_EXEC_MANIFEST ${swiftCompiler} \
                   --set CC ${swiftToolchain}/bin/clang \

--- a/flake.nix
+++ b/flake.nix
@@ -5,12 +5,12 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     xcross-linux-x64 = {
-      url = "https://github.com/arxdeus/xcross/releases/download/v1.3.2/xcross-linux-x64.tar.gz";
+      url = "https://github.com/arxdeus/xcross/releases/download/v1.4.0/xcross-linux-x64.tar.gz";
       flake = false;
     };
 
     xcross-linux-arm64 = {
-      url = "https://github.com/arxdeus/xcross/releases/download/v1.3.2/xcross-linux-arm64.tar.gz";
+      url = "https://github.com/arxdeus/xcross/releases/download/v1.4.0/xcross-linux-arm64.tar.gz";
       flake = false;
     };
   };
@@ -18,7 +18,7 @@
   outputs =
     inputs@{ nixpkgs, ... }:
     let
-      xcrossVersion = "1.3.2";
+      xcrossVersion = "1.4.0";
       swiftVersion = "6.3.3";
 
       systems = [
@@ -96,6 +96,11 @@
 
           runtimePackages = [
             swiftToolchain
+            pkgs.llvmPackages_21.llvm
+            pkgs.llvmPackages_21.lld
+            pkgs.flutter
+            pkgs.jdk
+            pkgs.git
             pkgs.python313
             pkgs.python313Packages.pymobiledevice3
             pkgs.usbmuxd
@@ -104,6 +109,38 @@
             pkgs.pkg-config
             pkgs.gnupg
           ];
+
+          runtimeEnvironment = pkgs.writeText "xcross-nix-environment" ''
+            export XCROSS_DARWIN_BUNDLE="''${XCROSS_DARWIN_BUNDLE:-''${XDG_CONFIG_HOME:-$HOME/.config}/xcross/swift-sdks/xcross-darwin.artifactbundle}"
+            export KONAN_DATA_DIR="''${KONAN_DATA_DIR:-$HOME/.konan}"
+          '';
+
+          configTemplate = pkgs.writeText "xcross-nix-config.yaml" (builtins.toJSON {
+            roots = {
+              darwinSdk = "$XCROSS_DARWIN_BUNDLE";
+              flutterSdk = "${pkgs.flutter}";
+              xcross = "@out@/bin/xcross";
+              javaHome = "${pkgs.jdk.home}";
+              konanData = "$KONAN_DATA_DIR";
+            };
+            toolchains = {
+              swift = "${swiftToolchain}/bin";
+              llvm = [
+                "${swiftToolchain}/bin"
+                "${pkgs.llvmPackages_21.llvm}/bin"
+                "${pkgs.llvmPackages_21.lld}/bin"
+              ];
+            };
+            excluded_commands = [ "config" "setup" ];
+            environment = {
+              PATH = map (package: "${package}/bin") runtimePackages;
+              SWIFT_EXEC = "${swiftCompiler}";
+              SWIFT_EXEC_MANIFEST = "${swiftCompiler}";
+              CC = "${swiftToolchain}/bin/clang";
+              CXX = "${swiftToolchain}/bin/clang++";
+              FLUTTER_ROOT = "${pkgs.flutter}";
+            };
+          });
 
           xcross = pkgs.stdenvNoCC.mkDerivation {
             pname = "xcross";
@@ -117,14 +154,18 @@
 
             installPhase = ''
               runHook preInstall
-              mkdir -p "$out/bin" "$out/lib/xcross" "$out/share/licenses/xcross"
+              mkdir -p "$out/bin" "$out/lib/xcross" "$out/share/licenses/xcross" "$out/share/xcross"
               cp -r bin lib "$out/lib/xcross/"
+              substitute ${configTemplate} "$out/share/xcross/config.yaml" \
+                --replace-fail '@out@' "$out"
               install -m 0644 ${./LICENSE} "$out/share/licenses/xcross/LICENSE"
               install -m 0644 ${./packages/apple_developer_kit/ADI_LICENSE} \
                 "$out/share/licenses/xcross/provision-dart.txt"
 
               for executable in xcross xcrun; do
                 makeWrapper "$out/lib/xcross/bin/$executable" "$out/bin/$executable" \
+                  --run "source ${runtimeEnvironment}" \
+                  --set XCROSS_CONFIG "$out/share/xcross/config.yaml" \
                   --prefix PATH : ${pkgs.lib.makeBinPath runtimePackages} \
                   --set SWIFT_EXEC ${swiftCompiler} \
                   --set SWIFT_EXEC_MANIFEST ${swiftCompiler} \
@@ -155,6 +196,10 @@
           ];
 
           shellHook = ''
+            source ${runtimeEnvironment}
+            export XCROSS_CONFIG=${xcross}/share/xcross/config.yaml
+            export FLUTTER_ROOT=${pkgs.flutter}
+            export JAVA_HOME=${pkgs.jdk.home}
             export SWIFT_EXEC=${swiftCompiler}
             export SWIFT_EXEC_MANIFEST=${swiftCompiler}
             export CC=${swiftToolchain}/bin/clang

--- a/packages/xcross/lib/src/flutter/build/internal/apple_tool_shims.dart
+++ b/packages/xcross/lib/src/flutter/build/internal/apple_tool_shims.dart
@@ -322,6 +322,8 @@ Future<void> _installUnixToolShims(
   );
   await _writeUnixShim(directory, 'clang', compilerScript);
   await _writeUnixShim(directory, 'cc', compilerScript);
+  await _writeUnixShim(directory, 'ar', renderUnixToolShim(config.archiver));
+  await _writeUnixShim(directory, 'ld', renderUnixToolShim(config.linker));
   await _writeUnixShim(directory, 'xcrun', renderUnixToolShim(config.xcrun));
   if (toolForwarderExecutable != null) {
     await _writeUnixShim(

--- a/packages/xcross/test/flutter/build/ios_native_assets_test.dart
+++ b/packages/xcross/test/flutter/build/ios_native_assets_test.dart
@@ -407,6 +407,89 @@ void main() {
     }
   });
 
+  test(
+    'Unix hook tools keep Apple targets and the selected Mach-O linker',
+    () async {
+      if (Platform.isWindows) return;
+      final tmp = await Directory.systemTemp.createTemp('apple hook tools-');
+      try {
+        final toolchain = Directory(p.join(tmp.path, 'toolchain'))
+          ..createSync();
+        for (final name in ['clang', 'llvm-ar', 'ld64.lld']) {
+          final tool = File(p.join(toolchain.path, name))
+            ..writeAsStringSync('#!/bin/sh\nprintf \'%s\\n\' "$name" "\$@"\n');
+          final chmod = await Process.run('chmod', ['+x', tool.path]);
+          expect(chmod.exitCode, 0);
+        }
+        final shims = p.join(tmp.path, 'shims');
+        final linker = p.join(toolchain.path, 'ld64.lld');
+        await installAppleToolShims(
+          shims,
+          AppleToolShimConfig(
+            iosSdk: '/sdk/iPhoneOS.sdk',
+            clang: p.join(toolchain.path, 'clang'),
+            hostCompiler: '/bin/echo',
+            archiver: p.join(toolchain.path, 'llvm-ar'),
+            linker: linker,
+            deploymentTarget: '15.0',
+            lipo: '/bin/echo',
+            otool: null,
+            installNameTool: null,
+            xcrun: '/bin/echo',
+          ),
+        );
+
+        for (final arguments in [
+          [
+            '-shared',
+            '-target',
+            'arm64-apple-ios',
+            '-mios-version-min=13',
+            'asset.o',
+          ],
+          [
+            '-arch',
+            'arm64',
+            '-dynamiclib',
+            '-miphoneos-version-min=15.0',
+            'debug_app.cc',
+          ],
+        ]) {
+          final result = await Process.run(
+            p.join(shims, 'clang'),
+            arguments,
+            environment: const {},
+            includeParentEnvironment: false,
+          );
+          expect(result.exitCode, 0);
+          final forwarded = const LineSplitter().convert(
+            result.stdout as String,
+          );
+          expect(forwarded.first, 'clang');
+          expect(forwarded, contains('--ld-path=$linker'));
+          expect(forwarded, contains('-fuse-ld=lld'));
+          expect(forwarded, containsAllInOrder(arguments));
+          if (!arguments.contains('-target')) {
+            expect(forwarded, contains('--target=arm64-apple-ios15.0'));
+          }
+        }
+
+        for (final entry in {'ar': 'llvm-ar', 'ld': 'ld64.lld'}.entries) {
+          final result = await Process.run(
+            p.join(shims, entry.key),
+            ['--version'],
+            environment: const {},
+            includeParentEnvironment: false,
+          );
+          expect(result.exitCode, 0);
+          expect(result.stdout, '${entry.value}\n--version\n');
+        }
+      } finally {
+        await tmp.delete(recursive: true);
+      }
+    },
+  );
+
   test('Apple tool shims expose configured tools including xcrun', () async {
     if (Platform.isWindows) return;
     final tmp = await Directory.systemTemp.createTemp('apple_shims_test-');


### PR DESCRIPTION
## Summary

- package hash-pinned x86_64-linux and aarch64-linux v1.3.2 release archives without modifying their binaries
- expose `xcross` and `xcrun` through PATH wrappers with the required Flutter, Swift, LLVM, pymobiledevice3, and device tools
- provide separate end-user and `.#contributor` shells
- add dedicated native x64/ARM64 Nix CI and concise downstream flake usage documentation

## Validation

- `nix flake check` passed on x86_64-linux and aarch64-linux, including byte-for-byte release binary checks
- `nix build .#xcross`, `nix run`, `xcross`, and `xcrun` runtime assertions passed outside the Nix build sandbox on both native Ubuntu architectures
- end-user dependency probes passed on both architectures
- Dart analysis and all six workspace test suites passed through `nix develop .#contributor` on both architectures
- local `git diff --check` passed

Closes #55