### PR TITLE
fix(build): repair fast stubs sharing a selref when one can relocate

### DIFF
--- a/packages/xcross/lib/src/flutter/build/objc_fast_stub_rewriter.dart
+++ b/packages/xcross/lib/src/flutter/build/objc_fast_stub_rewriter.dart
@@ -131,8 +131,14 @@ abstract final class ObjCFastStubRewriter {
         ifAbsent: () => 1,
       );
     }
+
+    // Phase 1: every stub that already has a correct ref, or can adopt an
+    // existing valid ref elsewhere, is resolved first. A stub retargeted
+    // this way stops reading its old ref, which can free that ref up for
+    // whichever other stub still shares it.
     final instructionRepairs = <(_FastObjCStub, int)>[];
-    final pointerRepairs = <(int, int)>[];
+    final vacatedCounts = <int, int>{};
+    final unresolved = <_FastObjCStub>[];
     for (final stub in fastStubs) {
       final refFileOffset =
           selectorRefs.fileOffset + stub.refAddress - selectorRefs.address;
@@ -142,9 +148,27 @@ abstract final class ObjCFastStubRewriter {
       final matchingRefs = validRefsByName[stub.selector];
       if (matchingRefs != null && matchingRefs.isNotEmpty) {
         instructionRepairs.add((stub, matchingRefs.first));
+        vacatedCounts.update(
+          stub.refAddress,
+          (count) => count + 1,
+          ifAbsent: () => 1,
+        );
         continue;
       }
-      if (refUseCounts[stub.refAddress] != 1) {
+      unresolved.add(stub);
+    }
+
+    // Phase 2: everything left still needs its ref rewritten in place.
+    // That is only safe once every stub resolved in phase 1 that used to
+    // share it has moved away, leaving exactly one remaining reader.
+    final pointerRepairs = <(int, int)>[];
+    for (final stub in unresolved) {
+      final refFileOffset =
+          selectorRefs.fileOffset + stub.refAddress - selectorRefs.address;
+      final remainingUsers =
+          refUseCounts[stub.refAddress]! -
+          (vacatedCounts[stub.refAddress] ?? 0);
+      if (remainingUsers != 1) {
         fileInvalid(
           file,
           'fast stub "${stub.selector}" has no safe selref repair',

--- a/packages/xcross/test/flutter/build/macho_dylib_rewriter_test.dart
+++ b/packages/xcross/test/flutter/build/macho_dylib_rewriter_test.dart
@@ -162,8 +162,38 @@ void main() {
     );
   });
 
-  test('rejects repair of a malformed selref shared by fast stubs', () {
+  test('repairs a malformed selref shared by fast stubs when one can '
+      'relocate to a free existing ref', () {
     final fixture = _objcMacho(sharedMalformedSelref: true);
+    final data = ByteData.sublistView(fixture.bytes);
+
+    expect(
+      MachODylibRewriter.rewriteBytes(
+        fixture.bytes,
+        dylibName: 'libPlugin.dylib',
+        producedDylibNames: const {},
+        repairObjCFastStubs: true,
+      ),
+      isTrue,
+    );
+    // "bar" already has a valid ref elsewhere, so it relocates there,
+    // freeing the shared ref for "foo" to claim in place.
+    expect(
+      data.getUint64(fixture.firstSelrefOffset, Endian.little),
+      fixture.fooAddress,
+    );
+    expect(
+      data.getUint64(fixture.firstSelrefOffset + 8, Endian.little),
+      fixture.barAddress,
+    );
+  });
+
+  test('rejects repair of a malformed selref shared by fast stubs with no '
+      'free fallback ref', () {
+    final fixture = _objcMacho(
+      sharedMalformedSelref: true,
+      sharedSelrefFallbackAvailable: false,
+    );
     final original = Uint8List.fromList(fixture.bytes);
 
     expect(
@@ -278,6 +308,7 @@ Uint8List _macho(List<(int, String)> commands) {
 _objcMacho({
   bool hasMatchingSelref = false,
   bool sharedMalformedSelref = false,
+  bool sharedSelrefFallbackAvailable = true,
 }) {
   const textVm = 0x100000000;
   const dataVm = 0x100002000;
@@ -348,17 +379,18 @@ _objcMacho({
     ..setUint32(commandOffset + 20, stringTable.length, Endian.little);
 
   bytes.setRange(namesOffset, namesOffset + 8, utf8.encode('foo\x00bar\x00'));
+  final secondSelrefValue = hasMatchingSelref
+      ? fooAddress
+      : sharedMalformedSelref && !sharedSelrefFallbackAvailable
+      ? 0xbaadf00d
+      : barAddress;
   data
     ..setUint64(
       selrefsOffset,
       hasMatchingSelref ? barAddress : 0xdeadbeef,
       Endian.little,
     )
-    ..setUint64(
-      selrefsOffset + 8,
-      hasMatchingSelref ? fooAddress : barAddress,
-      Endian.little,
-    );
+    ..setUint64(selrefsOffset + 8, secondSelrefValue, Endian.little);
   for (var index = 0; index < stubCount; index++) {
     final address = textVm + stubOffset + index * 12;
     _putStub(data, stubOffset + index * 12, address, dataVm);


### PR DESCRIPTION
## Problem

On Linux hosts, `swift build` links Flutter's generated plugins package with `-objc_stubs_small` (see `objectiveCSmallStubSwiftDriverArguments`), which `ld64.lld` sometimes emits with a malformed `__objc_selrefs` entry shared by two different `_objc_msgSend$<selector>` fast stubs. `ObjCFastStubRewriter.repair` — the post-link pass that patches these up — refused to touch a shared/ambiguous ref at all, even when one of the colliding stubs already has a *correct*, unrelated ref elsewhere in the same section that it could simply be retargeted to. That left the whole dylib unrepaired and the build hard-failing with:

```
error: .../libFlutterPluginsGenerated.dylib: invalid Mach-O: fast stub "webView" has no safe selref repair
```

This is exactly the pattern the reporter hit: the first (clean) build succeeds, but a later build — where SwiftPM relinks and produces a different fast-stub/selref layout — trips the previously all-or-nothing safety check for stubs whose selector (`webView`, `handleRefresh`, `initWithCloseButton:...`) is common enough to already have a valid ref elsewhere in the binary.

## Fix

Split `ObjCFastStubRewriter.repair` into two phases:

1. Resolve every stub that already points at a correct ref, or that can be retargeted (instruction-only) to an existing valid ref elsewhere — same as before — while tracking how many stubs vacate each shared ref this way.
2. For everything left, only rewrite a shared ref's pointer in place once its original sharer count, minus however many vacated it in phase 1, is exactly 1. A ref still shared between two or more stubs that have nowhere else to go continues to throw `"... has no safe selref repair"`, so genuinely ambiguous/unrepairable files are still rejected rather than silently mis-patched.

## Testing

- `dart test packages/xcross/test/flutter/build/macho_dylib_rewriter_test.dart` — all 11 cases pass, including:
  - new: repairs a shared malformed selref when one of the two stubs can relocate to a free existing ref (the scenario from #63)
  - updated: still rejects repair when a shared selref has *no* fallback for either colliding selector
- `dart analyze` on the touched files reports no issues.