### PR TITLE
feat(cli): add doctor command

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -266,6 +266,17 @@ jobs:
             "$env:RUNNER_TEMP\xcross-bundle"
           & "$env:RUNNER_TEMP\xcross-bundle\bin\xcross.exe" setup
 
+      - name: Test doctor on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Push-Location packages/xcross
+          dart test test/cli/doctor_command_test.dart
+          Pop-Location
+          & "$env:RUNNER_TEMP\xcross-bundle\bin\xcross.exe" doctor --help
+          if ($LASTEXITCODE -ne 0) { throw 'doctor help failed' }
+
       - name: Restore cached Darwin SDK
         uses: ./.github/actions/setup-darwin-sdk
 

--- a/README.md
+++ b/README.md
@@ -223,15 +223,18 @@ xcross setup
 xcross sdk install ~/Downloads/Xcode.xip
 xcross auth --apple-id you@example.com
 
-# 2. Once per device reconnect: mount DDI + start the RSD tunnel
+# 2. Check build and run requirements without changing anything
+cd my_flutter_app
+xcross doctor
+
+# 3. Once per device reconnect: mount DDI + start the RSD tunnel
 #    (Administrator PowerShell on Windows; root on Linux)
 xcross tunnel
 
-# 3. Build, sign, install, launch, hot-reload
-cd my_flutter_app
+# 4. Build, sign, install, launch, hot-reload
 xcross flutter run
 
-# 4. Optional: wire up your IDE
+# 5. Optional: wire up your IDE
 xcross ide vscode      # or: xcross ide idea
 ```
 
@@ -244,6 +247,8 @@ While the app is running:
 | `q` / `Ctrl-C` / `Ctrl-D` | Quit |
 
 With multiple iPhones connected, an interactive terminal shows a numbered device picker; pass `-u <UDID>` for CI or piped runs.
+
+`xcross doctor` is read-only: it checks Linux or Windows host tools, the Darwin SDK, the current Flutter or Compose project, authentication, device tooling, and connected iOS versions without building, installing, or launching. Missing project or device context is a warning; failed requirements return a nonzero exit code.
 
 ## Run over Wi-Fi
 
@@ -286,6 +291,7 @@ See the full [Wi-Fi setup and troubleshooting guide](https://xcross.sh/docs/wire
 | `xcross sdk install <Xcode.xip>` | Extract a private Darwin Swift SDK from an Xcode archive, patched against the Swift toolchain currently on `PATH` |
 | `xcross auth` | Save Apple ID or App Store Connect credentials |
 | `xcross auth clear` | Delete saved credentials, sessions, and signing material |
+| `xcross doctor` | Read-only check of host, SDK, project, authentication, and device requirements for build and run |
 | `xcross tunnel` | Mount the Developer Disk Image + start the iOS 17+ RSD tunnel over USB |
 | `xcross tunnel --wifi` | Prepare wireless pairing, reconnect or advertise pair-host, mount DDI, and open the Wi-Fi RSD tunnel |
 | `xcross flutter run` | Build → sign → install → launch → hot reload |

--- a/packages/xcross/lib/src/cli/basic/doctor_command.dart
+++ b/packages/xcross/lib/src/cli/basic/doctor_command.dart
@@ -1,57 +1,15 @@
-import 'dart:io';
-
-import 'package:apple_developer_kit/apple_developer_kit.dart';
 import 'package:args/command_runner.dart';
 import 'package:cli_kit/cli_kit.dart';
 import 'package:cli_util/cli_logging.dart';
-import 'package:dart_mobile_device/dart_mobile_device.dart';
-import 'package:darwin_sdk_kit/darwin_sdk_kit.dart';
-import 'package:path/path.dart' as p;
-import 'package:xcross/src/cli/basic/sdk_install.dart';
-import 'package:xcross/src/compose/project/kmp_project.dart';
-import 'package:xcross/src/compose/toolchain/compose_host.dart';
-import 'package:xcross/src/compose/toolchain/compose_toolchain_resolver.dart';
+import 'package:xcross/src/cli/basic/doctor_examiner.dart';
+import 'package:xcross/src/cli/basic/doctor_models.dart';
 import 'package:xcross/src/errors.dart';
-import 'package:xcross/src/flutter/build/flutter_packer.dart';
-import 'package:xcross/src/flutter/models/pubspec_info.dart';
-import 'package:xcross/src/package_config_resolver.dart';
 
-enum DoctorStatus { success, warning, failure }
-
-final class DoctorCheck {
-  const DoctorCheck(this.status, this.name, this.message, {this.path});
-
-  const DoctorCheck.success(this.name, this.message, {this.path})
-    : status = DoctorStatus.success;
-  const DoctorCheck.warning(this.name, this.message, {this.path})
-    : status = DoctorStatus.warning;
-  const DoctorCheck.failure(this.name, this.message, {this.path})
-    : status = DoctorStatus.failure;
-
-  final DoctorStatus status;
-  final String name;
-  final String message;
-  final String? path;
-}
-
-enum DoctorProjectKind { flutter, compose }
-
-final class DoctorProject {
-  const DoctorProject(this.kind, this.root);
-
-  const DoctorProject.flutter(this.root) : kind = DoctorProjectKind.flutter;
-  const DoctorProject.compose(this.root) : kind = DoctorProjectKind.compose;
-
-  final DoctorProjectKind kind;
-  final String root;
-}
+export 'package:xcross/src/cli/basic/doctor_examiner.dart';
+export 'package:xcross/src/cli/basic/doctor_models.dart';
 
 typedef DoctorExamine = Future<List<DoctorCheck>> Function();
 typedef DoctorWriteLine = void Function(String line);
-typedef DoctorChecks = Future<List<DoctorCheck>> Function();
-typedef DoctorDetectProject = Future<DoctorProject?> Function();
-typedef DoctorProjectChecks =
-    Future<List<DoctorCheck>> Function(DoctorProject project);
 
 final class DoctorCommand extends Command<void> {
   DoctorCommand()
@@ -82,23 +40,23 @@ final class DoctorCommand extends Command<void> {
     for (final check in checks) {
       _writeLine(formatCheck(check, ansi: Log.ansi));
     }
-    final failures = checks
-        .where((check) => check.status == DoctorStatus.failure)
-        .length;
-    final warnings = checks
-        .where((check) => check.status == DoctorStatus.warning)
-        .length;
+
+    final failures = _count(checks, DoctorStatus.failure);
     if (failures > 0) {
-      throw XcrossError(
-        'Doctor found $failures ${failures == 1 ? 'failure' : 'failures'}.',
-      );
+      throw XcrossError(_summary(failures, 'failure'));
     }
+
+    final warnings = _count(checks, DoctorStatus.warning);
     _writeLine(
-      warnings == 0
-          ? 'No issues found.'
-          : 'Doctor found $warnings ${warnings == 1 ? 'warning' : 'warnings'}.',
+      warnings == 0 ? 'No issues found.' : _summary(warnings, 'warning'),
     );
   }
+
+  static int _count(List<DoctorCheck> checks, DoctorStatus status) =>
+      checks.where((check) => check.status == status).length;
+
+  static String _summary(int count, String issue) =>
+      'Doctor found $count $issue${count == 1 ? '' : 's'}.';
 
   static String formatCheck(
     DoctorCheck check, {
@@ -110,309 +68,10 @@ final class DoctorCommand extends Command<void> {
       DoctorStatus.warning => ('!', ansi.yellow),
       DoctorStatus.failure => ('✗', ansi.red),
     };
-    final status = '$color[$marker]${ansi.none}';
-    final line = '$status ${check.name}: ${check.message}';
-    final path = check.path;
-    if (path == null) return line;
-    final dimPath = (dim ?? Log.dim)(path);
-    return '$line\n    $dimPath';
-  }
-}
-
-final class DoctorExaminer {
-  const DoctorExaminer()
-    : _hostChecks = _defaultHostChecks,
-      _detectProject = _defaultDetectProject,
-      _projectChecks = _defaultProjectChecks,
-      _runChecks = _defaultRunChecks;
-
-  const DoctorExaminer.withSeams({
-    required DoctorChecks hostChecks,
-    required DoctorDetectProject detectProject,
-    required DoctorProjectChecks projectChecks,
-    required DoctorChecks runChecks,
-  }) : _hostChecks = hostChecks,
-       _detectProject = detectProject,
-       _projectChecks = projectChecks,
-       _runChecks = runChecks;
-
-  final DoctorChecks _hostChecks;
-  final DoctorDetectProject _detectProject;
-  final DoctorProjectChecks _projectChecks;
-  final DoctorChecks _runChecks;
-
-  Future<List<DoctorCheck>> examine() async {
-    final checks = [...await _hostChecks()];
-    final project = await _detectProject();
-    if (project == null) {
-      checks.add(
-        const DoctorCheck.warning(
-          'Project',
-          'No Flutter or Compose project found in the current directory.',
-        ),
-      );
-    } else {
-      checks.addAll(await _projectChecks(project));
+    final line = '$color[$marker]${ansi.none} ${check.name}: ${check.message}';
+    if (check.path case final path?) {
+      return '$line\n    ${(dim ?? Log.dim)(path)}';
     }
-    checks.addAll(await _runChecks());
-    return checks;
-  }
-
-  static Future<List<DoctorCheck>> _defaultHostChecks() async {
-    final checks = <DoctorCheck>[];
-    final supported =
-        Platform.isLinux || Platform.isMacOS || Platform.isWindows;
-    checks.add(
-      supported
-          ? DoctorCheck.success(
-              'Host',
-              '${Platform.operatingSystem} is supported.',
-            )
-          : DoctorCheck.failure(
-              'Host',
-              '${Platform.operatingSystem} is not supported.',
-            ),
-    );
-    for (final tool in const [
-      'swift',
-      'clang',
-      'clang++',
-      'llvm-ar',
-      'ld64.lld',
-    ]) {
-      final path = await ProcessRunner.which(
-        tool,
-        accept: tool == 'ld64.lld' ? DarwinSdk.usableLd64Lld : null,
-        extraDirectories: DarwinSdk.llvmToolDirs(),
-      );
-      checks.add(
-        path == null
-            ? DoctorCheck.failure(
-                tool,
-                'Not found. Run `xcross setup` after installing Swift.',
-              )
-            : DoctorCheck.success(tool, 'Found', path: path),
-      );
-    }
-    final sdkPath = DarwinSdk.nativeInstallDir();
-    if (!DarwinSdk.isValidBundle(sdkPath)) {
-      checks.add(
-        const DoctorCheck.failure(
-          'Darwin SDK',
-          'Missing or incomplete. Run `xcross sdk install <Xcode.xip>`.',
-        ),
-      );
-    } else {
-      final mismatch = await SdkInstall.hostToolchainMismatch(sdkPath);
-      checks.add(
-        mismatch == null
-            ? DoctorCheck.success('Darwin SDK', 'Installed', path: sdkPath)
-            : DoctorCheck.failure(
-                'Darwin SDK',
-                '$mismatch Reinstall it with `xcross sdk install <Xcode.xip>`.',
-              ),
-      );
-    }
-    return checks;
-  }
-
-  static Future<DoctorProject?> _defaultDetectProject() async =>
-      detectProjectAt(Directory.current.path);
-
-  static DoctorProject? detectProjectAt(String root) {
-    if (File(p.join(root, 'pubspec.yaml')).existsSync()) {
-      return DoctorProject.flutter(root);
-    }
-    if (File(p.join(root, 'settings.gradle.kts')).existsSync() ||
-        File(p.join(root, 'settings.gradle')).existsSync()) {
-      return DoctorProject.compose(root);
-    }
-    return null;
-  }
-
-  static Future<List<DoctorCheck>> _defaultProjectChecks(
-    DoctorProject project,
-  ) => switch (project.kind) {
-    DoctorProjectKind.flutter => _flutterChecks(project.root),
-    DoctorProjectKind.compose => _composeChecks(project.root),
-  };
-
-  static Future<List<DoctorCheck>> _flutterChecks(String root) async {
-    final checks = <DoctorCheck>[];
-    try {
-      final pubspec = PubspecInfo.loadSync(root);
-      checks.add(DoctorCheck.success('Flutter project', pubspec.name));
-    } on Object catch (error) {
-      return [DoctorCheck.failure('Flutter project', '$error')];
-    }
-    final entrypoint = File(p.join(root, 'lib', 'main.dart'));
-    checks.add(
-      entrypoint.existsSync()
-          ? DoctorCheck.success(
-              'Flutter entrypoint',
-              'Found',
-              path: entrypoint.path,
-            )
-          : const DoctorCheck.failure(
-              'Flutter entrypoint',
-              'lib/main.dart does not exist.',
-            ),
-    );
-    try {
-      final flutterRoot = await FlutterPacker.resolveFlutterRoot(
-        projectRoot: root,
-      );
-      checks.add(
-        DoctorCheck.success('Flutter SDK', 'Found', path: flutterRoot),
-      );
-    } on Object catch (error) {
-      checks.add(DoctorCheck.failure('Flutter SDK', '$error'));
-    }
-    final packageConfig = await PackageConfigResolver.find(root);
-    checks.add(
-      packageConfig == null
-          ? const DoctorCheck.warning(
-              'Flutter packages',
-              'No package_config.json; `flutter pub get` will be required.',
-            )
-          : DoctorCheck.success(
-              'Flutter packages',
-              'Resolved',
-              path: packageConfig,
-            ),
-    );
-    return checks;
-  }
-
-  static Future<List<DoctorCheck>> _composeChecks(String root) async {
-    try {
-      final project = KmpProject.detect(root);
-      final checks = <DoctorCheck>[
-        DoctorCheck.success('Compose project', project.moduleName),
-      ];
-      ComposeHost host;
-      try {
-        host = ComposeHost.current();
-      } on XcrossError catch (error) {
-        checks.add(DoctorCheck.failure('Compose host', error.message));
-        return checks;
-      }
-      final problems = await ComposeToolchainResolver.problems(
-        host: host,
-        environment: Platform.environment,
-        projectRoot: root,
-      );
-      checks.add(
-        problems.isEmpty
-            ? const DoctorCheck.success('Compose toolchain', 'Ready.')
-            : DoctorCheck.failure('Compose toolchain', problems.join(' ')),
-      );
-      return checks;
-    } on Object catch (error) {
-      return [DoctorCheck.failure('Compose project', '$error')];
-    }
-  }
-
-  static Future<List<DoctorCheck>> _defaultRunChecks() async {
-    final checks = <DoctorCheck>[];
-    try {
-      final invocation = await Pymd.resolve();
-      checks.add(
-        DoctorCheck.success(
-          'Device tools',
-          'Found',
-          path: invocation.executable,
-        ),
-      );
-    } on Object catch (error) {
-      checks.add(DoctorCheck.failure('Device tools', '$error'));
-      return checks;
-    }
-    checks.add(await _authCheck());
-    try {
-      final devices = await PymdDevices.devices();
-      checks.addAll(await deviceChecks(devices));
-    } on Object catch (error) {
-      checks.add(DoctorCheck.warning('Device', 'Discovery failed: $error'));
-    }
-    return checks;
-  }
-
-  static Future<List<DoctorCheck>> deviceChecks(
-    List<Device> devices, {
-    Future<int?> Function(Device device)? osMajorVersion,
-  }) async {
-    if (devices.isEmpty) {
-      return const [
-        DoctorCheck.warning('Device', 'No connected iOS device found.'),
-      ];
-    }
-    final resolveVersion =
-        osMajorVersion ??
-        (device) => OsVersion.deviceOSMajorVersion(
-          device.udid,
-          overTunnel: device.source == DeviceSource.tunneld,
-        );
-    final checks = <DoctorCheck>[];
-    for (final device in devices) {
-      final label = '${device.name} (${device.udid})';
-      final major = await resolveVersion(device);
-      checks.add(
-        major == null
-            ? DoctorCheck.warning(
-                'Device',
-                '$label: could not read the iOS version.',
-              )
-            : major < 17
-            ? DoctorCheck.failure(
-                'Device',
-                '$label runs iOS $major; iOS 17 or later is required.',
-              )
-            : DoctorCheck.success('Device', '$label runs iOS $major.'),
-      );
-    }
-    return checks;
-  }
-
-  static Future<DoctorCheck> _authCheck() async {
-    try {
-      final session = await GrandSlamSessionStore().load();
-      if (session != null && !session.isExpired) {
-        return const DoctorCheck.success(
-          'Authentication',
-          'Apple ID session is available.',
-        );
-      }
-    } on Object catch (error) {
-      return DoctorCheck.failure(
-        'Authentication',
-        'Apple ID session is unusable: $error',
-      );
-    }
-    final path = AscCredentials.defaultConfigPath();
-    if (File(path).existsSync()) {
-      try {
-        final credentials = await AscCredentials.fromFile(path);
-        final client = AscClient(credentials);
-        try {
-          await client.listDevices();
-        } finally {
-          client.close();
-        }
-        return const DoctorCheck.success(
-          'Authentication',
-          'App Store Connect credentials are valid.',
-        );
-      } on Object catch (error) {
-        return DoctorCheck.failure(
-          'Authentication',
-          'App Store Connect credentials are unusable: $error',
-        );
-      }
-    }
-    return const DoctorCheck.failure(
-      'Authentication',
-      'No credentials found. Run `xcross auth`.',
-    );
+    return line;
   }
 }

--- a/packages/xcross/lib/src/cli/basic/doctor_command.dart
+++ b/packages/xcross/lib/src/cli/basic/doctor_command.dart
@@ -1,0 +1,418 @@
+import 'dart:io';
+
+import 'package:apple_developer_kit/apple_developer_kit.dart';
+import 'package:args/command_runner.dart';
+import 'package:cli_kit/cli_kit.dart';
+import 'package:cli_util/cli_logging.dart';
+import 'package:dart_mobile_device/dart_mobile_device.dart';
+import 'package:darwin_sdk_kit/darwin_sdk_kit.dart';
+import 'package:path/path.dart' as p;
+import 'package:xcross/src/cli/basic/sdk_install.dart';
+import 'package:xcross/src/compose/project/kmp_project.dart';
+import 'package:xcross/src/compose/toolchain/compose_host.dart';
+import 'package:xcross/src/compose/toolchain/compose_toolchain_resolver.dart';
+import 'package:xcross/src/errors.dart';
+import 'package:xcross/src/flutter/build/flutter_packer.dart';
+import 'package:xcross/src/flutter/models/pubspec_info.dart';
+import 'package:xcross/src/package_config_resolver.dart';
+
+enum DoctorStatus { success, warning, failure }
+
+final class DoctorCheck {
+  const DoctorCheck(this.status, this.name, this.message, {this.path});
+
+  const DoctorCheck.success(this.name, this.message, {this.path})
+    : status = DoctorStatus.success;
+  const DoctorCheck.warning(this.name, this.message, {this.path})
+    : status = DoctorStatus.warning;
+  const DoctorCheck.failure(this.name, this.message, {this.path})
+    : status = DoctorStatus.failure;
+
+  final DoctorStatus status;
+  final String name;
+  final String message;
+  final String? path;
+}
+
+enum DoctorProjectKind { flutter, compose }
+
+final class DoctorProject {
+  const DoctorProject(this.kind, this.root);
+
+  const DoctorProject.flutter(this.root) : kind = DoctorProjectKind.flutter;
+  const DoctorProject.compose(this.root) : kind = DoctorProjectKind.compose;
+
+  final DoctorProjectKind kind;
+  final String root;
+}
+
+typedef DoctorExamine = Future<List<DoctorCheck>> Function();
+typedef DoctorWriteLine = void Function(String line);
+typedef DoctorChecks = Future<List<DoctorCheck>> Function();
+typedef DoctorDetectProject = Future<DoctorProject?> Function();
+typedef DoctorProjectChecks =
+    Future<List<DoctorCheck>> Function(DoctorProject project);
+
+final class DoctorCommand extends Command<void> {
+  DoctorCommand()
+    : this.withSeams(
+        examine: const DoctorExaminer().examine,
+        writeLine: Log.logStatus,
+      );
+
+  DoctorCommand.withSeams({
+    required DoctorExamine examine,
+    required DoctorWriteLine writeLine,
+  }) : _examine = examine,
+       _writeLine = writeLine;
+
+  final DoctorExamine _examine;
+  final DoctorWriteLine _writeLine;
+
+  @override
+  String get name => 'doctor';
+
+  @override
+  String get description =>
+      'Check build and run requirements without building or running.';
+
+  @override
+  Future<void> run() async {
+    final checks = await _examine();
+    for (final check in checks) {
+      _writeLine(formatCheck(check, ansi: Log.ansi));
+    }
+    final failures = checks
+        .where((check) => check.status == DoctorStatus.failure)
+        .length;
+    final warnings = checks
+        .where((check) => check.status == DoctorStatus.warning)
+        .length;
+    if (failures > 0) {
+      throw XcrossError(
+        'Doctor found $failures ${failures == 1 ? 'failure' : 'failures'}.',
+      );
+    }
+    _writeLine(
+      warnings == 0
+          ? 'No issues found.'
+          : 'Doctor found $warnings ${warnings == 1 ? 'warning' : 'warnings'}.',
+    );
+  }
+
+  static String formatCheck(
+    DoctorCheck check, {
+    required Ansi ansi,
+    String Function(String value)? dim,
+  }) {
+    final (marker, color) = switch (check.status) {
+      DoctorStatus.success => ('✓', ansi.green),
+      DoctorStatus.warning => ('!', ansi.yellow),
+      DoctorStatus.failure => ('✗', ansi.red),
+    };
+    final status = '$color[$marker]${ansi.none}';
+    final line = '$status ${check.name}: ${check.message}';
+    final path = check.path;
+    if (path == null) return line;
+    final dimPath = (dim ?? Log.dim)(path);
+    return '$line\n    $dimPath';
+  }
+}
+
+final class DoctorExaminer {
+  const DoctorExaminer()
+    : _hostChecks = _defaultHostChecks,
+      _detectProject = _defaultDetectProject,
+      _projectChecks = _defaultProjectChecks,
+      _runChecks = _defaultRunChecks;
+
+  const DoctorExaminer.withSeams({
+    required DoctorChecks hostChecks,
+    required DoctorDetectProject detectProject,
+    required DoctorProjectChecks projectChecks,
+    required DoctorChecks runChecks,
+  }) : _hostChecks = hostChecks,
+       _detectProject = detectProject,
+       _projectChecks = projectChecks,
+       _runChecks = runChecks;
+
+  final DoctorChecks _hostChecks;
+  final DoctorDetectProject _detectProject;
+  final DoctorProjectChecks _projectChecks;
+  final DoctorChecks _runChecks;
+
+  Future<List<DoctorCheck>> examine() async {
+    final checks = [...await _hostChecks()];
+    final project = await _detectProject();
+    if (project == null) {
+      checks.add(
+        const DoctorCheck.warning(
+          'Project',
+          'No Flutter or Compose project found in the current directory.',
+        ),
+      );
+    } else {
+      checks.addAll(await _projectChecks(project));
+    }
+    checks.addAll(await _runChecks());
+    return checks;
+  }
+
+  static Future<List<DoctorCheck>> _defaultHostChecks() async {
+    final checks = <DoctorCheck>[];
+    final supported =
+        Platform.isLinux || Platform.isMacOS || Platform.isWindows;
+    checks.add(
+      supported
+          ? DoctorCheck.success(
+              'Host',
+              '${Platform.operatingSystem} is supported.',
+            )
+          : DoctorCheck.failure(
+              'Host',
+              '${Platform.operatingSystem} is not supported.',
+            ),
+    );
+    for (final tool in const [
+      'swift',
+      'clang',
+      'clang++',
+      'llvm-ar',
+      'ld64.lld',
+    ]) {
+      final path = await ProcessRunner.which(
+        tool,
+        accept: tool == 'ld64.lld' ? DarwinSdk.usableLd64Lld : null,
+        extraDirectories: DarwinSdk.llvmToolDirs(),
+      );
+      checks.add(
+        path == null
+            ? DoctorCheck.failure(
+                tool,
+                'Not found. Run `xcross setup` after installing Swift.',
+              )
+            : DoctorCheck.success(tool, 'Found', path: path),
+      );
+    }
+    final sdkPath = DarwinSdk.nativeInstallDir();
+    if (!DarwinSdk.isValidBundle(sdkPath)) {
+      checks.add(
+        const DoctorCheck.failure(
+          'Darwin SDK',
+          'Missing or incomplete. Run `xcross sdk install <Xcode.xip>`.',
+        ),
+      );
+    } else {
+      final mismatch = await SdkInstall.hostToolchainMismatch(sdkPath);
+      checks.add(
+        mismatch == null
+            ? DoctorCheck.success('Darwin SDK', 'Installed', path: sdkPath)
+            : DoctorCheck.failure(
+                'Darwin SDK',
+                '$mismatch Reinstall it with `xcross sdk install <Xcode.xip>`.',
+              ),
+      );
+    }
+    return checks;
+  }
+
+  static Future<DoctorProject?> _defaultDetectProject() async =>
+      detectProjectAt(Directory.current.path);
+
+  static DoctorProject? detectProjectAt(String root) {
+    if (File(p.join(root, 'pubspec.yaml')).existsSync()) {
+      return DoctorProject.flutter(root);
+    }
+    if (File(p.join(root, 'settings.gradle.kts')).existsSync() ||
+        File(p.join(root, 'settings.gradle')).existsSync()) {
+      return DoctorProject.compose(root);
+    }
+    return null;
+  }
+
+  static Future<List<DoctorCheck>> _defaultProjectChecks(
+    DoctorProject project,
+  ) => switch (project.kind) {
+    DoctorProjectKind.flutter => _flutterChecks(project.root),
+    DoctorProjectKind.compose => _composeChecks(project.root),
+  };
+
+  static Future<List<DoctorCheck>> _flutterChecks(String root) async {
+    final checks = <DoctorCheck>[];
+    try {
+      final pubspec = PubspecInfo.loadSync(root);
+      checks.add(DoctorCheck.success('Flutter project', pubspec.name));
+    } on Object catch (error) {
+      return [DoctorCheck.failure('Flutter project', '$error')];
+    }
+    final entrypoint = File(p.join(root, 'lib', 'main.dart'));
+    checks.add(
+      entrypoint.existsSync()
+          ? DoctorCheck.success(
+              'Flutter entrypoint',
+              'Found',
+              path: entrypoint.path,
+            )
+          : const DoctorCheck.failure(
+              'Flutter entrypoint',
+              'lib/main.dart does not exist.',
+            ),
+    );
+    try {
+      final flutterRoot = await FlutterPacker.resolveFlutterRoot(
+        projectRoot: root,
+      );
+      checks.add(
+        DoctorCheck.success('Flutter SDK', 'Found', path: flutterRoot),
+      );
+    } on Object catch (error) {
+      checks.add(DoctorCheck.failure('Flutter SDK', '$error'));
+    }
+    final packageConfig = await PackageConfigResolver.find(root);
+    checks.add(
+      packageConfig == null
+          ? const DoctorCheck.warning(
+              'Flutter packages',
+              'No package_config.json; `flutter pub get` will be required.',
+            )
+          : DoctorCheck.success(
+              'Flutter packages',
+              'Resolved',
+              path: packageConfig,
+            ),
+    );
+    return checks;
+  }
+
+  static Future<List<DoctorCheck>> _composeChecks(String root) async {
+    try {
+      final project = KmpProject.detect(root);
+      final checks = <DoctorCheck>[
+        DoctorCheck.success('Compose project', project.moduleName),
+      ];
+      ComposeHost host;
+      try {
+        host = ComposeHost.current();
+      } on XcrossError catch (error) {
+        checks.add(DoctorCheck.failure('Compose host', error.message));
+        return checks;
+      }
+      final problems = await ComposeToolchainResolver.problems(
+        host: host,
+        environment: Platform.environment,
+        projectRoot: root,
+      );
+      checks.add(
+        problems.isEmpty
+            ? const DoctorCheck.success('Compose toolchain', 'Ready.')
+            : DoctorCheck.failure('Compose toolchain', problems.join(' ')),
+      );
+      return checks;
+    } on Object catch (error) {
+      return [DoctorCheck.failure('Compose project', '$error')];
+    }
+  }
+
+  static Future<List<DoctorCheck>> _defaultRunChecks() async {
+    final checks = <DoctorCheck>[];
+    try {
+      final invocation = await Pymd.resolve();
+      checks.add(
+        DoctorCheck.success(
+          'Device tools',
+          'Found',
+          path: invocation.executable,
+        ),
+      );
+    } on Object catch (error) {
+      checks.add(DoctorCheck.failure('Device tools', '$error'));
+      return checks;
+    }
+    checks.add(await _authCheck());
+    try {
+      final devices = await PymdDevices.devices();
+      checks.addAll(await deviceChecks(devices));
+    } on Object catch (error) {
+      checks.add(DoctorCheck.warning('Device', 'Discovery failed: $error'));
+    }
+    return checks;
+  }
+
+  static Future<List<DoctorCheck>> deviceChecks(
+    List<Device> devices, {
+    Future<int?> Function(Device device)? osMajorVersion,
+  }) async {
+    if (devices.isEmpty) {
+      return const [
+        DoctorCheck.warning('Device', 'No connected iOS device found.'),
+      ];
+    }
+    final resolveVersion =
+        osMajorVersion ??
+        (device) => OsVersion.deviceOSMajorVersion(
+          device.udid,
+          overTunnel: device.source == DeviceSource.tunneld,
+        );
+    final checks = <DoctorCheck>[];
+    for (final device in devices) {
+      final label = '${device.name} (${device.udid})';
+      final major = await resolveVersion(device);
+      checks.add(
+        major == null
+            ? DoctorCheck.warning(
+                'Device',
+                '$label: could not read the iOS version.',
+              )
+            : major < 17
+            ? DoctorCheck.failure(
+                'Device',
+                '$label runs iOS $major; iOS 17 or later is required.',
+              )
+            : DoctorCheck.success('Device', '$label runs iOS $major.'),
+      );
+    }
+    return checks;
+  }
+
+  static Future<DoctorCheck> _authCheck() async {
+    try {
+      final session = await GrandSlamSessionStore().load();
+      if (session != null && !session.isExpired) {
+        return const DoctorCheck.success(
+          'Authentication',
+          'Apple ID session is available.',
+        );
+      }
+    } on Object catch (error) {
+      return DoctorCheck.failure(
+        'Authentication',
+        'Apple ID session is unusable: $error',
+      );
+    }
+    final path = AscCredentials.defaultConfigPath();
+    if (File(path).existsSync()) {
+      try {
+        final credentials = await AscCredentials.fromFile(path);
+        final client = AscClient(credentials);
+        try {
+          await client.listDevices();
+        } finally {
+          client.close();
+        }
+        return const DoctorCheck.success(
+          'Authentication',
+          'App Store Connect credentials are valid.',
+        );
+      } on Object catch (error) {
+        return DoctorCheck.failure(
+          'Authentication',
+          'App Store Connect credentials are unusable: $error',
+        );
+      }
+    }
+    return const DoctorCheck.failure(
+      'Authentication',
+      'No credentials found. Run `xcross auth`.',
+    );
+  }
+}

--- a/packages/xcross/lib/src/cli/basic/doctor_environment_checks.dart
+++ b/packages/xcross/lib/src/cli/basic/doctor_environment_checks.dart
@@ -1,0 +1,185 @@
+import 'dart:io';
+
+import 'package:apple_developer_kit/apple_developer_kit.dart';
+import 'package:cli_kit/cli_kit.dart';
+import 'package:dart_mobile_device/dart_mobile_device.dart';
+import 'package:darwin_sdk_kit/darwin_sdk_kit.dart';
+import 'package:xcross/src/cli/basic/doctor_models.dart';
+import 'package:xcross/src/cli/basic/sdk_install.dart';
+
+abstract final class DoctorEnvironmentChecks {
+  static const _requiredTools = [
+    'swift',
+    'clang',
+    'clang++',
+    'llvm-ar',
+    'ld64.lld',
+  ];
+
+  static Future<List<DoctorCheck>> host() async {
+    final checks = <DoctorCheck>[_hostPlatform()];
+    for (final tool in _requiredTools) {
+      checks.add(await _tool(tool));
+    }
+    checks.add(await _darwinSdk());
+    return checks;
+  }
+
+  static DoctorCheck _hostPlatform() {
+    final supported =
+        Platform.isLinux || Platform.isMacOS || Platform.isWindows;
+    final message =
+        '${Platform.operatingSystem} is '
+        '${supported ? 'supported' : 'not supported'}.';
+    return supported
+        ? DoctorCheck.success('Host', message)
+        : DoctorCheck.failure('Host', message);
+  }
+
+  static Future<DoctorCheck> _tool(String name) async {
+    final path = await ProcessRunner.which(
+      name,
+      accept: name == 'ld64.lld' ? DarwinSdk.usableLd64Lld : null,
+      extraDirectories: DarwinSdk.llvmToolDirs(),
+    );
+    return path == null
+        ? DoctorCheck.failure(
+            name,
+            'Not found. Run `xcross setup` after installing Swift.',
+          )
+        : DoctorCheck.success(name, 'Found', path: path);
+  }
+
+  static Future<DoctorCheck> _darwinSdk() async {
+    final path = DarwinSdk.nativeInstallDir();
+    if (!DarwinSdk.isValidBundle(path)) {
+      return const DoctorCheck.failure(
+        'Darwin SDK',
+        'Missing or incomplete. Run `xcross sdk install <Xcode.xip>`.',
+      );
+    }
+    final mismatch = await SdkInstall.hostToolchainMismatch(path);
+    return mismatch == null
+        ? DoctorCheck.success('Darwin SDK', 'Installed', path: path)
+        : DoctorCheck.failure(
+            'Darwin SDK',
+            '$mismatch Reinstall it with `xcross sdk install <Xcode.xip>`.',
+          );
+  }
+
+  static Future<List<DoctorCheck>> run() async {
+    final deviceTools = await _deviceTools();
+    if (deviceTools.status == DoctorStatus.failure) return [deviceTools];
+
+    final checks = <DoctorCheck>[deviceTools, await _authentication()];
+    try {
+      checks.addAll(await devices(await PymdDevices.devices()));
+    } on Object catch (error) {
+      checks.add(DoctorCheck.warning('Device', 'Discovery failed: $error'));
+    }
+    return checks;
+  }
+
+  static Future<DoctorCheck> _deviceTools() async {
+    try {
+      final invocation = await Pymd.resolve();
+      return DoctorCheck.success(
+        'Device tools',
+        'Found',
+        path: invocation.executable,
+      );
+    } on Object catch (error) {
+      return DoctorCheck.failure('Device tools', '$error');
+    }
+  }
+
+  static Future<List<DoctorCheck>> devices(
+    List<Device> found, {
+    Future<int?> Function(Device device)? osMajorVersion,
+  }) async {
+    if (found.isEmpty) {
+      return const [
+        DoctorCheck.warning('Device', 'No connected iOS device found.'),
+      ];
+    }
+    final resolveVersion = osMajorVersion ?? _deviceOsMajorVersion;
+    final checks = <DoctorCheck>[];
+    for (final device in found) {
+      checks.add(_deviceCheck(device, await resolveVersion(device)));
+    }
+    return checks;
+  }
+
+  static Future<int?> _deviceOsMajorVersion(Device device) =>
+      OsVersion.deviceOSMajorVersion(
+        device.udid,
+        overTunnel: device.source == DeviceSource.tunneld,
+      );
+
+  static DoctorCheck _deviceCheck(Device device, int? osMajor) {
+    final label = '${device.name} (${device.udid})';
+    if (osMajor == null) {
+      return DoctorCheck.warning(
+        'Device',
+        '$label: could not read the iOS version.',
+      );
+    }
+    if (osMajor < 17) {
+      return DoctorCheck.failure(
+        'Device',
+        '$label runs iOS $osMajor; iOS 17 or later is required.',
+      );
+    }
+    return DoctorCheck.success('Device', '$label runs iOS $osMajor.');
+  }
+
+  static Future<DoctorCheck> _authentication() async {
+    final appleId = await _appleIdAuthentication();
+    if (appleId != null) return appleId;
+    return _appStoreConnectAuthentication();
+  }
+
+  static Future<DoctorCheck?> _appleIdAuthentication() async {
+    try {
+      final session = await GrandSlamSessionStore().load();
+      if (session == null || session.isExpired) return null;
+      return const DoctorCheck.success(
+        'Authentication',
+        'Apple ID session is available.',
+      );
+    } on Object catch (error) {
+      return DoctorCheck.failure(
+        'Authentication',
+        'Apple ID session is unusable: $error',
+      );
+    }
+  }
+
+  static Future<DoctorCheck> _appStoreConnectAuthentication() async {
+    final path = AscCredentials.defaultConfigPath();
+    if (!File(path).existsSync()) {
+      return const DoctorCheck.failure(
+        'Authentication',
+        'No credentials found. Run `xcross auth`.',
+      );
+    }
+    try {
+      final credentials = await AscCredentials.fromFile(path);
+      final client = AscClient(credentials);
+      try {
+        await client.listDevices();
+      } finally {
+        client.close();
+      }
+      return const DoctorCheck.success(
+        'Authentication',
+        'App Store Connect credentials are valid.',
+      );
+    } on Object catch (error) {
+      return DoctorCheck.failure(
+        'Authentication',
+        'App Store Connect credentials are unusable: $error',
+      );
+    }
+  }
+}

--- a/packages/xcross/lib/src/cli/basic/doctor_environment_checks.dart
+++ b/packages/xcross/lib/src/cli/basic/doctor_environment_checks.dart
@@ -7,6 +7,15 @@ import 'package:darwin_sdk_kit/darwin_sdk_kit.dart';
 import 'package:xcross/src/cli/basic/doctor_models.dart';
 import 'package:xcross/src/cli/basic/sdk_install.dart';
 
+typedef DoctorLocateTool =
+    Future<String?> Function(
+      String name, {
+      bool? windows,
+      bool Function(String path)? accept,
+      Iterable<String> extraDirectories,
+    });
+typedef DoctorSingleCheck = Future<DoctorCheck> Function();
+
 abstract final class DoctorEnvironmentChecks {
   static const _requiredTools = [
     'swift',
@@ -16,29 +25,48 @@ abstract final class DoctorEnvironmentChecks {
     'ld64.lld',
   ];
 
-  static Future<List<DoctorCheck>> host() async {
-    final checks = <DoctorCheck>[_hostPlatform()];
+  static Future<List<DoctorCheck>> host() => hostWithSeams(
+    operatingSystem: Platform.operatingSystem,
+    windows: Platform.isWindows,
+    locateTool: ProcessRunner.which,
+    darwinSdk: _darwinSdk,
+  );
+
+  static Future<List<DoctorCheck>> hostWithSeams({
+    required String operatingSystem,
+    required bool windows,
+    required DoctorLocateTool locateTool,
+    required DoctorSingleCheck darwinSdk,
+  }) async {
+    final checks = <DoctorCheck>[_hostPlatform(operatingSystem)];
     for (final tool in _requiredTools) {
-      checks.add(await _tool(tool));
+      checks.add(await _tool(tool, windows: windows, locateTool: locateTool));
     }
-    checks.add(await _darwinSdk());
+    checks.add(await darwinSdk());
     return checks;
   }
 
-  static DoctorCheck _hostPlatform() {
-    final supported =
-        Platform.isLinux || Platform.isMacOS || Platform.isWindows;
+  static DoctorCheck _hostPlatform(String operatingSystem) {
+    final supported = const {
+      'linux',
+      'macos',
+      'windows',
+    }.contains(operatingSystem);
     final message =
-        '${Platform.operatingSystem} is '
-        '${supported ? 'supported' : 'not supported'}.';
+        '$operatingSystem is ${supported ? 'supported' : 'not supported'}.';
     return supported
         ? DoctorCheck.success('Host', message)
         : DoctorCheck.failure('Host', message);
   }
 
-  static Future<DoctorCheck> _tool(String name) async {
-    final path = await ProcessRunner.which(
+  static Future<DoctorCheck> _tool(
+    String name, {
+    required bool windows,
+    required DoctorLocateTool locateTool,
+  }) async {
+    final path = await locateTool(
       name,
+      windows: windows,
       accept: name == 'ld64.lld' ? DarwinSdk.usableLd64Lld : null,
       extraDirectories: DarwinSdk.llvmToolDirs(),
     );
@@ -48,6 +76,26 @@ abstract final class DoctorEnvironmentChecks {
             'Not found. Run `xcross setup` after installing Swift.',
           )
         : DoctorCheck.success(name, 'Found', path: path);
+  }
+
+  static Future<DoctorCheck> flutterTool() =>
+      flutterToolWithSeams(windows: Platform.isWindows);
+
+  static Future<DoctorCheck> flutterToolWithSeams({
+    required bool windows,
+    DoctorLocateTool locateTool = ProcessRunner.which,
+  }) async {
+    final path = await locateTool(
+      'flutter',
+      windows: windows,
+      extraDirectories: const [],
+    );
+    return path == null
+        ? const DoctorCheck.failure(
+            'Flutter SDK',
+            'Flutter was not found on PATH.',
+          )
+        : DoctorCheck.success('Flutter SDK', 'Found', path: path);
   }
 
   static Future<DoctorCheck> _darwinSdk() async {

--- a/packages/xcross/lib/src/cli/basic/doctor_examiner.dart
+++ b/packages/xcross/lib/src/cli/basic/doctor_examiner.dart
@@ -1,0 +1,63 @@
+import 'dart:io';
+
+import 'package:dart_mobile_device/dart_mobile_device.dart';
+import 'package:xcross/src/cli/basic/doctor_environment_checks.dart';
+import 'package:xcross/src/cli/basic/doctor_models.dart';
+import 'package:xcross/src/cli/basic/doctor_project_checks.dart';
+
+typedef DoctorChecks = Future<List<DoctorCheck>> Function();
+typedef DoctorDetectProject = Future<DoctorProject?> Function();
+typedef DoctorProjectCheckRunner =
+    Future<List<DoctorCheck>> Function(DoctorProject project);
+
+final class DoctorExaminer {
+  const DoctorExaminer()
+    : _hostChecks = DoctorEnvironmentChecks.host,
+      _detectProject = _detectCurrentProject,
+      _projectChecks = DoctorProjectChecks.examine,
+      _runChecks = DoctorEnvironmentChecks.run;
+
+  const DoctorExaminer.withSeams({
+    required DoctorChecks hostChecks,
+    required DoctorDetectProject detectProject,
+    required DoctorProjectCheckRunner projectChecks,
+    required DoctorChecks runChecks,
+  }) : _hostChecks = hostChecks,
+       _detectProject = detectProject,
+       _projectChecks = projectChecks,
+       _runChecks = runChecks;
+
+  final DoctorChecks _hostChecks;
+  final DoctorDetectProject _detectProject;
+  final DoctorProjectCheckRunner _projectChecks;
+  final DoctorChecks _runChecks;
+
+  Future<List<DoctorCheck>> examine() async {
+    final checks = [...await _hostChecks()];
+    final project = await _detectProject();
+    checks.addAll(
+      project == null
+          ? const [
+              DoctorCheck.warning(
+                'Project',
+                'No Flutter or Compose project found in the current directory.',
+              ),
+            ]
+          : await _projectChecks(project),
+    );
+    checks.addAll(await _runChecks());
+    return checks;
+  }
+
+  static Future<DoctorProject?> _detectCurrentProject() async =>
+      detectProjectAt(Directory.current.path);
+
+  static DoctorProject? detectProjectAt(String root) =>
+      DoctorProjectChecks.detect(root);
+
+  static Future<List<DoctorCheck>> deviceChecks(
+    List<Device> devices, {
+    Future<int?> Function(Device device)? osMajorVersion,
+  }) =>
+      DoctorEnvironmentChecks.devices(devices, osMajorVersion: osMajorVersion);
+}

--- a/packages/xcross/lib/src/cli/basic/doctor_models.dart
+++ b/packages/xcross/lib/src/cli/basic/doctor_models.dart
@@ -1,0 +1,29 @@
+enum DoctorStatus { success, warning, failure }
+
+final class DoctorCheck {
+  const DoctorCheck(this.status, this.name, this.message, {this.path});
+
+  const DoctorCheck.success(this.name, this.message, {this.path})
+    : status = DoctorStatus.success;
+  const DoctorCheck.warning(this.name, this.message, {this.path})
+    : status = DoctorStatus.warning;
+  const DoctorCheck.failure(this.name, this.message, {this.path})
+    : status = DoctorStatus.failure;
+
+  final DoctorStatus status;
+  final String name;
+  final String message;
+  final String? path;
+}
+
+enum DoctorProjectKind { flutter, compose }
+
+final class DoctorProject {
+  const DoctorProject(this.kind, this.root);
+
+  const DoctorProject.flutter(this.root) : kind = DoctorProjectKind.flutter;
+  const DoctorProject.compose(this.root) : kind = DoctorProjectKind.compose;
+
+  final DoctorProjectKind kind;
+  final String root;
+}

--- a/packages/xcross/lib/src/cli/basic/doctor_project_checks.dart
+++ b/packages/xcross/lib/src/cli/basic/doctor_project_checks.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
+import 'package:xcross/src/cli/basic/doctor_environment_checks.dart';
 import 'package:xcross/src/cli/basic/doctor_models.dart';
 import 'package:xcross/src/compose/project/kmp_project.dart';
 import 'package:xcross/src/compose/toolchain/compose_host.dart';
@@ -35,6 +36,7 @@ abstract final class DoctorProjectChecks {
     return [
       projectCheck,
       _flutterEntrypoint(root),
+      await DoctorEnvironmentChecks.flutterTool(),
       await _flutterSdk(root),
       await _flutterPackages(root),
     ];

--- a/packages/xcross/lib/src/cli/basic/doctor_project_checks.dart
+++ b/packages/xcross/lib/src/cli/basic/doctor_project_checks.dart
@@ -1,0 +1,127 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:xcross/src/cli/basic/doctor_models.dart';
+import 'package:xcross/src/compose/project/kmp_project.dart';
+import 'package:xcross/src/compose/toolchain/compose_host.dart';
+import 'package:xcross/src/compose/toolchain/compose_toolchain_resolver.dart';
+import 'package:xcross/src/errors.dart';
+import 'package:xcross/src/flutter/build/flutter_packer.dart';
+import 'package:xcross/src/flutter/models/pubspec_info.dart';
+import 'package:xcross/src/package_config_resolver.dart';
+
+abstract final class DoctorProjectChecks {
+  static DoctorProject? detect(String root) {
+    if (File(p.join(root, 'pubspec.yaml')).existsSync()) {
+      return DoctorProject.flutter(root);
+    }
+    if (File(p.join(root, 'settings.gradle.kts')).existsSync() ||
+        File(p.join(root, 'settings.gradle')).existsSync()) {
+      return DoctorProject.compose(root);
+    }
+    return null;
+  }
+
+  static Future<List<DoctorCheck>> examine(DoctorProject project) =>
+      switch (project.kind) {
+        DoctorProjectKind.flutter => _flutter(project.root),
+        DoctorProjectKind.compose => _compose(project.root),
+      };
+
+  static Future<List<DoctorCheck>> _flutter(String root) async {
+    final projectCheck = _flutterProject(root);
+    if (projectCheck.status == DoctorStatus.failure) return [projectCheck];
+
+    return [
+      projectCheck,
+      _flutterEntrypoint(root),
+      await _flutterSdk(root),
+      await _flutterPackages(root),
+    ];
+  }
+
+  static DoctorCheck _flutterProject(String root) {
+    try {
+      return DoctorCheck.success(
+        'Flutter project',
+        PubspecInfo.loadSync(root).name,
+      );
+    } on Object catch (error) {
+      return DoctorCheck.failure('Flutter project', '$error');
+    }
+  }
+
+  static DoctorCheck _flutterEntrypoint(String root) {
+    final entrypoint = File(p.join(root, 'lib', 'main.dart'));
+    return entrypoint.existsSync()
+        ? DoctorCheck.success(
+            'Flutter entrypoint',
+            'Found',
+            path: entrypoint.path,
+          )
+        : const DoctorCheck.failure(
+            'Flutter entrypoint',
+            'lib/main.dart does not exist.',
+          );
+  }
+
+  static Future<DoctorCheck> _flutterSdk(String root) async {
+    try {
+      final flutterRoot = await FlutterPacker.resolveFlutterRoot(
+        projectRoot: root,
+      );
+      return DoctorCheck.success('Flutter SDK', 'Found', path: flutterRoot);
+    } on Object catch (error) {
+      return DoctorCheck.failure('Flutter SDK', '$error');
+    }
+  }
+
+  static Future<DoctorCheck> _flutterPackages(String root) async {
+    final packageConfig = await PackageConfigResolver.find(root);
+    return packageConfig == null
+        ? const DoctorCheck.warning(
+            'Flutter packages',
+            'No package_config.json; `flutter pub get` will be required.',
+          )
+        : DoctorCheck.success(
+            'Flutter packages',
+            'Resolved',
+            path: packageConfig,
+          );
+  }
+
+  static Future<List<DoctorCheck>> _compose(String root) async {
+    try {
+      final project = KmpProject.detect(root);
+      final projectCheck = DoctorCheck.success(
+        'Compose project',
+        project.moduleName,
+      );
+      final host = _resolveComposeHost();
+      if (host.problem case final problem?) {
+        return [projectCheck, DoctorCheck.failure('Compose host', problem)];
+      }
+      final problems = await ComposeToolchainResolver.problems(
+        host: host.value!,
+        environment: Platform.environment,
+        projectRoot: root,
+      );
+      return [projectCheck, _composeToolchain(problems)];
+    } on Object catch (error) {
+      return [DoctorCheck.failure('Compose project', '$error')];
+    }
+  }
+
+  static ({ComposeHost? value, String? problem}) _resolveComposeHost() {
+    try {
+      return (value: ComposeHost.current(), problem: null);
+    } on XcrossError catch (error) {
+      return (value: null, problem: error.message);
+    }
+  }
+
+  static DoctorCheck _composeToolchain(List<String> problems) =>
+      problems.isEmpty
+      ? const DoctorCheck.success('Compose toolchain', 'Ready.')
+      : DoctorCheck.failure('Compose toolchain', problems.join(' '));
+}

--- a/packages/xcross/lib/src/cli/runner.dart
+++ b/packages/xcross/lib/src/cli/runner.dart
@@ -11,6 +11,7 @@ import 'package:darwin_sdk_kit/darwin_sdk_kit.dart';
 import 'package:path/path.dart' as p;
 import 'package:xcross/src/cli/basic/auth_command.dart';
 import 'package:xcross/src/cli/basic/completion_command.dart';
+import 'package:xcross/src/cli/basic/doctor_command.dart';
 import 'package:xcross/src/cli/basic/sdk_command.dart';
 import 'package:xcross/src/cli/basic/setup_command.dart';
 import 'package:xcross/src/cli/basic/tunnel_command.dart';
@@ -154,6 +155,7 @@ abstract final class XcrossCli {
         ..addCommand(FlutterCommand())
         ..addCommand(ComposeCommand())
         ..addCommand(TunnelCommand())
+        ..addCommand(DoctorCommand())
         ..addCommand(SetupCommand())
         ..addCommand(AuthCommand())
         ..addCommand(SdkCommand())

--- a/packages/xcross/test/cli/doctor_command_test.dart
+++ b/packages/xcross/test/cli/doctor_command_test.dart
@@ -5,6 +5,7 @@ import 'package:cli_util/cli_logging.dart';
 import 'package:dart_mobile_device/dart_mobile_device.dart';
 import 'package:test/test.dart';
 import 'package:xcross/src/cli/basic/doctor_command.dart';
+import 'package:xcross/src/cli/basic/doctor_environment_checks.dart';
 import 'package:xcross/src/cli/runner.dart';
 import 'package:xcross/src/errors.dart';
 
@@ -157,6 +158,42 @@ void main() {
         DoctorProjectKind.compose,
       ),
     );
+  });
+
+  test('Windows host checks resolve PATHEXT executable names', () async {
+    final requested = <String>[];
+    final checks = await DoctorEnvironmentChecks.hostWithSeams(
+      operatingSystem: 'windows',
+      windows: true,
+      locateTool: (name, {windows, accept, extraDirectories = const []}) async {
+        requested.add(name);
+        return 'C:\\Tools\\$name.exe';
+      },
+      darwinSdk: () async => const DoctorCheck.success(
+        'Darwin SDK',
+        'Installed',
+        path: r'C:\xcross\sdk',
+      ),
+    );
+
+    expect(requested, ['swift', 'clang', 'clang++', 'llvm-ar', 'ld64.lld']);
+    expect(checks.first.status, DoctorStatus.success);
+    expect(checks.where((check) => check.path != null), hasLength(6));
+  });
+
+  test('Windows Flutter checks require the Flutter launcher', () async {
+    final checks = await DoctorEnvironmentChecks.flutterToolWithSeams(
+      windows: true,
+      locateTool: (name, {windows, accept, extraDirectories = const []}) async {
+        expect(name, 'flutter');
+        expect(windows, isTrue);
+        return r'C:\flutter\bin\flutter.bat';
+      },
+    );
+
+    expect(checks, isA<DoctorCheck>());
+    expect(checks.status, DoctorStatus.success);
+    expect(checks.path, r'C:\flutter\bin\flutter.bat');
   });
 
   test('device checks reject connected devices older than iOS 17', () async {

--- a/packages/xcross/test/cli/doctor_command_test.dart
+++ b/packages/xcross/test/cli/doctor_command_test.dart
@@ -1,0 +1,204 @@
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:cli_util/cli_logging.dart';
+import 'package:dart_mobile_device/dart_mobile_device.dart';
+import 'package:test/test.dart';
+import 'package:xcross/src/cli/basic/doctor_command.dart';
+import 'package:xcross/src/cli/runner.dart';
+import 'package:xcross/src/errors.dart';
+
+void main() {
+  test('doctor is registered by the top-level runner', () {
+    expect(XcrossCli.buildRunner().commands.keys, contains('doctor'));
+  });
+
+  test('colors status markers like Flutter doctor', () {
+    expect(
+      DoctorCommand.formatCheck(
+        const DoctorCheck.success('SDK', 'ready'),
+        ansi: Ansi(true),
+      ),
+      '\u001b[32m[✓]\u001b[0m SDK: ready',
+    );
+    expect(
+      DoctorCommand.formatCheck(
+        const DoctorCheck.warning('Project', 'missing'),
+        ansi: Ansi(true),
+      ),
+      '\u001b[33m[!]\u001b[0m Project: missing',
+    );
+    expect(
+      DoctorCommand.formatCheck(
+        const DoctorCheck.failure('Swift', 'missing'),
+        ansi: Ansi(true),
+      ),
+      '\u001b[31m[✗]\u001b[0m Swift: missing',
+    );
+  });
+
+  test('prints a path dimmed below its status line', () {
+    expect(
+      DoctorCommand.formatCheck(
+        const DoctorCheck.success('Flutter SDK', 'Found', path: '/opt/flutter'),
+        ansi: Ansi(true),
+        dim: (value) => '<dim>$value</dim>',
+      ),
+      '\u001b[32m[✓]\u001b[0m Flutter SDK: Found\n'
+      '    <dim>/opt/flutter</dim>',
+    );
+  });
+
+  test('prints a path plainly below its status when ANSI is unavailable', () {
+    expect(
+      DoctorCommand.formatCheck(
+        const DoctorCheck.success('Flutter SDK', 'Found', path: '/opt/flutter'),
+        ansi: Ansi(false),
+        dim: (value) => value,
+      ),
+      '[✓] Flutter SDK: Found\n    /opt/flutter',
+    );
+  });
+
+  test('keeps status markers plain when ANSI is unavailable', () {
+    expect(
+      DoctorCommand.formatCheck(
+        const DoctorCheck.failure('Swift', 'missing'),
+        ansi: Ansi(false),
+      ),
+      '[✗] Swift: missing',
+    );
+  });
+
+  test('warnings do not fail doctor', () async {
+    final lines = <String>[];
+    final command = DoctorCommand.withSeams(
+      examine: () async => const [
+        DoctorCheck.warning('Project', 'No Flutter or Compose project found.'),
+      ],
+      writeLine: lines.add,
+    );
+    final runner = CommandRunner<void>('xcross', 'test')..addCommand(command);
+
+    await runner.run(['doctor']);
+
+    expect(lines, [
+      '[!] Project: No Flutter or Compose project found.',
+      'Doctor found 1 warning.',
+    ]);
+  });
+
+  test('failures are all reported and fail doctor', () async {
+    final lines = <String>[];
+    final command = DoctorCommand.withSeams(
+      examine: () async => const [
+        DoctorCheck.failure('Swift', 'swift was not found on PATH.'),
+        DoctorCheck.success('SDK', 'Darwin SDK is installed.'),
+        DoctorCheck.failure('Device tools', 'pymobiledevice3 was not found.'),
+      ],
+      writeLine: lines.add,
+    );
+    final runner = CommandRunner<void>('xcross', 'test')..addCommand(command);
+
+    await expectLater(
+      runner.run(['doctor']),
+      throwsA(
+        isA<XcrossError>().having(
+          (error) => error.message,
+          'message',
+          'Doctor found 2 failures.',
+        ),
+      ),
+    );
+    expect(lines, [
+      '[✗] Swift: swift was not found on PATH.',
+      '[✓] SDK: Darwin SDK is installed.',
+      '[✗] Device tools: pymobiledevice3 was not found.',
+    ]);
+  });
+
+  test('missing project is a warning', () async {
+    final examiner = DoctorExaminer.withSeams(
+      hostChecks: () async => const [],
+      detectProject: () async => null,
+      projectChecks: (_) => throw StateError('project checks must not run'),
+      runChecks: () async => const [],
+    );
+
+    final results = await examiner.examine();
+
+    expect(results.single.status, DoctorStatus.warning);
+    expect(results.single.name, 'Project');
+  });
+
+  test('detects Flutter and Compose projects from the current directory', () {
+    final flutter = Directory.systemTemp.createTempSync('doctor_flutter');
+    final compose = Directory.systemTemp.createTempSync('doctor_compose');
+    addTearDown(() {
+      flutter.deleteSync(recursive: true);
+      compose.deleteSync(recursive: true);
+    });
+    File('${flutter.path}/pubspec.yaml').writeAsStringSync('name: demo');
+    File('${compose.path}/settings.gradle.kts').writeAsStringSync('');
+
+    expect(
+      DoctorExaminer.detectProjectAt(flutter.path),
+      isA<DoctorProject>().having(
+        (project) => project.kind,
+        'kind',
+        DoctorProjectKind.flutter,
+      ),
+    );
+    expect(
+      DoctorExaminer.detectProjectAt(compose.path),
+      isA<DoctorProject>().having(
+        (project) => project.kind,
+        'kind',
+        DoctorProjectKind.compose,
+      ),
+    );
+  });
+
+  test('device checks reject connected devices older than iOS 17', () async {
+    final checks = await DoctorExaminer.deviceChecks(const [
+      Device(name: 'Old iPhone', udid: 'old', type: ConnectionType.usb),
+      Device(name: 'New iPhone', udid: 'new', type: ConnectionType.usb),
+    ], osMajorVersion: (device) async => device.udid == 'old' ? 16 : 17);
+
+    expect(checks.map((check) => check.status), [
+      DoctorStatus.failure,
+      DoctorStatus.success,
+    ]);
+  });
+
+  test(
+    'default examiner validates a detected project without building it',
+    () async {
+      final calls = <String>[];
+      final examiner = DoctorExaminer.withSeams(
+        hostChecks: () async {
+          calls.add('host');
+          return const [DoctorCheck.success('Host', 'ready')];
+        },
+        detectProject: () async => const DoctorProject.flutter('/project'),
+        projectChecks: (project) async {
+          calls.add('project:${project.root}');
+          return const [DoctorCheck.success('Flutter project', 'ready')];
+        },
+        runChecks: () async {
+          calls.add('run');
+          return const [DoctorCheck.warning('Device', 'not connected')];
+        },
+      );
+
+      final results = await examiner.examine();
+
+      expect(calls, ['host', 'project:/project', 'run']);
+      expect(results.map((result) => result.name), [
+        'Host',
+        'Flutter project',
+        'Device',
+      ]);
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- add a read-only `xcross doctor` command for build and run prerequisites
- validate host tools, Darwin SDK, Flutter or Compose project state, authentication, and connected iOS devices
- show colored statuses and dim filesystem paths with plain-terminal fallbacks

## Testing

- `dart analyze`
- `dart test test/cli`
- `git diff --check`