### PR TITLE
chore(nix): Swift binary patching and CC/CXX priority

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -59,13 +59,15 @@
         python313Packages = final.python313.pkgs;
       };
 
-      packagesFor = system:
+      packagesFor =
+        system:
         import nixpkgs {
           inherit system;
           overlays = [ pymobiledeviceOverlay ];
         };
 
-      environmentFor = system:
+      environmentFor =
+        system:
         let
           pkgs = packagesFor system;
           xcrossRelease = xcrossReleases.${system};
@@ -77,16 +79,32 @@
             src = pkgs.fetchurl {
               inherit (swiftToolchainSource) url hash;
             };
+            nativeBuildInputs = [ pkgs.autoPatchelfHook ];
+            buildInputs = [
+              pkgs.stdenv.cc.cc.lib
+              pkgs.zlib
+              pkgs.ncurses
+              pkgs.libxml2_13
+              pkgs.libedit
+              pkgs.curl
+              pkgs.libuuid
+              pkgs.python312 # note: needs to be 3.12 specifically, matching libpython3.12.so.1.0
+              pkgs.sqlite
+            ];
 
             dontConfigure = true;
             dontBuild = true;
-            dontFixup = true;
+            autoPatchelfIgnoreMissingDeps = [ "libedit.so.2" ]; # TODO: find actual packages
 
             installPhase = ''
               runHook preInstall
-              mkdir -p "$out"
-              cp -r usr/* "$out/"
+              mkdir -p $out
+              cp -r usr/* $out/
               runHook postInstall
+            '';
+            postFixup = ''
+              find $out -type f -executable -exec \
+                patchelf --replace-needed libedit.so.2 libedit.so.0 {} \; 2>/dev/null || true
             '';
           };
 
@@ -161,16 +179,19 @@
             export CXX=${swiftToolchain}/bin/clang++
           '';
 
-          smokeCheck = pkgs.runCommand "xcross-smoke-check" {
-            nativeBuildInputs = [ xcross ];
-          } ''
-            test -x ${xcross}/bin/xcross
-            test -x ${xcross}/bin/xcrun
-            test -d ${xcross}/lib/xcross/lib
-            cmp ${xcrossRelease}/bin/xcross ${xcross}/lib/xcross/bin/xcross
-            cmp ${xcrossRelease}/bin/xcrun ${xcross}/lib/xcross/bin/xcrun
-            touch "$out"
-          '';
+          smokeCheck =
+            pkgs.runCommand "xcross-smoke-check"
+              {
+                nativeBuildInputs = [ xcross ];
+              }
+              ''
+                test -x ${xcross}/bin/xcross
+                test -x ${xcross}/bin/xcrun
+                test -d ${xcross}/lib/xcross/lib
+                cmp ${xcrossRelease}/bin/xcross ${xcross}/lib/xcross/bin/xcross
+                cmp ${xcrossRelease}/bin/xcrun ${xcross}/lib/xcross/bin/xcrun
+                touch "$out"
+              '';
         in
         {
           inherit

--- a/flake.nix
+++ b/flake.nix
@@ -94,7 +94,7 @@
 
             dontConfigure = true;
             dontBuild = true;
-            autoPatchelfIgnoreMissingDeps = [ "libedit.so.2" ]; # TODO: find actual packages
+            autoPatchelfIgnoreMissingDeps = [ "libedit.so.2" ];
 
             installPhase = ''
               runHook preInstall
@@ -165,6 +165,8 @@
           userPackages = [ xcross ] ++ runtimePackages;
 
           contributorPackages = userPackages ++ [
+            pkgs.dart
+            pkgs.clang
             pkgs.cmake
             pkgs.ninja
             pkgs.git

--- a/flake.nix
+++ b/flake.nix
@@ -109,13 +109,20 @@
           };
 
           swiftCompiler = pkgs.writeShellScript "xcross-swiftc" ''
-            exec ${swiftToolchain}/bin/swiftc -use-ld=lld "$@"
+            export LIBRARY_PATH="${pkgs.stdenv.cc.libc}/lib:${pkgs.stdenv.cc.cc.lib}/lib''${LIBRARY_PATH:+:$LIBRARY_PATH}"
+            export C_INCLUDE_PATH="${pkgs.stdenv.cc.libc.dev}/include''${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}"
+            exec ${swiftToolchain}/bin/swiftc -use-ld=lld \
+              -Xclang-linker --gcc-toolchain=${pkgs.gcc.cc} \
+              -Xclang-linker -B${pkgs.stdenv.cc.libc}/lib \
+              "$@"
           '';
 
           runtimePackages = [
             swiftToolchain
             pkgs.python313
             pkgs.python313Packages.pymobiledevice3
+            pkgs.llvmPackages_21.lld
+            pkgs.llvmPackages_21.llvm
             pkgs.usbmuxd
             pkgs.libimobiledevice
             pkgs.usbutils

--- a/flake.nix
+++ b/flake.nix
@@ -173,68 +173,6 @@
             };
           };
 
-          xcross-git = pkgs.buildDartApplication {
-            pname = "xcross";
-            version = "git";
-            src = inputs.self;
-
-            packageRoot = "packages/xcross";
-            autoPubspecLock = ./pubspec.lock;
-
-            dontDartInstallCache = true;
-
-            buildPhase = ''
-              cd "$NIX_BUILD_TOP/source/packages/xcross"
-              runHook preBuild
-              dart run \
-                "-DXCROSS_VERSION=git" \
-                "-DXCROSS_RELEASED=false" \
-                tool/build_xcross.dart
-              runHook postBuild
-            '';
-
-            installPhase = ''
-              cd "$NIX_BUILD_TOP/source/packages/xcross"
-              runHook preInstall
-
-              arch=${if pkgs.stdenv.hostPlatform.isAarch64 then "linux_arm64" else "linux_x64"}
-              bundle=build/cli/$arch/bundle
-              test -d "$bundle"
-
-              # Manually create pubcache so nix doesnt crash out
-              mkdir -p $pubcache
-
-              mkdir -p "$out/bin" "$out/lib/xcross"
-              cp -a "$bundle/bin" "$bundle/lib" "$out/lib/xcross/"
-
-              if [ ! -e "$out/lib/xcross/bin/xcrun" ]; then
-                cp -a build/xcrun/bundle/bin/xcrun "$out/lib/xcross/bin/"
-              fi
-
-              for executable in xcross xcrun; do
-                makeWrapper "$out/lib/xcross/bin/$executable" "$out/bin/$executable" \
-                  --prefix PATH : ${pkgs.lib.makeBinPath runtimePackages} \
-                  --set SWIFT_EXEC ${swiftCompiler} \
-                  --set SWIFT_EXEC_MANIFEST ${swiftCompiler} \
-                  --set CC ${swiftToolchain}/bin/clang \
-                  --set CXX ${swiftToolchain}/bin/clang++
-              done
-
-              runHook postInstall
-            '';
-
-            nativeBuildInputs = [ pkgs.makeWrapper ];
-            # runtimePackages / swift via the wrappers above
-
-            meta = {
-              description = "Build, run, and hot-reload Flutter iOS apps from Linux (built from source)";
-              homepage = "https://github.com/arxdeus/xcross";
-              license = pkgs.lib.licenses.mit;
-              mainProgram = "xcross";
-              platforms = systems;
-            };
-          };
-
           userPackages = [ xcross ] ++ runtimePackages;
 
           contributorPackages = userPackages ++ [

--- a/flake.nix
+++ b/flake.nix
@@ -225,7 +225,6 @@
           };
 
           userPackages = [ xcross ] ++ runtimePackages;
-          userPackagesGit = [ xcross-git ] ++ runtimePackages;
 
           contributorPackages = userPackages ++ [
             pkgs.dart
@@ -262,9 +261,7 @@
           inherit
             pkgs
             xcross
-            xcross-git
             userPackages
-            userPackagesGit
             contributorPackages
             shellHook
             smokeCheck
@@ -278,7 +275,7 @@
           environment = environmentFor system;
         in
         {
-          inherit (environment) xcross xcross-git;
+          inherit (environment) xcross;
           default = environment.xcross;
         }
       );
@@ -291,14 +288,9 @@
             type = "app";
             program = "${environment.xcross}/bin/xcross";
           };
-          app-git = {
-            type = "app";
-            program = "${environment.xcross-git}/bin/xcross";
-          };
         in
         {
           xcross = app;
-          xcross-git = app-git;
           default = app;
         }
       );
@@ -311,10 +303,6 @@
         {
           default = environment.pkgs.mkShell {
             packages = environment.userPackages;
-            inherit (environment) shellHook;
-          };
-          git = environment.pkgs.mkShell {
-            packages = environment.userPackagesGit;
             inherit (environment) shellHook;
           };
           contributor = environment.pkgs.mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -162,7 +162,70 @@
             };
           };
 
+          xcross-git = pkgs.buildDartApplication {
+            pname = "xcross";
+            version = "git";
+            src = inputs.self;
+
+            packageRoot = "packages/xcross";
+            autoPubspecLock = ./pubspec.lock;
+
+            dontDartInstallCache = true;
+
+            buildPhase = ''
+              cd "$NIX_BUILD_TOP/source/packages/xcross"
+              runHook preBuild
+              dart run \
+                "-DXCROSS_VERSION=git" \
+                "-DXCROSS_RELEASED=false" \
+                tool/build_xcross.dart
+              runHook postBuild
+            '';
+
+            installPhase = ''
+              cd "$NIX_BUILD_TOP/source/packages/xcross"
+              runHook preInstall
+
+              arch=${if pkgs.stdenv.hostPlatform.isAarch64 then "linux_arm64" else "linux_x64"}
+              bundle=build/cli/$arch/bundle
+              test -d "$bundle"
+
+              # Manually create pubcache so nix doesnt crash out
+              mkdir -p $pubcache
+
+              mkdir -p "$out/bin" "$out/lib/xcross"
+              cp -a "$bundle/bin" "$bundle/lib" "$out/lib/xcross/"
+
+              if [ ! -e "$out/lib/xcross/bin/xcrun" ]; then
+                cp -a build/xcrun/bundle/bin/xcrun "$out/lib/xcross/bin/"
+              fi
+
+              for executable in xcross xcrun; do
+                makeWrapper "$out/lib/xcross/bin/$executable" "$out/bin/$executable" \
+                  --prefix PATH : ${pkgs.lib.makeBinPath runtimePackages} \
+                  --set SWIFT_EXEC ${swiftCompiler} \
+                  --set SWIFT_EXEC_MANIFEST ${swiftCompiler} \
+                  --set CC ${swiftToolchain}/bin/clang \
+                  --set CXX ${swiftToolchain}/bin/clang++
+              done
+
+              runHook postInstall
+            '';
+
+            nativeBuildInputs = [ pkgs.makeWrapper ];
+            # runtimePackages / swift via the wrappers above
+
+            meta = {
+              description = "Build, run, and hot-reload Flutter iOS apps from Linux (built from source)";
+              homepage = "https://github.com/arxdeus/xcross";
+              license = pkgs.lib.licenses.mit;
+              mainProgram = "xcross";
+              platforms = systems;
+            };
+          };
+
           userPackages = [ xcross ] ++ runtimePackages;
+          userPackagesGit = [ xcross-git ] ++ runtimePackages;
 
           contributorPackages = userPackages ++ [
             pkgs.dart
@@ -199,7 +262,9 @@
           inherit
             pkgs
             xcross
+            xcross-git
             userPackages
+            userPackagesGit
             contributorPackages
             shellHook
             smokeCheck
@@ -213,7 +278,7 @@
           environment = environmentFor system;
         in
         {
-          inherit (environment) xcross;
+          inherit (environment) xcross xcross-git;
           default = environment.xcross;
         }
       );
@@ -226,9 +291,14 @@
             type = "app";
             program = "${environment.xcross}/bin/xcross";
           };
+          app-git = {
+            type = "app";
+            program = "${environment.xcross-git}/bin/xcross";
+          };
         in
         {
           xcross = app;
+          xcross-git = app-git;
           default = app;
         }
       );
@@ -243,7 +313,10 @@
             packages = environment.userPackages;
             inherit (environment) shellHook;
           };
-
+          git = environment.pkgs.mkShell {
+            packages = environment.userPackagesGit;
+            inherit (environment) shellHook;
+          };
           contributor = environment.pkgs.mkShell {
             packages = environment.contributorPackages;
             inherit (environment) shellHook;

--- a/flake.nix
+++ b/flake.nix
@@ -121,8 +121,12 @@
             swiftToolchain
             pkgs.python313
             pkgs.python313Packages.pymobiledevice3
+
+            pkgs.llvmPackages_21.clang
             pkgs.llvmPackages_21.lld
             pkgs.llvmPackages_21.llvm
+            pkgs.git
+
             pkgs.usbmuxd
             pkgs.libimobiledevice
             pkgs.usbutils

--- a/packages/apple_developer_kit/hook/build.dart
+++ b/packages/apple_developer_kit/hook/build.dart
@@ -87,19 +87,24 @@ Future<void> _buildWithSystemCc({
 
 /// Prefer absolute system compilers that are not swiftly shims.
 String _resolveSystemCc() {
-  for (final candidate in const [
-    '/usr/bin/cc',
-    '/usr/bin/gcc',
-    '/usr/bin/clang',
-  ]) {
-    final file = File(candidate);
-    if (!file.existsSync()) continue;
-    final real = file.resolveSymbolicLinksSync();
-    if (real.endsWith('/swiftly') || real.contains('/swiftly/')) continue;
-    return candidate;
+  // Hardcoded /usr/bin paths don't exist on all Linux distros (e.g. NixOS
+  // has no /usr/bin at all), so search PATH generically instead, filtering
+  // out the swiftly clang shim by the same symlink check as before.
+  final pathEnv = Platform.environment['PATH'] ?? '';
+  final dirs = pathEnv.split(Platform.isWindows ? ';' : ':');
+
+  for (final name in const ['cc', 'gcc', 'clang']) {
+    for (final dir in dirs) {
+      if (dir.isEmpty) continue;
+      final file = File('$dir/$name');
+      if (!file.existsSync()) continue;
+      final real = file.resolveSymbolicLinksSync();
+      if (real.endsWith('/swiftly') || real.contains('/swiftly/')) continue;
+      return file.path;
+    }
   }
   throw StateError(
-    'No usable system C compiler found (/usr/bin/cc|gcc|clang). '
+    'No usable system C compiler found (cc|gcc|clang) on PATH. '
     "Install build-essential, or remove swiftly's clang shim from PATH.",
   );
 }

--- a/packages/darwin_sdk_kit/lib/src/darwin_sdk.dart
+++ b/packages/darwin_sdk_kit/lib/src/darwin_sdk.dart
@@ -346,6 +346,25 @@ final class DarwinSdk {
     Future<CapturedProcess> Function(String, List<String>)? runProcess,
   }) async {
     final sysroot = sdk.iPhoneOSSdk();
+
+    // An explicit CC/CXX override takes precedence over the PATH search
+    // below — this matters on systems (e.g. Nix) where a stray system
+    // compiler sits ahead of the intended one on PATH.
+    final envVar = name == 'clang++' ? 'CXX' : 'CC';
+    final override = Platform.environment[envVar];
+    if (override != null && override.isNotEmpty) {
+      final failure = await probeDarwinDriver(
+        override,
+        sysroot: sysroot,
+        runProcess: runProcess,
+      );
+      if (failure == null) return override;
+      throw DarwinSdkError(
+        "\$$envVar is set to '$override' but it cannot target iOS.\n"
+        '  $failure',
+      );
+    }
+
     final searched = llvmToolDirs();
     final candidates = await ProcessRunner.whichAll(
       name,

--- a/packages/xcross/lib/src/cli/ide/xcross_executable.dart
+++ b/packages/xcross/lib/src/cli/ide/xcross_executable.dart
@@ -8,16 +8,37 @@ import 'package:path/path.dart' as p;
 /// Captured now so a later PATH change cannot break the editor. Under
 /// `dart run` the resolved executable is the Dart VM, which the IDE cannot
 /// use to start xcross — warn instead of silently writing a dead config.
+///
+/// Under Nix, `Platform.resolvedExecutable` resolves through the
+/// `makeWrapper` script's `exec` straight to the unwrapped binary at
+/// `.../lib/xcross/bin/xcross`, which breaks the expected environment setup.
 String resolveXcrossExecutable({
   required String subcommand,
   required String brokenFeature,
 }) {
-  final exe = Platform.resolvedExecutable;
+  var exe = Platform.resolvedExecutable;
+
   if (p.basenameWithoutExtension(exe) != 'xcross') {
     Log.logWarn(
       'embedding $exe — run `xcross ide $subcommand` from the installed '
       'binary, not `dart run`, or $brokenFeature will not work',
     );
+    return exe;
   }
+
+  if (exe.contains('${p.separator}nix${p.separator}store${p.separator}')) {
+    final wrapped = p.normalize(
+      p.join(p.dirname(exe), '..', '..', '..', 'bin', p.basename(exe)),
+    );
+    if (File(wrapped).existsSync()) {
+      exe = wrapped;
+    } else {
+      Log.logWarn(
+        'embedding $exe from a Nix store path, but the expected wrapper '
+        'at $wrapped was not found — $brokenFeature may not work correctly',
+      );
+    }
+  }
+
   return exe;
 }


### PR DESCRIPTION
Properly patches the swift binaries so it can work on NixOS, also prioritizes the clang compiler at $CC or $CXX (if they are set). The CC/CXX priority thing might be overwritten by the user select compiler feature later on.